### PR TITLE
Feature/chatstore 페이지 터지는 에러 fix

### DIFF
--- a/src/features/chat/ChatModal.tsx
+++ b/src/features/chat/ChatModal.tsx
@@ -25,7 +25,8 @@ const ChatModal = ({ onClose }: { onClose: () => void }) => {
   // const handleChangeMessage = (e: ChangeEvent<HTMLInputElement>) => {
   //   setMessage(e.target.value);
   // };
-  const WS_URL = process.env.NEXT_PUBLIC_WS_URL || 'ws://localhost:8080/chat';
+  const WS_URL = 'ws://localhost:5173';
+  //TODO WS_URL에 API 주소 할당.
   useEffect(() => {
     connect(WS_URL);
     return () => disconnect(); // 모달 닫힐 때 연결 종료


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 버그 수정


### 반영 브랜치

feature/chatstore -> develop

### 변경 사항

api 연결을 위한 환경변수 선언에 실제 api 주소가 할당되지 않아 페이지가 터지던 오류 임시수정.

