### PR TITLE
feat: 로그인 혹은 회원가입 후 유저정보 zustand 로 전역상태로 저장

### DIFF
--- a/src/components/common/confirmModal.tsx
+++ b/src/components/common/confirmModal.tsx
@@ -1,7 +1,14 @@
-import { useModalStore } from '@store/modalStore';
+// import { useModalStore } from '@store/modalStore';
 
-const ConfirmModal = () => {
-  const { isOpen, message, handleConfirm } = useModalStore();
+interface ConfirmModalProps {
+  isOpen: boolean;
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const ConfirmModal: React.FC<ConfirmModalProps> = ({ isOpen, message, onConfirm, onCancel }) => {
+  // const { isOpen, message, handleConfirm } = useModalStore();
 
   if (!isOpen) return null;
 
@@ -10,16 +17,10 @@ const ConfirmModal = () => {
       <div className="bg-dark p-2xl rounded-md">
         <p className="mb-4 text-heading5">{message}</p>
         <div className="flex justify-evenly">
-          <button
-            onClick={() => handleConfirm(true)}
-            className="px-md py-xs bg-point text-text-primary rounded-md"
-          >
+          <button onClick={onConfirm} className="px-md py-xs bg-point text-text-primary rounded-md">
             확인
           </button>
-          <button
-            onClick={() => handleConfirm(false)}
-            className="px-md py-xs bg-point text-text-primary rounded-md"
-          >
+          <button onClick={onCancel} className="px-md py-xs bg-point text-text-primary rounded-md">
             취소
           </button>
         </div>

--- a/src/components/hook/useLike.ts
+++ b/src/components/hook/useLike.ts
@@ -24,20 +24,20 @@ export const useLike = (): UseLikeReturn => {
   // 찜하기 토글
   const toggleLike = useCallback(
     async (productId: number) => {
-      const wasLiked = likedProductIds.includes(productId);
+      const isLiked = likedProductIds.includes(productId);
 
       setLikedProductIds(prev =>
-        wasLiked ? prev.filter(id => id !== productId) : [...prev, productId],
+        isLiked ? prev.filter(id => id !== productId) : [...prev, productId],
       );
 
       try {
-        if (wasLiked) await removeLike(productId);
+        if (isLiked) await removeLike(productId);
         else await addLike(productId);
       } catch (e) {
         console.error('[useLike] 토글 실패, 롤백:', e);
         // 롤백
         setLikedProductIds(prev =>
-          wasLiked ? [...prev, productId] : prev.filter(id => id !== productId),
+          isLiked ? [...prev, productId] : prev.filter(id => id !== productId),
         );
         alert('찜하기 처리 중 오류가 발생했습니다.');
       }

--- a/src/components/layout/UserDropDown.tsx
+++ b/src/components/layout/UserDropDown.tsx
@@ -1,8 +1,9 @@
-import { useAuthStore } from '@store/authStore';
-import type { DropdownProps } from 'src/types/DropDownType';
+import ConfirmModal from '@common/confirmModal';
 import { DropdownButton } from '@common/DropdownButton';
-import { useModalStore } from '@store/modalStore';
+import { useUserStore } from '@store/userStore';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import type { DropdownProps } from 'src/types/DropDownType';
 
 // 상태관리 props 전달을 위한 타입설정은 재사용을 위해 types 폴더로 이동.
 // 로그인 관련 Props는 전역상태관리로 바뀌었으므로 삭제
@@ -11,61 +12,89 @@ import { useNavigate } from 'react-router-dom';
 /* 타입은 리액트 함수형 컴포넌트(React.FC)이고, 위에 상태관리 타입설정도 props로 전달한다.*/
 const UserDropdown: React.FC<DropdownProps> = ({ isOpen, setIsOpen }) => {
   const navigate = useNavigate();
-  const { isLoggedIn, login, logout } = useAuthStore();
-  const logoutconfirm = useModalStore(state => state.confirm);
+  // const logoutconfirm = useModalStore(state => state.confirm);
   //react 훅의 사용규칙 중에는 훅의 호출이 반드시 컴포넌트 상단에 위치하여야 한다(런타임 에러의 원인이 될 수 있다)라는 룰이 있고 이를 ESlint가 지적하여 코드상에 경고가 발생함.
   // 때문에 상단으로 이동하는 것을 수정.
   // 오히려 eslint가 제대로 작동하면서 나온 안내성 경고였음.
 
-  // 전역상태관리로 바꾼 로그인여부 호출, 기존 로그인상태관리 주석처리.
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalMessage, setModalMessage] = useState('');
+
+  const user = useUserStore(state => state.user);
+  const clearAll = useUserStore(state => state.clearAll);
+  const isLogged = useUserStore(state => state.isLogin);
+
+  // isLoggedIn은 함수이므로 호출해서 사용
+  const isLoggedIn = isLogged();
+
+  // 드롭다운이 열려있지 않으면 렌더링하지 않음
   if (!isOpen) return null;
+
+  // 전역상태관리로 바꾼 로그인여부 호출, 기존 로그인상태관리 주석처리.
+  // if (!isOpen) return null;
   // 드롭다운 활성화 boolean값이 false면 드롭다운이 사라진다.
 
   const goToSignIn = () => {
     navigate('/signin');
+    setIsOpen(false);
   };
   const goToMyPage = () => {
     navigate('/mypage');
+    setIsOpen(false);
   };
 
   const goToProductPost = () => {
     navigate('/product-post');
+    setIsOpen(false);
   };
-  // 로그아웃 확인 모달 설정
 
-  const handleLogout = async () => {
-    const result = await logoutconfirm('로그아웃 하시겠습니까?');
-    if (result === true) {
-      logout();
-    } else {
-      return;
-    }
+  // 로그아웃 모달 설정
+  const handleLogout = () => {
+    setModalMessage('로그아웃 하시겠습니까?');
+    setIsModalOpen(true);
+  };
+
+  // 모달에서 확인 클릭 시
+  const handleConfirmLogout = async () => {
+    clearAll(); // 로그아웃 실행
+    setIsModalOpen(false);
+    setIsOpen(false);
+    navigate('/'); // 홈으로 이동 (선택사항)
+  };
+
+  const handleCancelLogout = () => {
+    setIsModalOpen(false); // 모달만 닫기
   };
 
   return (
-    <div className="absolute right-2 top-full bg-point rounded-xl z-50 opacity-65 flex flex-col whitespace-nowrap min-w-[5rem]">
-      {!isLoggedIn /*로그인이 안 되어있을 경우*/ ? (
-        <>
-          {/* 드롭다운메뉴 내의 버튼 별도 컴포넌트화 */}
-          <DropdownButton label={'로그인'} onClick={goToSignIn} />
-          {/*로그인/로그아웃 상태변경 여부 확인용 테스트버튼*/}
-          <DropdownButton
-            label={'테스트'}
-            onClick={() => {
-              login();
-              setIsOpen(false);
-            }}
-          />
-        </>
-      ) : (
-        /*로그인이 되어있을 경우*/
-        <>
-          <DropdownButton label={'마이페이지'} onClick={goToMyPage} />
-          <DropdownButton label={'로그아웃'} onClick={handleLogout} />
-          <DropdownButton label={'상품 등록'} onClick={goToProductPost} />
-        </>
-      )}
-    </div>
+    <>
+      <div className="absolute right-2 top-full bg-point rounded-xl z-50 opacity-65 flex flex-col whitespace-nowrap min-w-[5rem]">
+        {!isLoggedIn /*로그인이 안 되어있을 경우*/ ? (
+          <>
+            {/* 드롭다운메뉴 내의 버튼 별도 컴포넌트화 */}
+            <DropdownButton label={'로그인'} onClick={goToSignIn} />
+          </>
+        ) : (
+          /*로그인이 되어있을 경우*/
+          <>
+            {user && (
+              <div className="px-md py-sm border-b border-border/20">
+                <p className="text-sm font-medium">{user.nickname}</p>
+              </div>
+            )}
+            <DropdownButton label={'마이페이지'} onClick={goToMyPage} />
+            <DropdownButton label={'로그아웃'} onClick={handleLogout} />
+            <DropdownButton label={'상품 등록'} onClick={goToProductPost} />
+          </>
+        )}
+      </div>
+      <ConfirmModal
+        isOpen={isModalOpen}
+        message={modalMessage}
+        onConfirm={handleConfirmLogout}
+        onCancel={handleCancelLogout}
+      />
+    </>
   );
 };
 

--- a/src/components/layout/myList.tsx
+++ b/src/components/layout/myList.tsx
@@ -10,7 +10,7 @@ type TabId = 'products' | 'wishlist';
 interface MyListProps {
   activeTab: TabId;
   onCountsUpdate?: (counts: { products: number; wishlist: number }) => void; // ← 추가
-  onDelete: (itemId?: number) => Promise<void>; // 삭제 핸들러 prop 추가
+  onDelete: (itemId?: number) => void;
 }
 
 const getProductState = (status: string): ProductState => {
@@ -25,101 +25,6 @@ const getProductState = (status: string): ProductState => {
       return 'selling';
   }
 };
-
-// interface Product {
-//   id: number;
-//   image: string;
-//   title: string;
-//   price: number;
-//   state: ProductState;
-//   view: number;
-// }
-
-// type ProductList = Product[];
-// const wishlist: ProductList = [];
-
-// const MyproductList: ProductList = [
-//   {
-//     id: 1,
-//     image: exampleImage,
-//     title: '강아지밥그릇',
-//     price: 20000,
-//     state: ProductState.Selling,
-//     view: 12,
-//   },
-//   {
-//     id: 2,
-//     image: defaultImage,
-//     title: '고양이장난감',
-//     price: 15000,
-//     state: ProductState.Selling,
-//     view: 12,
-//   },
-//   {
-//     id: 3,
-//     image: defaultImage,
-//     title: '햄스터집',
-//     state: ProductState.Selling,
-//     price: 25000,
-//     view: 120,
-//   },
-//   {
-//     id: 4,
-//     image: defaultImage,
-//     title: '새장',
-//     state: ProductState.Selling,
-//     price: 35000,
-//     view: 20,
-//   },
-//   {
-//     id: 5,
-//     image: defaultImage,
-//     title: '애착 방석',
-//     state: ProductState.Reserved,
-//     price: 5000,
-//     view: 10,
-//   },
-//   {
-//     id: 6,
-//     image: defaultImage,
-//     title: '애착 방석',
-//     price: 5000,
-//     state: ProductState.Sold,
-//     view: 120,
-//   },
-//   {
-//     id: 7,
-//     image: defaultImage,
-//     title: '애착 방석',
-//     price: 5000,
-//     state: ProductState.Reserved,
-//     view: 120,
-//   },
-//   {
-//     id: 8,
-//     image: defaultImage,
-//     title: '애착 방석',
-//     price: 5000,
-//     state: ProductState.Reserved,
-//     view: 120,
-//   },
-//   {
-//     id: 9,
-//     image: defaultImage,
-//     title: '애착 방석',
-//     price: 5000,
-//     state: ProductState.Selling,
-//     view: 120,
-//   },
-//   {
-//     id: 10,
-//     image: defaultImage,
-//     title: '애착 방석',
-//     price: 5000,
-//     state: ProductState.Reserved,
-//     view: 120,
-//   },
-// ];
 
 const MyList: React.FC<MyListProps> = ({ activeTab, onCountsUpdate, onDelete }) => {
   const [MyProductList, setMyProductList] = useState<Product[]>([]);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -26,7 +26,7 @@ const Home = () => {
    * 하트 번호 클릭 -> toggleLike 함수 실행(useLike 안의 toggleLike) ->
    * toggleLike 함수 안의 addLike 함수 실행 -> 핸들러 안의 http.post('/api/likes') 실행
    */
-  const { isProductLiked, toggleLike } = useLike();
+  const { isProductLiked } = useLike();
 
   const loadProducts = async () => {
     try {
@@ -189,7 +189,7 @@ const Home = () => {
               data-index={index}
               product={product}
               isLiked={isProductLiked(product.id)}
-              onToggleLike={() => toggleLike(product.id)}
+              // onToggleLike={() => toggleLike(product.id)}
             />
           ))}
         </ul>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,11 +1,13 @@
 import logo from '@images/CuddleMarketLogoBase.png';
 import kakao from '@images/kakao.svg';
+import { useUserStore } from '@store/userStore';
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
 //  React.FC : "Login은 React 함수형 컴포넌트야!" 라고 타입스크립트에게 알려주는 것
 const Login: React.FC = () => {
   const location = useLocation();
+  const setRedirectUrl = useUserStore(state => state.setRedirectUrl);
   const KAKAO_CLIENT_ID: string = import.meta.env.VITE_KAKAO_CLIENT_ID || '';
   const REDIRECT_URI: string =
     import.meta.env.VITE_KAKAO_REDIRECT_URI || `${window.location.origin}/oauth/kakao/callback`;
@@ -42,19 +44,19 @@ const Login: React.FC = () => {
           const url = new URL(from);
           // 같은 도메인인 경우만 저장
           if (url.origin === window.location.origin) {
-            localStorage.setItem('redirectUrl', url.pathname);
-            console.log('📍 이전 페이지 저장:', url.pathname);
+            setRedirectUrl(url.pathname); // localStorage 대신 zustand 사용
+            console.log(' 이전 페이지 저장:', url.pathname);
           }
         } catch {
           // from이 상대 경로인 경우
           if (from.startsWith('/')) {
-            localStorage.setItem('redirectUrl', from);
-            console.log('📍 이전 페이지 저장:', from);
+            setRedirectUrl(from); // localStorage 대신 zustand 사용
+            console.log('이전 페이지 저장:', from);
           }
         }
       }
     }
-  }, [location]);
+  }, [location, setRedirectUrl]);
 
   return (
     <div className="flex items-center justify-center bg-primary h-[90vh]">

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,7 +1,8 @@
 import userDefaultImage from '@images/userDefault.svg';
 import MyList from '@layout/myList';
 import { SimpleHeader } from '@layout/SimpleHeader';
-import { useModalStore } from '@store/modalStore';
+// import { useModalStore } from '@store/modalStore';
+import ConfirmModal from '@common/confirmModal';
 import React, { useEffect, useState } from 'react';
 import { CiCalendar, CiLocationOn } from 'react-icons/ci';
 import { Link } from 'react-router-dom';
@@ -22,37 +23,61 @@ const MyPage: React.FC = () => {
   const [counts, setCounts] = useState({ products: 0, wishlist: 0 });
 
   // 확인 모달 설정 (22번째 줄 근처)
-  const exitConfirm = useModalStore(state => state.confirm);
-  const deleteConfirm = useModalStore(state => state.confirm);
+  // const exitConfirm = useModalStore(state => state.confirm);
+  // const deleteConfirm = useModalStore(state => state.confirm);
+
+  // 모달 상태 관리
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalMessage, setModalMessage] = useState('');
+  const [modalAction, setModalAction] = useState<'exit' | 'delete' | null>(null);
+  const [deleteItemId, setDeleteItemId] = useState<number | undefined>();
 
   // 회원탈퇴 핸들러
-  const handleExit = async (): Promise<void> => {
-    const result = await exitConfirm('회원탈퇴 하시겠습니까?');
-    if (result === true) {
-      // TODO: 회원탈퇴 로직 구현
-      console.log('회원탈퇴 진행');
-      return;
-    } else {
-      return;
-    }
+  const handleExit = () => {
+    setModalMessage('정말로 회원탈퇴 하시겠습니까?\n탈퇴 후에는 복구할 수 없습니다.');
+    setModalAction('exit');
+    setIsModalOpen(true);
   };
 
   // 상품삭제 핸들러 (MyList 컴포넌트에서 사용할 수 있도록 함수로 제공)
-  const handleDelete = async (itemId?: number): Promise<void> => {
-    const result = await deleteConfirm('삭제하시겠습니까?');
-    if (result === true) {
-      // TODO: 상품삭제 로직 구현
-      console.log(`게시물 ${itemId} 삭제 진행`);
-      return;
-    } else {
-      return;
-    }
+  const handleDelete = (itemId?: number) => {
+    setModalMessage('정말로 삭제하시겠습니까?');
+    setModalAction('delete');
+    setDeleteItemId(itemId);
+    setIsModalOpen(true);
   };
 
   // const formatJoinDate = (dateString: string): string => {
   //   const date = new Date(dateString);
   //   return `${date.getFullYear()}년 ${date.getMonth() + 1}월 가입`;
   // };
+
+  const handleModalConfirm = () => {
+    setIsModalOpen(false);
+
+    if (modalAction === 'exit') {
+      // TODO: 회원탈퇴 API 호출
+      console.log('회원탈퇴 진행');
+      // 예: await deleteAccount();
+      // navigate('/');
+    } else if (modalAction === 'delete') {
+      // TODO: 상품삭제 API 호출
+      console.log(`게시물 ${deleteItemId} 삭제 진행`);
+      // 예: await deleteProduct(deleteItemId);
+      // 삭제 후 목록 새로고침
+      loadUserInfo();
+    }
+
+    // 상태 초기화
+    setModalAction(null);
+    setDeleteItemId(undefined);
+  };
+
+  const handleModalCancel = () => {
+    setIsModalOpen(false);
+    setModalAction(null);
+    setDeleteItemId(undefined);
+  };
 
   const loadUserInfo = async () => {
     try {
@@ -94,7 +119,7 @@ const MyPage: React.FC = () => {
           {/* 가입일 */}
           <div className="flex items-center gap-sm">
             <CiCalendar />
-           가입일 :{/* {userInfo.created_at ? formatJoinDate(userInfo.created_at) : ''} */}
+            가입일 :{/* {userInfo.created_at ? formatJoinDate(userInfo.created_at) : ''} */}
           </div>
 
           <Link
@@ -178,6 +203,12 @@ const MyPage: React.FC = () => {
           </div>
         </section>
       </main>
+      <ConfirmModal
+        isOpen={isModalOpen}
+        message={modalMessage}
+        onConfirm={handleModalConfirm}
+        onCancel={handleModalCancel}
+      />
     </>
   );
 };

--- a/src/pages/ProductPost.tsx
+++ b/src/pages/ProductPost.tsx
@@ -66,9 +66,9 @@ const ProductPost = () => {
 
   /**거주지 */
   const [selectedState, setSelectedState] = useState<StateCode | string>('');
-  const [showStateSelect, setShowStateSelect] = useState(false);
   const [selectedCity, setSelectedCity] = useState<CityCode | string>('');
-  const [showCitySelect, setShowCitySelect] = useState(false);
+  const [showStateDropdown, setShowStateDropdown] = useState(false);
+  const [showCityDropdown, setShowCityDropdown] = useState(false);
 
   const cityOptions = selectedState
     ? LOCATIONS.find(location => location.code === selectedState)?.cities || []
@@ -178,17 +178,16 @@ const ProductPost = () => {
   };
 
   // 거주지
-  const handleSelectState = (opt: StateCode) => {
-    setSelectedState(opt);
+  const handleStateSelect = (stateCode: string) => {
+    setSelectedState(stateCode);
     setSelectedCity('');
-    setShowStateSelect(false);
-    setShowCitySelect(false);
+    setShowStateDropdown(false);
   };
 
-  const handleSelectCity = (opt: CityCode) => {
-    setSelectedCity(opt);
-    setShowCitySelect(false);
-    if (selectedState && opt) {
+  const handleCitySelect = (cityCode: string) => {
+    setSelectedCity(cityCode);
+    setShowCityDropdown(false);
+    if (selectedState && cityCode) {
       setErrors(prev => {
         const newErrors = { ...prev };
         delete newErrors.location;
@@ -395,12 +394,12 @@ const ProductPost = () => {
       const target = e.target as Node;
 
       // 시/도 드롭다운 바깥 클릭
-      if (showStateSelect && stateBoxRef.current && !stateBoxRef.current.contains(target)) {
-        setShowStateSelect(false);
+      if (showStateDropdown && stateBoxRef.current && !stateBoxRef.current.contains(target)) {
+        setShowStateDropdown(false);
       }
       // 구/군 드롭다운 바깥 클릭
-      if (showCitySelect && cityBoxRef.current && !cityBoxRef.current.contains(target)) {
-        setShowCitySelect(false);
+      if (showCityDropdown && cityBoxRef.current && !cityBoxRef.current.contains(target)) {
+        setShowCityDropdown(false);
       }
       // 반려동물 카테고리 드롭다운
       if (showPetTypeSelect && petTypeBoxRef.current && !petTypeBoxRef.current.contains(target)) {
@@ -418,8 +417,8 @@ const ProductPost = () => {
 
     const handleEsc = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        if (showStateSelect) setShowStateSelect(false);
-        if (showCitySelect) setShowCitySelect(false);
+        if (showStateDropdown) setShowStateDropdown(false);
+        if (showCityDropdown) setShowCityDropdown(false);
         if (showPetTypeSelect) setShowPetTypeSelect(false);
         if (showPetTypeDetailSelect) setShowPetTypeDetailSelect(false);
       }
@@ -431,7 +430,7 @@ const ProductPost = () => {
       document.removeEventListener('mousedown', handleOutside);
       document.removeEventListener('keydown', handleEsc);
     };
-  }, [showStateSelect, showCitySelect, showPetTypeSelect, showPetTypeDetailSelect]);
+  }, [showStateDropdown, showCityDropdown, showPetTypeSelect, showPetTypeDetailSelect]);
 
   // 수정 모드일 때 기존 데이터 로드
   useEffect(() => {
@@ -939,10 +938,10 @@ const ProductPost = () => {
                           <button
                             type="button"
                             role="combobox"
-                            aria-expanded={showStateSelect}
+                            aria-expanded={showStateDropdown}
                             onClick={() => {
-                              setShowStateSelect(prev => !prev);
-                              setShowCitySelect(false);
+                              setShowStateDropdown(prev => !prev);
+                              setShowCityDropdown(false);
                             }}
                             className={`flex w-full rounded-md py-2 pl-10 text-sm bg-secondary/30`}
                           >
@@ -952,7 +951,7 @@ const ProductPost = () => {
                                 : '시/도를 선택해주세요'}
                             </span>
                           </button>
-                          {showStateSelect && (
+                          {showStateDropdown && (
                             <div
                               role="listbox"
                               aria-label="시/도 선택"
@@ -962,9 +961,9 @@ const ProductPost = () => {
                                 <button
                                   key={location.code}
                                   role="option"
-                                  aria-selected={selectedState === location.code}
                                   type="button"
-                                  onClick={() => handleSelectState(location.code)}
+                                  aria-selected={selectedState === location.code}
+                                  onClick={() => handleStateSelect(location.code)}
                                   className={`w-full px-3 py-xs rounded-md transition
                                 hover:bg-gray-100 focus:bg-gray-100 focus:outline-none text-left bodySmall
                                 ${
@@ -984,11 +983,11 @@ const ProductPost = () => {
                           <button
                             type="button"
                             role="combobox"
-                            aria-expanded={showCitySelect}
+                            aria-expanded={showCityDropdown}
                             onClick={() => {
                               if (!selectedState) return;
-                              setShowCitySelect(prev => !prev);
-                              setShowStateSelect(false);
+                              setShowCityDropdown(prev => !prev);
+                              setShowStateDropdown(false);
                             }}
                             className={`flex w-full rounded-md py-2 pl-10 text-sm bg-secondary/30`}
                           >
@@ -1000,7 +999,7 @@ const ProductPost = () => {
                                 : '먼저 시/도를 선택해주세요'}
                             </span>
                           </button>
-                          {showCitySelect && selectedState && (
+                          {showCityDropdown && selectedState && (
                             <div
                               role="listbox"
                               aria-label="구/군 선택"
@@ -1013,7 +1012,7 @@ const ProductPost = () => {
                                   type="button"
                                   role="option"
                                   aria-selected={selectedCity === city.code}
-                                  onClick={() => handleSelectCity(city.code)}
+                                  onClick={() => handleCitySelect(city.code)}
                                   className={`w-full px-3 py-xs rounded-md transition
                                     hover:bg-gray-100 focus:bg-gray-100 focus:outline-none text-left bodySmall
                                     ${

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,97 +1,105 @@
+import { LOCATIONS, type CityCode, type StateCode } from '@constants/constants';
 import logoImage from '@images/CuddleMarketLogoImage.png';
+import { useUserStore } from '@store/userStore';
 import { useEffect, useRef, useState } from 'react';
 import { CiCalendar, CiLocationOn, CiUser } from 'react-icons/ci';
 import { PiTagThin } from 'react-icons/pi';
 import { useNavigate } from 'react-router-dom';
 import type { CreateUserRequest, CreateUserResponse, FormErrors } from 'src/types';
-
 //max-w-[375px]  : 해당 값보다 요소가 더 커지지 않게
-const CITIES = {
-  서울특별시: [
-    '강남구',
-    '강동구',
-    '강북구',
-    '강서구',
-    '관악구',
-    '광진구',
-    '구로구',
-    '금천구',
-    '노원구',
-    '도봉구',
-    '동대문구',
-    '동작구',
-    '마포구',
-    '서대문구',
-    '서초구',
-    '성동구',
-    '성북구',
-    '송파구',
-    '양천구',
-    '영등포구',
-    '용산구',
-    '은평구',
-    '종로구',
-    '중구',
-    '중랑구',
-  ],
-  부산광역시: [
-    '강서구',
-    '금정구',
-    '기장군',
-    '남구',
-    '동구',
-    '동래구',
-    '부산진구',
-    '북구',
-    '사상구',
-    '사하구',
-    '서구',
-    '수영구',
-    '연제구',
-    '영도구',
-    '중구',
-    '해운대구',
-  ],
-  대구광역시: ['남구', '달서구', '달성군', '동구', '북구', '서구', '수성구', '중구'],
-  인천광역시: [
-    '강화군',
-    '계양구',
-    '남동구',
-    '동구',
-    '미추홀구',
-    '부평구',
-    '서구',
-    '연수구',
-    '옹진군',
-    '중구',
-  ],
-  광주광역시: ['광산구', '남구', '동구', '북구', '서구'],
-  대전광역시: ['대덕구', '동구', '서구', '유성구', '중구'],
-  울산광역시: ['남구', '동구', '북구', '울주군', '중구'],
-  세종특별자치시: ['세종시'],
-} as const;
-type Province = keyof typeof CITIES;
-const PROVINCES = Object.keys(CITIES) as Province[];
+// const CITIES = {
+//   서울특별시: [
+//     '강남구',
+//     '강동구',
+//     '강북구',
+//     '강서구',
+//     '관악구',
+//     '광진구',
+//     '구로구',
+//     '금천구',
+//     '노원구',
+//     '도봉구',
+//     '동대문구',
+//     '동작구',
+//     '마포구',
+//     '서대문구',
+//     '서초구',
+//     '성동구',
+//     '성북구',
+//     '송파구',
+//     '양천구',
+//     '영등포구',
+//     '용산구',
+//     '은평구',
+//     '종로구',
+//     '중구',
+//     '중랑구',
+//   ],
+//   부산광역시: [
+//     '강서구',
+//     '금정구',
+//     '기장군',
+//     '남구',
+//     '동구',
+//     '동래구',
+//     '부산진구',
+//     '북구',
+//     '사상구',
+//     '사하구',
+//     '서구',
+//     '수영구',
+//     '연제구',
+//     '영도구',
+//     '중구',
+//     '해운대구',
+//   ],
+//   대구광역시: ['남구', '달서구', '달성군', '동구', '북구', '서구', '수성구', '중구'],
+//   인천광역시: [
+//     '강화군',
+//     '계양구',
+//     '남동구',
+//     '동구',
+//     '미추홀구',
+//     '부평구',
+//     '서구',
+//     '연수구',
+//     '옹진군',
+//     '중구',
+//   ],
+//   광주광역시: ['광산구', '남구', '동구', '북구', '서구'],
+//   대전광역시: ['대덕구', '동구', '서구', '유성구', '중구'],
+//   울산광역시: ['남구', '동구', '북구', '울주군', '중구'],
+//   세종특별자치시: ['세종시'],
+// } as const;
+// type Province = keyof typeof CITIES;
+// const PROVINCES = Object.keys(CITIES) as Province[];
 
 const Signup = () => {
   const [userName, setUserName] = useState<string>('');
   const [userNickName, setUserNickName] = useState<string>('');
   const [userBirth, setUserBirth] = useState<string>('');
 
-  const [selectedProvince, setSelectedProvince] = useState<Province | null>(null);
-  const [showProvinceSelect, setShowProvinceSelect] = useState(false);
+  /**거주지 */
+  const [selectedState, setSelectedState] = useState<StateCode | string>('');
+  const [selectedCity, setSelectedCity] = useState<CityCode | string>('');
+  const [showStateDropdown, setShowStateDropdown] = useState(false);
+  const [showCityDropdown, setShowCityDropdown] = useState(false);
 
-  const [selectedCity, setSelectedCity] = useState<string>('');
-  const [showCitySelect, setShowCitySelect] = useState(false);
+  const cityOptions = selectedState
+    ? LOCATIONS.find(location => location.code === selectedState)?.cities || []
+    : [];
 
-  const cityOptions = selectedProvince ? CITIES[selectedProvince] : [];
-  const provinceBoxRef = useRef<HTMLDivElement | null>(null);
+  /** 거주지 선택창 */
+  const stateBoxRef = useRef<HTMLDivElement | null>(null);
   const cityBoxRef = useRef<HTMLDivElement | null>(null);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errors, setErrors] = useState<FormErrors>({});
   const navigate = useNavigate();
   const API_BASE_URL: string = import.meta.env.VITE_API_BASE_URL;
+
+  const { accessToken, updateUserProfile, redirectUrl, setRedirectUrl } = useUserStore();
+
   // 이름
   const handleUserName = (val: string) => {
     setUserName(val === '' ? '' : val);
@@ -126,17 +134,16 @@ const Signup = () => {
     }
   };
 
-  const handleSelectProvince = (opt: Province) => {
-    setSelectedProvince(opt);
+  const handleStateSelect = (stateCode: string) => {
+    setSelectedState(stateCode);
     setSelectedCity('');
-    setShowProvinceSelect(false);
-    setShowCitySelect(false);
+    setShowStateDropdown(false);
   };
 
-  const handleSelectCity = (opt: string) => {
-    setSelectedCity(opt);
-    setShowCitySelect(false);
-    if (selectedProvince && opt) {
+  const handleCitySelect = (cityCode: string) => {
+    setSelectedCity(cityCode);
+    setShowCityDropdown(false);
+    if (selectedState && cityCode) {
       setErrors(prev => {
         const newErrors = { ...prev };
         delete newErrors.location;
@@ -166,7 +173,7 @@ const Signup = () => {
       newErrors.userBirth = '생년월일을 선택해주세요.';
     }
 
-    if (!selectedProvince || !selectedCity) {
+    if (!selectedState || !selectedCity) {
       newErrors.location = '거래 희망 지역을 선택해주세요.';
     }
 
@@ -178,33 +185,51 @@ const Signup = () => {
     }
     try {
       const requestBody: CreateUserRequest = {
-        nickname: userName,
-        name: userNickName,
+        nickname: userNickName,
+        name: userName,
         birthday: userBirth,
-        state: selectedProvince!,
+        state: selectedState!,
         city: selectedCity,
       };
-      const token = localStorage.getItem('access_token');
+
+      if (!accessToken) {
+        alert('로그인이 필요합니다.');
+        navigate('/login');
+        return;
+      }
 
       const response = await fetch(`${API_BASE_URL}/users/profile-complete/`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
+          Authorization: `Bearer ${accessToken}`,
         },
         body: JSON.stringify(requestBody),
       });
 
+      if (!response.ok) {
+        throw new Error('회원가입 실패');
+      }
+
       const data: CreateUserResponse = await response.json();
       console.log('📍 응답 데이터:', data);
 
-      const redirectUrl = localStorage.getItem('redirectUrl');
+      updateUserProfile({
+        nickname: data.nickname,
+        name: data.name,
+        birthday: data.birthday,
+        state: data.state,
+        city: data.city,
+        profile_completed: true,
+      });
+
       if (redirectUrl) {
-        console.log('📍 저장된 페이지로 이동:', redirectUrl);
-        localStorage.removeItem('redirectUrl'); // 사용 후 삭제
-        navigate(redirectUrl, { replace: true });
+        const targetUrl = redirectUrl;
+        setRedirectUrl(null); // 사용 후 초기화
+        console.log('저장된 페이지로 이동:', targetUrl);
+        navigate(targetUrl, { replace: true });
       } else {
-        console.log('📍 홈으로 이동');
+        console.log('홈으로 이동');
         navigate('/', { replace: true });
       }
     } catch (error) {
@@ -222,23 +247,19 @@ const Signup = () => {
       const target = e.target as Node;
 
       // 시/도 드롭다운 바깥 클릭
-      if (
-        showProvinceSelect &&
-        provinceBoxRef.current &&
-        !provinceBoxRef.current.contains(target)
-      ) {
-        setShowProvinceSelect(false);
+      if (showStateDropdown && stateBoxRef.current && !stateBoxRef.current.contains(target)) {
+        setShowStateDropdown(false);
       }
       // 구/군 드롭다운 바깥 클릭
-      if (showCitySelect && cityBoxRef.current && !cityBoxRef.current.contains(target)) {
-        setShowCitySelect(false);
+      if (showCityDropdown && cityBoxRef.current && !cityBoxRef.current.contains(target)) {
+        setShowCityDropdown(false);
       }
     };
 
     const handleEsc = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        if (showProvinceSelect) setShowProvinceSelect(false);
-        if (showCitySelect) setShowCitySelect(false);
+        if (showStateDropdown) setShowStateDropdown(false);
+        if (showCityDropdown) setShowCityDropdown(false);
       }
     };
 
@@ -248,7 +269,7 @@ const Signup = () => {
       document.removeEventListener('mousedown', handleOutside);
       document.removeEventListener('keydown', handleEsc);
     };
-  }, [showProvinceSelect, showCitySelect]);
+  }, [showStateDropdown, showCityDropdown]);
 
   return (
     <div className="px-lg py-8 bg-primary min-h-[100vh] flex items-center justify-center">
@@ -373,7 +394,7 @@ const Signup = () => {
                   <label className="bodySmall font-medium text-text-primary">거주지 *</label>
 
                   <div className="flex flex-col gap-3">
-                    <div className="relative" ref={provinceBoxRef}>
+                    <div className="relative" ref={stateBoxRef}>
                       <CiLocationOn
                         className="absolute left-4 top-1/2 translate-y-[-50%]"
                         size={18}
@@ -381,36 +402,41 @@ const Signup = () => {
                       <button
                         type="button"
                         role="combobox"
+                        aria-expanded={showStateDropdown}
                         onClick={() => {
-                          setShowProvinceSelect(prev => !prev);
-                          setShowCitySelect(false);
+                          setShowStateDropdown(prev => !prev);
+                          setShowCityDropdown(false);
                         }}
                         className={`flex w-full rounded-md py-2 pl-10 text-sm bg-light border border-border`}
                       >
                         <span className="text-gray-500">
-                          {selectedProvince || '시/도를 선택해주세요'}
+                          {selectedState
+                            ? LOCATIONS.find(location => location.code === selectedState)?.name
+                            : '시/도를 선택해주세요'}
                         </span>
                       </button>
-                      {showProvinceSelect && (
+                      {showStateDropdown && (
                         <div
                           role="listbox"
                           aria-label="시/도 선택"
                           className="absolute left-0 top-full z-40  w-full rounded-md border border-border bg-white p-1 shadow-md mt-sm"
                         >
-                          {PROVINCES.map(opt => (
+                          {LOCATIONS.map(location => (
                             <button
-                              key={opt}
+                              key={location.code}
                               role="option"
-                              aria-selected={selectedProvince === opt}
                               type="button"
-                              onClick={() => handleSelectProvince(opt)}
+                              aria-selected={selectedState === location.code}
+                              onClick={() => handleStateSelect(location.code)}
                               className={`w-full p-1 rounded-md transition
                               hover:bg-gray-100 focus:bg-gray-100 focus:outline-none text-left bodySmall
-                              ${
-                                selectedProvince === opt ? 'bg-gray-100 ring-1 ring-gray-300' : ''
-                              }`}
+                          ${
+                            selectedState === location.code
+                              ? 'bg-gray-100 ring-1 ring-gray-300'
+                              : ''
+                          }`}
                             >
-                              {opt}
+                              {location.name}
                             </button>
                           ))}
                         </div>
@@ -424,40 +450,45 @@ const Signup = () => {
                       <button
                         type="button"
                         role="combobox"
-                        aria-expanded={showCitySelect}
+                        aria-expanded={showCityDropdown}
                         onClick={() => {
-                          if (!selectedProvince) return;
-                          setShowCitySelect(prev => !prev);
-                          setShowProvinceSelect(false);
+                          if (!selectedState) return;
+                          setShowCityDropdown(prev => !prev);
+                          setShowStateDropdown(false);
                         }}
                         className={`flex w-full rounded-md py-2 pl-10 text-sm bg-light border border-border`}
                       >
                         <span className="text-gray-500">
-                          {selectedCity ||
-                            (selectedProvince
-                              ? '구/군을 선택해주세요'
-                              : '먼저 시/도를 선택해주세요')}
+                          {selectedCity
+                            ? cityOptions.find(city => city.code === selectedCity)?.name
+                            : selectedState
+                            ? '구/군을 선택해주세요'
+                            : '먼저 시/도를 선택해주세요'}
                         </span>
                       </button>
-                      {showCitySelect && selectedProvince && (
+                      {showCityDropdown && selectedState && (
                         <div
                           role="listbox"
                           aria-label="구/군 선택"
                           className="absolute left-0 top-full z-40  w-full rounded-md border border-border bg-white p-1 shadow-md
                           mt-sm"
                         >
-                          {cityOptions.map(opt => (
+                          {cityOptions.map(city => (
                             <button
-                              key={opt}
+                              key={city.code}
                               role="option"
-                              aria-selected={selectedCity === opt}
+                              aria-selected={selectedCity === city.code}
                               type="button"
-                              onClick={() => handleSelectCity(opt)}
+                              onClick={() => handleCitySelect(city.code)}
                               className={`w-full p-1 py-xs rounded-md transition
                               hover:bg-gray-100 focus:bg-gray-100 focus:outline-none text-left bodySmall
-                              ${selectedCity === opt ? 'bg-gray-100 ring-1 ring-gray-300' : ''}`}
+                                ${
+                                  selectedCity === city.code
+                                    ? 'bg-gray-100 ring-1 ring-gray-300'
+                                    : ''
+                                }`}
                             >
-                              {opt}
+                              {city.name}
                             </button>
                           ))}
                         </div>

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -1,0 +1,221 @@
+/**
+ * [A 컴포넌트] --setUser()--> [Zustand Store] <--자동동기화--> [localStorage]
+                                  ↓
+                            (자동 알림!)
+                            ↓        ↓
+                      [B 컴포넌트] [C 컴포넌트]                      
+✅ 장점: 모든 컴포넌트 자동 업데이트!
+ */
+
+// 1️⃣ 필요한 기능들을 가져옵니다
+// create: 스토어를 만드는 함수 (상태 저장소 생성기)
+import { create } from 'zustand';
+
+// persist: 새로고침해도 데이터 유지하는 기능
+// createJSONStorage: localStorage와 연결하는 도구
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+// User: 타입스크립트 타입 (자동완성, 오류 방지)
+import type { User } from '../types/index';
+
+// 다른 스토어와 연동하기 위해 가져옴
+import { useAuthStore } from './authStore';
+
+interface UserState {
+  // ===== 상태(State) =====
+  /** 이것들이 "전역 변수"가 됩니다*/
+  /** 상태: 실제 저장되는 데이터 */
+
+  // 현재 로그인한 사용자 정보
+  // null = 로그인 안 함, User 객체 = 로그인 함
+  user: User | null;
+
+  // API 요청시 필요한 인증 토큰
+  // "나는 홍길동입니다"를 증명하는 신분증 같은 것
+  accessToken: string | null;
+
+  // 로그인 후 돌아갈 URL 임시 저장
+  // 예: 상품 페이지 → 로그인 → 다시 상품 페이지로
+  redirectUrl: string | null;
+
+  // ===== 액션(Actions) =====
+  /** 상태를 변경하는 함수들 (setter 역할)*/
+
+  // user 상태를 변경하는 함수
+  setUser: (user: User) => void;
+
+  // 토큰만 변경할 때
+  setAccessToken: (token: string) => void;
+
+  // URL만 변경할 때
+  setRedirectUrl: (url: string | null) => void;
+
+  // 프로필 수정
+  updateUserProfile: (updates: Partial<User>) => void;
+
+  // 로그인 처리 (여러 상태를 한번에 변경)
+  handleLogin: (user: User, accessToken: string) => void;
+
+  // 로그아웃
+  clearAll: () => void;
+
+  // 임시 토큰 제거
+  clearRegistrationToken: () => void;
+
+  // ===== 유틸리티 =====
+  isLogin: () => boolean;
+  // 프로필 완성 체크
+  isProfileCompleted: () => boolean;
+  // 닉네임 가져오기
+  getUserNickname: () => string;
+  //  ID 가져오기
+  getUserId: () => number | null;
+}
+
+/** Store 생성 부분 */
+export const useUserStore = create<UserState>()(
+  // create: "전역 상태 저장소를 만들어줘!"
+  // <UserState>: "이런 모양으로 만들어줘!" (타입스크립트)
+
+  // persist: "새로고침해도 데이터 유지해줘!"
+  persist(
+    // set: 상태를 변경하는 마법의 함수
+    // get: 현재 상태를 읽는 함수
+    // => ({}): 실제 스토어 내용을 정의
+    (set, get) => ({
+      // ===== 초기 상태 =====
+      /** 앱이 처음 시작될 때의 기본값들*/
+
+      // 처음엔 로그인 안 한 상태
+      user: null,
+
+      // 토큰도 없음
+      accessToken: null,
+
+      // 돌아갈 URL도 없음
+      redirectUrl: null,
+
+      // ===== 액션 구현 =====
+
+      // user만 변경
+      setUser: user => set({ user }),
+      // 풀어쓰면:
+      // setUser: (user) => {
+      //   set({ user: user })
+      // }
+      // set 함수가 실행되면:
+      // 동작: 1. { user: userData }로 상태 변경
+      //      2. user를 구독중인 모든 컴포넌트 리렌더링
+      //      3. localStorage 자동 저장
+
+      // 토큰만 변경
+      // 실행: setAccessToken("abc123")
+      // 동작: accessToken만 변경, token 구독 컴포넌트만 리렌더링
+      setAccessToken: token => set({ accessToken: token }),
+
+      // redirectUrl만 변경
+      // localStorage에는 저장 안함 (partialize에서 제외)
+      setRedirectUrl: (url: string | null) => set({ redirectUrl: url }),
+
+      // 프로필 수정
+      // Partial<User>: User의 일부 속성만 전달 가능
+      // 사용: updateUserProfile({ nickname: "새이름" })
+      // 결과: user.nickname만 변경, 나머지는 유지
+      updateUserProfile: (updates: Partial<User>) =>
+        set(state => ({
+          // 현재 상태를 받아옴
+          //    있으면?        기존 유저 복사, 새 값 덮어쓰기
+          //                                              없으면 null
+          user: state.user ? { ...state.user, ...updates } : null,
+        })),
+      // 사용: updateUserProfile({ nickname: "새이름" })
+      // 결과: user.nickname만 변경, 나머지는 유지
+      // 예시:
+      // 현재: user = { name: "홍길동", age: 20 }
+      // updateUserProfile({ age: 21 })
+      // 결과: user = { name: "홍길동", age: 21 }
+
+      // 여러 상태를 한번에 변경!
+      handleLogin: (user, accessToken) => {
+        // set({ user: user, accessToken: accessToken }) 의 축약형
+        // userStore의 두 상태를 한번에 변경
+        // 한번에 여러 상태 변경 (1회 리렌더링)
+        set({ user, accessToken });
+
+        // 다른 스토어의 함수도 실행!
+        // getState(): 컴포넌트 밖에서 스토어 접근하는 방법
+        // authStore의 isLoggedIn을 true로
+        useAuthStore.getState().login();
+      },
+      // 실행 흐름:
+      // 1. userStore의 user, accessToken 동시 변경
+      // 2. authStore의 isLoggedIn 변경
+      // 3. localStorage 자동 저장
+      // 4. 관련 컴포넌트들 리렌더링
+
+      // 모든 상태를 초기값으로 되돌림 (로그아웃)
+      clearAll: () => {
+        set({
+          user: null,
+          accessToken: null,
+          redirectUrl: null,
+        });
+      },
+      isLogin: () => {
+        const state = get();
+        return !!(state.user && state.accessToken);
+      },
+
+      isProfileCompleted: () => {
+        const user = get().user;
+        // get(): 현재 상태를 읽어옴
+        return user?.profile_completed ?? false;
+        // user가 있으면 profile_completed 값, 없으면 false
+        // ?. : 옵셔널 체이닝 (user가 null이어도 에러 안남)
+        // ?? : null 병합 연산자 (앞이 null/undefined면 뒤 값 사용)
+      },
+
+      getUserNickname: () => {
+        const user = get().user;
+        return user?.nickname || '';
+        //                    ^^ nickname이 없으면 빈 문자열
+      },
+
+      getUserId: () => {
+        const user = get().user;
+        return user?.id || null;
+        // number | null 반환
+      },
+      // redirectUrl만 초기화
+      clearRegistrationToken: () => {
+        set({ redirectUrl: null });
+        // redirectUrl만 초기화
+        // 이름이 맞지 않음 (registrationToken이 없어서)
+      },
+    }), // 스토어 정의 끝
+
+    // Persist 설정 - localStorage 연동
+    {
+      /**
+       *    name: 'user-storage',
+       *    storage: createJSONStorage(() => localStorage),
+       *├> "Zustand야, localStorage 써줘. 근데 네가 알아서 해!" */
+
+      // localStorage의 key 이름
+      // 실제로 localStorage['user-storage']에 저장됨
+      // 개발자도구 > Application > localStorage에서 확인 가능
+      name: 'user-storage',
+
+      // 어디에 저장할지 지정 (localStorage 사용)
+      storage: createJSONStorage(() => localStorage),
+
+      // 전체 상태 중 일부만 저장하고 싶을 때
+      partialize: state => ({
+        user: state.user,
+        accessToken: state.accessToken,
+        // redirectUrl은 저장 안 함 (임시값이라서)
+      }),
+      // 새로고침 후 user와 token은 복원, redirectUrl은 null
+    },
+  ),
+);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가

### 반영 브랜치

feature/user-zustand -> develop

### 변경 사항
- confirmModal store 사용하던거 수정
- useLikt 변수명 수정
- CategoryFilter 변수명 수정
- myList 주석 삭제 및 삭제 핸들러 Promise 반환하던거 수정
- ProductCard 에서 찜하기 버튼 눌렀을 경우, 미로그인시 comfirmModal 을 통해 로그인 하도록 유도
- UserDropDown 에서 로그인 되었을 경우 보이는 부분 달리 보이도록 되어잇던 로직 수정
- Home 찜하기 버튼 기능 주석
- KakaoCallback 에서 localStorage 사용하던 로직을 zustand 로 수정
- Login 에서 zustand 하용하여 이전페이지로 이동하던 로직 수정
- MyPage 에서 confirmModal 사용하도록 수정
- ProductPost 변수명 수정
- SignUp 에서 zustand store 사용하도록 수정
- useStore 생성

---

Closes #95 
