### PR TITLE
docs: PR 템플릿 복구,gitignore에서 lint 관련파일 제거, .env 추가

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
 
 ### 반영 브랜치
 
-ex) feature/... -> develop
+feature/... -> develop
 
 ### 변경 사항
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,4 @@ dist-ssr
 *.sln
 *.sw?
 convention
-.prettierrc
-eslint.config.js
+.env


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

PRtemplateFix -> main

### 변경 사항
origin의 main 브랜치를 받아온 상태에서 브랜치를 판 다음 작업했습니다.
PR 템플릿은 origin의 main 브랜치에서 불러오는 게 우선순위기 때문에 main으로 push 합니다.

github에서 기본으로 인식하는 제목양식의 파일이 단독으로 존재하는 경우, 별도의 디렉토리에 두면 무시한다고 하여 상위폴더인 .github로 이동했습니다. 

초기 설정에서 .gitignore에 넣은 eslint.config.js와 .prettierrc를 제거했고, eslint.config.js 내용도 최신버전으로 겸사겸사 업데이트 했습니다. 