### PR TITLE
refactor: Typography 시스템 네이밍 통일 및 레이어 순서 수정 (#132)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -9,8 +9,8 @@
 /* 폰트(base 레이어로 직접 삽입) */
 @import './styles/fonts.css' layer(base);
 
-/* 유틸리티(utilities 레이어) */
-@import './styles/utilities/typography.css' layer(utilities);
+/* 유틸리티 - Tailwind 이후에 로드하여 우선순위 확보 */
+@import './styles/utilities/typography.css';
 
 /* 기본 폰트 설정 - layer 외부에서 최종 적용 */
 html {
@@ -20,10 +20,17 @@ html {
 }
 
 body {
+  color: var(--color-gray-900);
   font-weight: 400;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga' 1, 'calt' 1;
+}
+
+/* Placeholder 폰트 상속 */
+input::placeholder,
+textarea::placeholder {
+  font-family: 'Pretendard Variable';
 }
 
 /* Chrome / Edge / Safari */

--- a/src/styles/tokens.typography.css
+++ b/src/styles/tokens.typography.css
@@ -1,49 +1,41 @@
 /* utilities 에서, @apply 키워드와 함께 사용하면 하나의 클래스네임의 Tailwind 클래스가 자동 생성됩니다. */
 /* 예시: @apply text-heading1; =>  --text-heading1 이라는 텍스트가 포함된 속성들은 전부 반영됩니다. */
 @theme {
-  --text-heading1: 36px;
-  --text-heading1--line-height: 1.25;
-  --text-heading1--font-weight: 500;
+  /* H1 */
+  --text-h1: 36px;
+  --text-h1--line-height: 40px;
+  --text-h1--weight: 700;
+  --text-h1--tracking: 0;
 
-  --text-heading2: 30px;
-  --text-heading2--line-height: 1.25;
-  --text-heading2--font-weight: 500;
+  /* H2 */
+  --text-h2: 30px;
+  --text-h2--line-height: 36px;
+  --text-h2--weight: 700;
+  --text-h2--tracking: 0;
 
-  --text-heading3: 24px;
-  --text-heading3--line-height: 1.375;
-  --text-heading3--font-weight: 500;
+  /* H3 */
+  --text-h3: 24px;
+  --text-h3--line-height: 32px;
+  --text-h3--weight: 700;
+  --text-h3--tracking: 0;
 
-  --text-heading4: 20px;
-  --text-heading4--line-height: 1.375;
-  --text-heading4--font-weight: 500;
+  /* H4 */
+  --text-h4: 20px;
+  --text-h4--line-height: 28px;
+  --text-h4--weight: 600;
+  --text-h4--tracking: 0;
 
-  --text-heading5: 18px;
-  --text-heading5--line-height: 1.375;
-  --text-heading5--font-weight: 500;
-
-  --text-bodyRegular: 16px;
-  --text-bodyRegular--line-height: 1.625;
-  --text-bodyRegular--font-weight: 400;
-
-  --text-bodyLarge: 18px;
-  --text-bodyLarge--line-height: 1.5;
-  --text-bodyLarge--font-weight: 400;
-
-  --text-bodySmall: 14px;
-  --text-bodySmall--line-height: 1.375;
-  --text-bodySmall--font-weight: 400;
-
-  --text-caption: 12px;
-  --text-caption--line-height: 1.375;
-  --text-caption--font-weight: 400;
+  /* H5 */
+  --text-h5: 18px;
+  --text-h5--line-height: 26px;
+  --text-h5--weight: 600;
+  --text-h5--tracking: 0;
 }
 
-/* src/styles/tokens.typography.css */
 /* theme 레이어에 타이포그래피 토큰 정의 */
-
 @theme {
   /* 폰트 패밀리 */
-  --font-family-pretendard: 'Pretendard Variable';
+  --font-pretendard: 'Pretendard Variable';
   --font-family-sans: 'Pretendard Variable', ui-sans-serif, system-ui, sans-serif;
   --font-family-mono: ui-monospace, SFMono-Regular, 'SF Mono', Monaco, monospace;
 }

--- a/src/styles/utilities/typography.css
+++ b/src/styles/utilities/typography.css
@@ -1,36 +1,38 @@
 @layer utilities {
   /* 헤딩 */
-  /* @apply 키워드를 사용하면 (예시: text-heading1) 하나의 클래스네임의 Tailwind 클래스가 자동 생성됩니다. */
-  .heading1 {
-    @apply text-heading1;
-  }
-  .heading2 {
-    @apply text-heading2;
-  }
-  .heading3 {
-    @apply text-heading3;
-  }
-  .heading4 {
-    @apply text-heading4;
-  }
-  .heading5 {
-    @apply text-heading5;
+  .heading-h1 {
+    font-size: var(--text-h1);
+    line-height: var(--text-h1--line-height);
+    font-weight: var(--text-h1--weight);
+    letter-spacing: var(--text-h1--tracking);
   }
 
-  /* 본문 */
-  .bodyRegular {
-    @apply text-bodyRegular;
-  }
-  .bodyLarge {
-    @apply text-bodyLarge;
-  }
-  .bodySmall {
-    @apply text-bodySmall;
+  .heading-h2 {
+    font-size: var(--text-h2);
+    line-height: var(--text-h2--line-height);
+    font-weight: var(--text-h2--weight);
+    letter-spacing: var(--text-h2--tracking);
   }
 
-  /* 캡션 */
-  .caption {
-    @apply text-caption;
+  .heading-h3 {
+    font-size: var(--text-h3);
+    line-height: var(--text-h3--line-height);
+    font-weight: var(--text-h3--weight);
+    letter-spacing: var(--text-h3--tracking);
+  }
+
+  .heading-h4 {
+    font-size: var(--text-h4);
+    line-height: var(--text-h4--line-height);
+    font-weight: var(--text-h4--weight);
+    letter-spacing: var(--text-h4--tracking);
+  }
+
+  .heading-h5 {
+    font-size: var(--text-h5);
+    line-height: var(--text-h5--line-height);
+    font-weight: var(--text-h5--weight);
+    letter-spacing: var(--text-h5--tracking);
   }
 
   .blind {
@@ -47,7 +49,7 @@
   }
 
   .nobreakstyle {
-    @apply whitespace-nowrap break-keep overflow-hidden text-ellipsis;
+    @apply overflow-hidden break-keep text-ellipsis whitespace-nowrap;
   }
 
   /* 기본 line-clamp 유틸리티 */


### PR DESCRIPTION

## 📌 개요

Typography 클래스명을 통일하고 CSS 레이어 순서를 수정하여 커스텀 유틸리티 클래스가 정상적으로 적용되도록 개선했습니다.

## 🔧 작업 내용
- heading 클래스 네이밍 통일 (heading-h1 ~ heading-h5)
- CSS 레이어 순서 최적화 (utilities import 방식 변경)
- tokens와 utilities 역할 분리 (중복 제거)
- 기본 폰트 컬러 gray-900 설정
- 폰트 파일 정리


## 📎 관련 이슈

- Close #132 
## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| 이미지  | 이미지  |

## 💬 리뷰어 참고 사항

- 리뷰어가 중점적으로 봐주었으면 하는 부분
- 추가 논의가 필요한 부분
