### PR TITLE
refactor: Header 컴포넌트 리팩토링 및 BMJUA 폰트 적용(#144)

### DIFF
--- a/src/components/commons/Input.tsx
+++ b/src/components/commons/Input.tsx
@@ -27,7 +27,7 @@ export function Input({
   return (
     <div
       className={cn(
-        'relative flex w-full items-center overflow-hidden rounded-lg transition-colors',
+        'relative flex w-full h-full items-center overflow-hidden rounded-lg transition-colors',
         border && 'focus-within:border-primary-500 border',
         border && borderColor,
         backgroundColor,

--- a/src/components/commons/header/Header.tsx
+++ b/src/components/commons/header/Header.tsx
@@ -1,143 +1,26 @@
-import logoImage from '@assets/images/CuddleMarketLogoImage.png';
-import { Z_INDEX } from '@constants/ui';
-import { useRef, useState } from 'react';
-import { HiOutlineBellAlert } from 'react-icons/hi2';
-import { IoIosSearch } from 'react-icons/io';
-import { RxAvatar } from 'react-icons/rx';
-import { Link } from 'react-router-dom';
-import { cn } from '@utils/cn';
-// import AlarmDropdown from '../layout/AlarmDropDown';
-// import UserDropdown from '../layout/UserDropDown';
-
-// import { useOutsideClick } from '../hook/useOutsideClick';
+import { Z_INDEX } from '@constants/ui'
+import { cn } from '@utils/cn'
+import Logo from './components/Logo'
+import { SearchBar } from './components/SearchBar'
+import Navigation from './components/Navigation'
 
 function Header() {
-  const [searchQuery, setSearchQuery] = useState('');
-  // const [isAlarmDropdownOpen, setIsAlarmDropdownOpen] = useState(false);
-  // const [isUserDropdownOpen, setIsUserDropdownOpen] = useState(false);
-  const alarmRef = useRef<HTMLDivElement>(null);
-  const userRef = useRef<HTMLDivElement>(null);
-
-  {
-    /* 드롭다운 메뉴 밖에서 마우스 클릭시 드롭다운 비활성화 */
-    /* 알람 드롭다운 메뉴의 더보기버튼 활성화를 위해 ref 중복문제 해결 필요*/
-  }
-  // useEffect(() => {
-  //   const handleClickOutside = (event: MouseEvent) => {
-  //     if (
-  //       alarmRef.current &&
-  //       !alarmRef.current.contains(event.target as Node) &&
-  //       userRef.current &&
-  //       !userRef.current.contains(event.target as Node)
-  //     ) {
-  //       setIsAlarmDropdownOpen(false);
-  //       setIsUserDropdownOpen(false);
-  //     }
-  //   };
-
-  //   document.addEventListener('mousedown', handleClickOutside);
-  //   return () => {
-  //     document.removeEventListener('mousedown', handleClickOutside);
-  //   };
-  // }, []);
-
-  //  useOutsideClick(
-  //   isGnbVisible, // 드롭다운이 열려있는지
-  //   [sidebarButtonRef, sidebarRef], // 안쪽으로 취급할 영역들
-  //   () => setIsGnbVisible(false) // 바깥 클릭시 실행할 함수
-  // )
-
   return (
     <header
       className={cn(
-        'custom:px-20 sticky top-0 flex h-16 w-full items-center justify-center border-b border-gray-200 bg-white px-0',
-        `${Z_INDEX.HEADER}`,
+        'sticky top-0 flex h-24 w-full items-center justify-center bg-primary-200',
+        `${Z_INDEX.HEADER}`
       )}
     >
-      <div className="max-w-7xl px-2.5">
+      <div className="max-w-7xl w-full px-2.5">
         <div className="flex items-center justify-between gap-lg">
-          {/* 로고를 link태그로 감싸 홈버튼으로 설정*/}
-          <Link to="/" className="flex items-center">
-            <img
-              src={logoImage}
-              alt="커들마켓"
-              className="w-auto h-15 tablet:h-22 object-contain"
-            />
-          </Link>
-
-          {/* 검색 영역 */}
-          <div className="flex-1 max-w-[42rem] mx-lg">
-            <div className="flex items-center gap-sm">
-              <div className="relative flex-1">
-                <input
-                  type="text"
-                  placeholder="원하는 반려동물 용품을 검색해보세요"
-                  value={searchQuery}
-                  onChange={e => setSearchQuery(e.target.value)}
-                  className="
-                    w-full
-                    px-lg py-sm
-                    border border-border rounded-lg
-                    bg-bg
-                    text-text-primary placeholder:text-text-secondary
-                  "
-                />
-              </div>
-
-              <button
-                type="button"
-                className="
-                  h-full px-sm py-sm
-                  border border-border rounded-md
-                  bg-bg/20 hover:bg-bg/30
-                  text-text-primary cursor-pointer
-                "
-              >
-                <IoIosSearch className="text-xl tablet:text-2xl" />
-              </button>
-            </div>
-          </div>
-          <div className="flex gap-md tablet:gap-xl relative">
-            {/* 알람 드롭다운 호출 */}
-            <div className="flex items-center" ref={alarmRef}>
-              <button
-                type="button"
-                className="cursor-pointer"
-                // onClick={() => {
-                //   setIsAlarmDropdownOpen(prev => !prev);
-                //   setIsUserDropdownOpen(false);
-                // }}
-              >
-                <HiOutlineBellAlert className="text-3xl tablet:text-4xl" />
-              </button>
-
-              {/* {isAlarmDropdownOpen && (
-                <AlarmDropdown isOpen={isAlarmDropdownOpen} setIsOpen={setIsAlarmDropdownOpen} />
-              )} */}
-            </div>
-
-            {/* 유저 드롭다운 호출 */}
-            <div className="flex items-center" ref={userRef}>
-              <button
-                type="button"
-                className="cursor-pointer"
-                // onClick={() => {
-                //   setIsUserDropdownOpen(prev => !prev);
-                //   setIsAlarmDropdownOpen(false);
-                // }}
-              >
-                <RxAvatar className="text-3xl tablet:text-4xl" />
-              </button>
-
-              {/* {isUserDropdownOpen && (
-                <UserDropdown isOpen={isUserDropdownOpen} setIsOpen={setIsUserDropdownOpen} />
-              )} */}
-            </div>
-          </div>
+          <Logo />
+          <SearchBar />
+          <Navigation />
         </div>
       </div>
     </header>
-  );
+  )
 }
 
-export default Header;
+export default Header

--- a/src/components/commons/header/components/Logo.tsx
+++ b/src/components/commons/header/components/Logo.tsx
@@ -1,0 +1,21 @@
+import CuddleMarketLogo from '@assets/images/CuddleMarketLogoImage.png'
+import { ROUTES } from '@src/constants/routes'
+import { Link } from 'react-router-dom'
+
+export default function Logo() {
+  return (
+    <Link to={ROUTES.HOME} className="flex items-center gap-2">
+      <div className="w-auto h-16 object-contain">
+        <img
+          src={CuddleMarketLogo}
+          alt="CuddleMarket 로고"
+          className="w-full h-full object-cover"
+        />
+      </div>
+      <p className="flex flex-col text-2xl text-white leading-none logo">
+        <span>CUDDLE</span>
+        <span>MARKET</span>
+      </p>
+    </Link>
+  )
+}

--- a/src/components/commons/header/components/Navigation.tsx
+++ b/src/components/commons/header/components/Navigation.tsx
@@ -1,0 +1,48 @@
+import UserMenu from '../components/user-section/UserMenu'
+import AuthMenu from '../components/user-section/AuthMenu'
+import NotificationButton from '../components/notification-section/NotificationButton'
+import { useState } from 'react'
+// import { useAuth } from '@src/store/auth'
+
+export default function Navigation() {
+  const [isUserMenuOpen, setIsUserMenuOpen] = useState(false)
+  const [isNotificationOpen, setIsNotificationOpen] = useState(false)
+
+  const isLoggedIn = false
+  // const isLoggedIn = useAuth((state) => state.isLoggedIn())
+  // const userNickname = useAuth((state) => state.user?.nickname ?? '사용자')
+  // const bootstrapped = useAuth((state) => state.bootstrapped)
+
+  // if (!bootstrapped) {
+  //   return (
+  //     <div className="flex items-center gap-4">
+  //       <div className="h-10 w-10 animate-pulse rounded-full bg-gray-200" />
+  //       <div className="h-6 w-20 animate-pulse rounded bg-gray-200" />
+  //     </div>
+  //   )
+  // }
+
+  return (
+    <div className="flex items-center gap-4">
+      {isLoggedIn ? (
+        <>
+          <NotificationButton
+            isNotificationOpen={isNotificationOpen}
+            setIsNotificationOpen={setIsNotificationOpen}
+            isUserMenuOpen={isUserMenuOpen}
+            setIsUserMenuOpen={setIsUserMenuOpen}
+          />
+          <UserMenu
+            isNotificationOpen={isNotificationOpen}
+            setIsNotificationOpen={setIsNotificationOpen}
+            isUserMenuOpen={isUserMenuOpen}
+            setIsUserMenuOpen={setIsUserMenuOpen}
+            // userNickname={userNickname}
+          />
+        </>
+      ) : (
+        <AuthMenu />
+      )}
+    </div>
+  )
+}

--- a/src/components/commons/header/components/SearchBar.tsx
+++ b/src/components/commons/header/components/SearchBar.tsx
@@ -1,0 +1,43 @@
+import { Search as SearchIcon } from 'lucide-react'
+import { useState } from 'react'
+// import { useDebounce } from '@hooks/useDebounce'
+import { cn } from '@src/utils/cn'
+import { Input } from '@components/commons/Input'
+
+interface SearchBarProps {
+  value?: string // 초기값
+  // onSearch: (keyword: string) => void // 디바운스 후 검색 실행
+  placeholder?: string
+  delay?: number // 디바운스 시간 (ms)
+  className?: string
+}
+
+export function SearchBar({
+  value = '',
+  // onSearch,
+  placeholder = '검색어 입력',
+  // delay = 500,
+  className,
+}: SearchBarProps) {
+  const [keyword, setKeyword] = useState(value)
+  // const debouncedKeyword = useDebounce(keyword, delay)
+
+  // 디바운스된 키워드가 변경되면 검색 실행
+  // useEffect(() => {
+  //   onSearch(debouncedKeyword)
+  // }, [debouncedKeyword, onSearch])
+  return (
+    <div className={cn('h-10 min-w-[700px]', className)}>
+      <Input
+        type="text"
+        value={keyword}
+        onChange={(e) => setKeyword(e.target.value)}
+        placeholder={placeholder}
+        icon={SearchIcon}
+        border
+        borderColor="border-gray-100"
+        backgroundColor="bg-white"
+      />
+    </div>
+  )
+}

--- a/src/components/commons/header/components/notification-section/NotificationButton.tsx
+++ b/src/components/commons/header/components/notification-section/NotificationButton.tsx
@@ -1,0 +1,60 @@
+import { useRef } from 'react'
+// import { useOutsideClick } from '@src/hooks/useOutsideClick'
+// import Icon from '@components/commons/Icon'
+// import { Bell as BellIcon } from 'lucide-react'
+// import NotificationsDropdown from './NotificationsDropdown'
+// import { useUnreadCountQuery } from '@hooks/useNotifications'
+
+interface NotificationButtonProps {
+  isNotificationOpen: boolean
+  setIsNotificationOpen: (isNotificationOpen: boolean) => void
+  isUserMenuOpen: boolean
+  setIsUserMenuOpen: (isUserMenuOpen: boolean) => void
+}
+
+export default function NotificationButton({
+  isNotificationOpen,
+  setIsNotificationOpen,
+  isUserMenuOpen,
+  setIsUserMenuOpen,
+}: NotificationButtonProps) {
+  // const { unreadCount } = useUnreadCountQuery()
+
+  // const notificationsDropdownRef = useRef<HTMLDivElement>(null)
+  const notificationButtonRef = useRef<HTMLDivElement>(null)
+
+  const handleNotificationToggle = () => {
+    // 마이페이지 ui가 열려있다면 마이페이지 ui 닫기
+    if (isUserMenuOpen) {
+      setIsUserMenuOpen(false)
+    }
+    // 알림드롭다운 토글
+    setIsNotificationOpen(!isNotificationOpen)
+  }
+
+  // useOutsideClick(
+  //   isNotificationOpen, // 드롭다운이 열려있는지
+  //   [notificationButtonRef, notificationsDropdownRef], // 안쪽으로 취급할 영역들
+  //   () => setIsNotificationOpen(false) // 바깥 클릭시 실행할 함수
+  // )
+
+  return (
+    <div className="relative">
+      <div
+        ref={notificationButtonRef}
+        className="relative flex size-10 cursor-pointer items-center justify-center rounded-full hover:bg-gray-100"
+        onClick={handleNotificationToggle}
+      >
+        {/* <Icon icon={BellIcon} size="md" className={`stroke-gray-600`} /> */}
+        {/* {unreadCount > 0 && (
+          <span className="bg-danger-500 absolute -top-1 left-6 flex h-5 min-w-5 items-center justify-center rounded-full px-1 text-xs font-semibold text-white">
+            {unreadCount > 99 ? '99+' : unreadCount}
+          </span>
+        )} */}
+      </div>
+      {/* {isNotificationOpen && (
+        <NotificationsDropdown notificationsDropdownRef={notificationsDropdownRef} setIsNotificationOpen={setIsNotificationOpen} />
+      )} */}
+    </div>
+  )
+}

--- a/src/components/commons/header/components/notification-section/NotificationItem.tsx
+++ b/src/components/commons/header/components/notification-section/NotificationItem.tsx
@@ -1,0 +1,160 @@
+// import { cn } from '@utils/cn'
+// import Icon from '@components/commons/Icon'
+// import {
+//   notificationIconClass,
+//   notificationIconStrokeClass,
+// } from './notificationIconClass'
+// import { useNavigate } from 'react-router-dom'
+// import {
+//   Bell as BellIcon,
+//   CalendarCheck as CalendarCheckIcon,
+//   Check as CheckIcon,
+//   NotebookPen as CreatingRecordIcon,
+//   UserRoundPlus as UserRoundPlusIcon,
+//   UsersRound as UsersRoundIcon,
+//   CalendarRange as CalendarRangeIcon,
+//   CalendarClock as CalendarClockIcon,
+//   X as CloseIcon,
+// } from 'lucide-react'
+
+// const iconMap = {
+//   ADD_APPLICATION: UserRoundPlusIcon,
+//   APPLICATION_ACCEPT: CheckIcon,
+//   APPLICATION_REJECT: CloseIcon,
+//   STUDY_JOIN: UsersRoundIcon,
+//   STUDY_NOTE_CREATE: CreatingRecordIcon,
+//   STUDY_REVIEW_REQUEST: CalendarCheckIcon,
+//   TODAY_SCHEDULE: CalendarClockIcon,
+//   UPCOMING_SCHEDULE: CalendarRangeIcon,
+// }
+
+// import type { NotificationItem as NotificationItemType } from '@src/types/notification'
+// import { useReadNotification } from '@src/hooks/useNotifications'
+
+// const getNotificationIcon = (type: NotificationItemType['type']) => {
+//   const IconComponent = iconMap[type] || BellIcon
+
+//   return (
+//     <div className={notificationIconClass({ type })}>
+//       <Icon
+//         icon={IconComponent}
+//         className={notificationIconStrokeClass({ type })}
+//         size="sm"
+//       />
+//     </div>
+//   )
+// }
+// const formatDate = (dateString: string) => {
+//   const serverDate = new Date(dateString)
+//   const now = new Date()
+
+//   const startOfToday = new Date(
+//     now.getFullYear(),
+//     now.getMonth(),
+//     now.getDate()
+//   )
+//   const startOfYesterday = new Date(startOfToday)
+//   startOfYesterday.setDate(startOfYesterday.getDate() - 1)
+
+//   const diffMs = now.getTime() - serverDate.getTime() // 밀리초 차이
+//   const hours = Math.floor(diffMs / (60 * 60 * 1000))
+//   const minutes = Math.floor(diffMs / 60000)
+
+//   if (serverDate >= startOfYesterday && serverDate < startOfToday) {
+//     return '어제'
+//   } else if (minutes < 1) {
+//     return '방금 전'
+//   } else if (minutes < 60) {
+//     return `${minutes}분 전`
+//   } else if (hours < 24) {
+//     return `${hours}시간 전`
+//   } else {
+//     return serverDate.toLocaleDateString('ko-KR', {
+//       month: 'long',
+//       day: 'numeric',
+//     })
+//   }
+// }
+
+// interface NotificationItemProps extends NotificationItemType {
+//   setIsNotificationOpen: (isOpen: boolean) => void
+// }
+
+// const ACCOUNT = 'https://account.ozcoding.site'
+// const STUDY_GROUP = 'https://study.ozcoding.site'
+// export default function NotificationItem({
+//   setIsNotificationOpen,
+//   ...notification
+// }: NotificationItemProps) {
+//   const { notification_id } = notification
+//   const navigate = useNavigate()
+//   const readNotificationMutation = useReadNotification()
+//   const handleNotificationClick = () => {
+//     const navigateToLink = () => {
+//       if (!notification.back_url_link) return
+
+//       if (
+//         notification.type === 'STUDY_JOIN' &&
+//         notification.back_url_link.includes('/study-group/')
+//       ) {
+//         const uuid = notification.back_url_link
+//           .split('/study-group/')[1]
+//           ?.split('/')[0]
+//         if (uuid) {
+//           navigate(`/?study_group_uuid=${uuid}`)
+//           return
+//         }
+//       }
+//       // "my-page"가 포함된 경우 외부 도메인으로 리다이렉트
+//       if (notification.back_url_link.includes('my-page')) {
+//         window.location.href = `${ACCOUNT}${notification.back_url_link}`
+//       } else if (notification.back_url_link.includes('study-group')) {
+//         window.location.href = `${STUDY_GROUP}${notification.back_url_link}`
+//       } else {
+//         navigate(ACCOUNT)
+//       }
+//     }
+
+//     if (notification.is_read || readNotificationMutation.isPending) {
+//       setIsNotificationOpen(false)
+//       navigateToLink()
+//       return
+//     }
+
+//     readNotificationMutation.mutate(notification_id, {
+//       onError: (error) => {
+//         alert(`Error: ${error}`)
+//       },
+//       onSuccess: () => {
+//         setIsNotificationOpen(false)
+//         navigateToLink()
+//       },
+//     })
+//   }
+//   return (
+//     <div
+//       className={cn(
+//         'flex cursor-pointer items-start gap-3 border-b border-gray-200 px-4 pt-[17px] pb-4 transition-colors hover:bg-gray-50',
+//         !notification.is_read ? 'bg-primary-50' : 'bg-white'
+//       )}
+//       onClick={() => handleNotificationClick()}
+//     >
+//       {getNotificationIcon(notification.type)}
+//       <div className="flex min-w-72 justify-between gap-1">
+//         <div className="flex flex-col gap-1">
+//           <p className="line-clamp-2 text-left text-sm text-gray-900">
+//             {notification.content}
+//           </p>
+//           <p className="flex items-center text-xs text-gray-500">
+//             {formatDate(notification.created_at)}
+//           </p>
+//         </div>
+//         {!notification.is_read && (
+//           <div className="flex pt-2">
+//             <div className="bg-primary-500 size-2 rounded-full" />
+//           </div>
+//         )}
+//       </div>
+//     </div>
+//   )
+// }

--- a/src/components/commons/header/components/notification-section/NotificationTabs.tsx
+++ b/src/components/commons/header/components/notification-section/NotificationTabs.tsx
@@ -1,0 +1,77 @@
+// import { tabClass } from './notificationIconClass'
+// import type { NotificationItem } from '@src/types/notification'
+// import { cn } from '@utils/cn'
+
+// interface NotificationTabsProps {
+//   setNotificationFilter: (filter: 'all' | 'unread' | 'read') => void
+//   notificationFilter: 'all' | 'unread' | 'read'
+//   notifications: NotificationItem[]
+//   totalCount: number
+//   unreadCount: number
+// }
+// export default function NotificationTabs({
+//   setNotificationFilter,
+//   notificationFilter,
+//   notifications,
+//   unreadCount,
+//   totalCount,
+// }: NotificationTabsProps) {
+//   const readCount = notifications.filter(
+//     (notification) => notification.is_read
+//   ).length
+//   const isUnreadTabDisabled = unreadCount === 0
+//   const isReadTabDisabled = unreadCount === 0
+//   const handleTabClick = (filter: 'all' | 'unread' | 'read') => {
+//     // 읽지않음 탭이 비활성화된 경우 클릭 무시
+//     if (
+//       (filter === 'unread' && isUnreadTabDisabled) ||
+//       (filter === 'read' && isReadTabDisabled)
+//     ) {
+//       return
+//     }
+//     setNotificationFilter(filter)
+//   }
+
+//   return (
+//     <div className="flex w-full max-w-md min-w-[320px]" role="tablist">
+//       <button
+//         role="tab"
+//         onClick={() => handleTabClick('all')}
+//         className={cn(
+//           'flex-1',
+//           tabClass({
+//             active: notificationFilter === 'all',
+//           })
+//         )}
+//       >
+//         전체보기 ({totalCount})
+//       </button>
+//       <button
+//         role="tab"
+//         onClick={() => handleTabClick('unread')}
+//         className={cn(
+//           'flex-1',
+//           tabClass({
+//             active: notificationFilter === 'unread' && !isUnreadTabDisabled,
+//           }),
+//           isUnreadTabDisabled && 'cursor-not-allowed text-gray-400 opacity-50'
+//         )}
+//       >
+//         읽지 않음 ({unreadCount})
+//       </button>
+//       <button
+//         role="tab"
+//         onClick={() => handleTabClick('read')}
+//         className={cn(
+//           'flex-1',
+//           tabClass({
+//             active: notificationFilter === 'read' && !isReadTabDisabled,
+//           }),
+//           isReadTabDisabled && 'cursor-not-allowed text-gray-400 opacity-50'
+//         )}
+//       >
+//         읽음 ({readCount})
+//       </button>
+//     </div>
+//   )
+// }

--- a/src/components/commons/header/components/notification-section/NotificationsDropdown.tsx
+++ b/src/components/commons/header/components/notification-section/NotificationsDropdown.tsx
@@ -1,0 +1,142 @@
+// import { useEffect, useMemo, useState, type RefObject } from 'react'
+// import { Z_INDEX } from '@constants/ui'
+// import { cn } from '@utils/cn'
+// import NotificationTabs from './NotificationTabs'
+// import NotificationItem from './NotificationItem'
+// import NotificationsSkeleton from './NotificationsSkeleton'
+// import {
+//   useNotifications,
+//   useMarkAllAsRead,
+//   useUnreadCountQuery,
+// } from '@hooks/useNotifications'
+// import { useIntersectionObserver } from '@hooks/useIntersectionObserver'
+
+// interface NotificationsDropdownProps {
+//   setIsNotificationOpen: (isNotificationOpen: boolean) => void
+//   notificationsDropdownRef: RefObject<HTMLDivElement | null>
+// }
+
+// export default function NotificationsDropdown({
+//   setIsNotificationOpen,
+//   notificationsDropdownRef,
+// }: NotificationsDropdownProps) {
+//   const [notificationFilter, setNotificationFilter] = useState<
+//     'all' | 'unread' | 'read'
+//   >('all')
+
+//   const {
+//     notifications,
+//     totalCount,
+//     isLoading,
+//     error,
+//     fetchNextPage,
+//     hasNextPage,
+//     isFetchingNextPage,
+//   } = useNotifications()
+
+//   const { unreadCount } = useUnreadCountQuery()
+//   const markAllAsReadMutation = useMarkAllAsRead()
+
+//   const handleMarkAllAsRead = () => {
+//     if (unreadCount === 0 || markAllAsReadMutation.isPending) {
+//       return
+//     }
+
+//     markAllAsReadMutation.mutate()
+//     if (notificationFilter === 'unread') {
+//       setNotificationFilter('all')
+//     }
+//   }
+//   const observerTargetRef = useIntersectionObserver({
+//     enabled: true,
+//     hasNextPage,
+//     isFetchingNextPage,
+//     onIntersect: () => fetchNextPage(),
+//     threshold: 0.5,
+//   })
+
+//   const filteredNotifications = useMemo(() => {
+//     switch (notificationFilter) {
+//       case 'unread':
+//         return notifications.filter((notification) => !notification.is_read)
+//       case 'read':
+//         return notifications.filter((notification) => notification.is_read)
+//       default:
+//         return notifications
+//     }
+//   }, [notifications, notificationFilter])
+
+//   // unreadCount가 0이 되면 자동으로 전체보기로
+//   useEffect(() => {
+//     if (unreadCount === 0 && notificationFilter === 'unread') {
+//       setNotificationFilter('all')
+//     }
+//   }, [unreadCount, notificationFilter])
+
+//   return (
+//     <div
+//       ref={notificationsDropdownRef}
+//       className={cn(
+//         'absolute top-12 right-0 max-h-[819.2px] overflow-hidden rounded-lg border border-gray-200 bg-white',
+//         `${Z_INDEX.DROPDOWN}`
+//       )}
+//       onClick={(e) => e.stopPropagation()}
+//     >
+//       <div className="flex items-center justify-between px-4 pt-4 pb-[17px]">
+//         <h3 className="flex items-center justify-start text-lg font-semibold text-gray-900">
+//           알림
+//         </h3>
+//         <button
+//           type="button"
+//           disabled={unreadCount === 0 || markAllAsReadMutation.isPending}
+//           onClick={handleMarkAllAsRead}
+//           className="text-primary-600 flex cursor-pointer items-center justify-center text-center text-sm"
+//         >
+//           {markAllAsReadMutation.isPending ? '처리 중…' : '모두 읽음'}
+//         </button>
+//       </div>
+
+//       <NotificationTabs
+//         setNotificationFilter={setNotificationFilter}
+//         notificationFilter={notificationFilter}
+//         notifications={notifications}
+//         totalCount={totalCount}
+//         unreadCount={unreadCount}
+//       />
+
+//       <div
+//         className="scrollbar-hide flex max-h-80 flex-col overflow-y-auto"
+//         role="tabpanel"
+//       >
+//         {isLoading ? (
+//           <NotificationsSkeleton />
+//         ) : error ? (
+//           <div className="flex h-32 min-w-[364px] items-center justify-center text-sm text-red-500">
+//             알림을 불러오는데 실패했습니다.
+//           </div>
+//         ) : filteredNotifications.length !== 0 ? (
+//           <>
+//             {filteredNotifications.map((notification) => (
+//               <NotificationItem
+//                 key={notification.notification_id}
+//                 {...notification}
+//                 setIsNotificationOpen={setIsNotificationOpen}
+//               />
+//             ))}
+//             <div ref={observerTargetRef} className="h-4" />
+//             {isFetchingNextPage && (
+//               <div className="flex items-center justify-center py-4 text-sm text-gray-500">
+//                 로딩 중...
+//               </div>
+//             )}
+//           </>
+//         ) : (
+//           <div className="flex h-32 min-w-[364px] items-center justify-center text-sm text-gray-500">
+//             표시할 알림이 없습니다.
+//           </div>
+//         )}
+//       </div>
+//       <div className="flex h-[45px] bg-gray-50" />
+//     </div>
+//   )
+// }

--- a/src/components/commons/header/components/notification-section/NotificationsSkeleton.tsx
+++ b/src/components/commons/header/components/notification-section/NotificationsSkeleton.tsx
@@ -1,0 +1,28 @@
+// export default function NotificationsSkeleton() {
+//   return (
+//     <>
+//       {[...Array(5)].map((_, index) => (
+//         <div
+//           key={index}
+//           className="flex animate-pulse items-start gap-3 border-b border-gray-200 px-4 pt-[17px] pb-4"
+//         >
+//           {/* 아이콘 자리 */}
+//           <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-200" />
+
+//           {/* 콘텐츠 자리 */}
+//           <div className="flex min-w-72 gap-1">
+//             <div className="flex flex-1 flex-col gap-1">
+//               <div className="h-4 w-full rounded bg-gray-200" />
+//               <div className="h-4 w-3/4 rounded bg-gray-200" />
+//               <div className="mt-1 h-3 w-16 rounded bg-gray-200" />
+//             </div>
+//             {/* 읽지 않음 표시 자리 */}
+//             <div className="flex pt-2">
+//               <div className="size-2 rounded-full bg-gray-200" />
+//             </div>
+//           </div>
+//         </div>
+//       ))}
+//     </>
+//   )
+// }

--- a/src/components/commons/header/components/notification-section/notificationIconClass.ts
+++ b/src/components/commons/header/components/notification-section/notificationIconClass.ts
@@ -1,0 +1,54 @@
+// import { cva, type VariantProps } from 'class-variance-authority'
+
+// export const notificationIconClass = cva(
+//   'flex h-8 w-8 shrink-0 items-center justify-center rounded-full',
+//   {
+//     variants: {
+//       type: {
+//         ADD_APPLICATION: 'bg-blue-100',
+//         APPLICATION_ACCEPT: 'bg-green-100',
+//         APPLICATION_REJECT: 'bg-red-100',
+//         STUDY_JOIN: 'bg-purple-100',
+//         STUDY_NOTE_CREATE: 'bg-[#CCFBF1]',
+//         STUDY_REVIEW_REQUEST: 'bg-orange-100',
+//         TODAY_SCHEDULE: 'bg-[#FCE7F3]',
+//         UPCOMING_SCHEDULE: 'bg-[#E0E7FF]',
+//       },
+//     },
+//     defaultVariants: {
+//       type: 'ADD_APPLICATION',
+//     },
+//   }
+// )
+
+// export const notificationIconStrokeClass = cva('', {
+//   variants: {
+//     type: {
+//       ADD_APPLICATION: 'stroke-[#2563EB]',
+//       APPLICATION_ACCEPT: 'stroke-[#16A34A]',
+//       APPLICATION_REJECT: 'stroke-[#DC2626]',
+//       STUDY_JOIN: 'stroke-[#9333EA]',
+//       STUDY_NOTE_CREATE: 'stroke-[#0D9488]',
+//       STUDY_REVIEW_REQUEST: 'stroke-[#EA580C]',
+//       TODAY_SCHEDULE: 'stroke-[#DB2777]',
+//       UPCOMING_SCHEDULE: 'stroke-[#4F46E5]',
+//     },
+//   },
+//   defaultVariants: {
+//     type: 'ADD_APPLICATION',
+//   },
+// })
+// export type NotificationIconClassProps = VariantProps<
+//   typeof notificationIconClass
+// >
+// export const tabClass = cva(
+//   'flex w-2/3 items-center justify-center pt-3 pb-3.5 text-sm border-b-2 transition-colors cursor-pointer',
+//   {
+//     variants: {
+//       active: {
+//         true: 'border-primary-500 text-primary-600',
+//         false: 'border-transparent text-gray-500',
+//       },
+//     },
+//   }
+// )

--- a/src/components/commons/header/components/user-section/AuthMenu.tsx
+++ b/src/components/commons/header/components/user-section/AuthMenu.tsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router-dom'
+import { ROUTES } from '@src/constants/routes'
+// import PageLink from '@components/commons/page-link/PageLink'
+// const ACCOUNT = 'https://account.ozcoding.site'
+// const returnTo = encodeURIComponent(window.location.href)
+export default function AuthMenu() {
+  return (
+    <>
+      <Link
+        to={ROUTES.LOGIN}
+        // variant="text"
+        // fontWeight="normal"
+        // link={`${ACCOUNT}/auth/login?return_to=${returnTo}`}
+        // size="lg"
+      >
+        로그인
+      </Link>
+      <Link
+        to={ROUTES.SIGNUP}
+        // variant="filled"
+        // size="base"
+        // fontWeight="medium"
+        // link="/signup"
+        className="rounded-lg bg-white px-4 py-2.5"
+      >
+        회원가입
+      </Link>
+    </>
+  )
+}

--- a/src/components/commons/header/components/user-section/HeaderUserSection.tsx
+++ b/src/components/commons/header/components/user-section/HeaderUserSection.tsx
@@ -1,0 +1,47 @@
+// import UserMenu from './UserMenu'
+import AuthMenu from './AuthMenu'
+// import NotificationButton from '@src/components/commons/header/components/notification-section/NotificationButton'
+// import { useState } from 'react'
+// import { useAuth } from '@src/store/auth'
+
+export default function HeaderUserSection() {
+  // const [isUserMenuOpen, setIsUserMenuOpen] = useState(false)
+  // const [isNotificationOpen, setIsNotificationOpen] = useState(false)
+
+  // const isLoggedIn = useAuth((state) => state.isLoggedIn())
+  // const userNickname = useAuth((state) => state.user?.nickname ?? '사용자')
+  // const bootstrapped = useAuth((state) => state.bootstrapped)
+
+  // if (!bootstrapped) {
+  //   return (
+  //     <div className="flex items-center gap-4">
+  //       <div className="h-10 w-10 animate-pulse rounded-full bg-gray-200" />
+  //       <div className="h-6 w-20 animate-pulse rounded bg-gray-200" />
+  //     </div>
+  //   )
+  // }
+
+  return (
+    <div className="flex items-center gap-4">
+      {/* {isLoggedIn ? (
+        <>
+          <NotificationButton
+            isNotificationOpen={isNotificationOpen}
+            setIsNotificationOpen={setIsNotificationOpen}
+            isUserMenuOpen={isUserMenuOpen}
+            setIsUserMenuOpen={setIsUserMenuOpen}
+          />
+          <UserMenu
+            isNotificationOpen={isNotificationOpen}
+            setIsNotificationOpen={setIsNotificationOpen}
+            isUserMenuOpen={isUserMenuOpen}
+            setIsUserMenuOpen={setIsUserMenuOpen}
+            userNickname={userNickname}
+          />
+        </>
+      ) : ( */}
+      <AuthMenu />
+      {/* )} */}
+    </div>
+  )
+}

--- a/src/components/commons/header/components/user-section/UserMenu.tsx
+++ b/src/components/commons/header/components/user-section/UserMenu.tsx
@@ -1,0 +1,68 @@
+// import Icon from '@components/commons/Icon'
+import { Z_INDEX } from '@constants/ui'
+// import { useOutsideClick } from '@src/hooks/useOutsideClick'
+import { cn } from '@utils/cn'
+import { UserRound as UserRoundIcon, LogOut as LogOutIcon } from 'lucide-react'
+import { useRef } from 'react'
+// import { EXTERNAL } from '@src/constants/external'
+// import { logoutHard } from '@src/store/auth'
+import { ROUTES } from '@src/constants/routes'
+
+interface UserMenuProps {
+  isNotificationOpen: boolean
+  setIsNotificationOpen: (isNotificationOpen: boolean) => void
+  isUserMenuOpen: boolean
+  setIsUserMenuOpen: (isUserMenuOpen: boolean) => void
+  userNickname?: string
+}
+
+export default function UserMenu({ isNotificationOpen, setIsNotificationOpen, isUserMenuOpen, setIsUserMenuOpen, userNickname }: UserMenuProps) {
+  const userMenuButtonRef = useRef<HTMLDivElement>(null)
+  const userMenuPanelRef = useRef<HTMLDivElement>(null)
+  const handleAvatarToggle = () => {
+    // 알림드롭다운 ui 가 열려있다면 알림드롭다운 닫기
+    if (isNotificationOpen) {
+      setIsNotificationOpen(false)
+    }
+    // 마이페이지 ui 토글
+    setIsUserMenuOpen(!isUserMenuOpen)
+  }
+
+  // const handleLogout = async () => {
+  //   await logoutHard()
+  // }
+  // useOutsideClick(isUserMenuOpen, [userMenuButtonRef, userMenuPanelRef], () =>
+  //   setIsUserMenuOpen(false)
+  // )
+
+  return (
+    <div ref={userMenuButtonRef} className="relative flex cursor-pointer items-center gap-2" onClick={handleAvatarToggle}>
+      <div className="bg-primary-100 flex h-8 w-8 items-center justify-center rounded-full">
+        {/* <Icon icon={UserRoundIcon} size="sm" className={`stroke-primary-600`} /> */}
+      </div>
+
+      <p className="text-base text-gray-700">{userNickname}</p>
+      {isUserMenuOpen && (
+        <div
+          ref={userMenuPanelRef}
+          className={cn(
+            'absolute top-12 right-0 flex w-48 flex-col divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white py-2 shadow-lg',
+            `${Z_INDEX.DROPDOWN}`
+          )}
+        >
+          <a href={ROUTES.MYPAGE} className="flex w-full items-center gap-3 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50">
+            <UserRoundIcon className="h-4 w-4" />
+            마이페이지
+          </a>
+          <button
+            // onClick={handleLogout}
+            className="flex w-full items-center gap-3 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
+          >
+            <LogOutIcon className="h-4 w-4 rotate-180" />
+            로그아웃
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/commons/header/components/user-section/notificationIconClass.ts
+++ b/src/components/commons/header/components/user-section/notificationIconClass.ts
@@ -1,0 +1,52 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+
+export const notificationIconClass = cva(
+  'flex h-8 w-8 shrink-0 items-center justify-center rounded-full',
+  {
+    variants: {
+      type: {
+        application: 'bg-blue-100',
+        approval: 'bg-green-100',
+        rejection: 'bg-red-100',
+        join: 'bg-purple-100',
+        study_end: 'bg-orange-100',
+        reminder: 'bg-gray-100',
+      },
+    },
+    defaultVariants: {
+      type: 'reminder',
+    },
+  }
+)
+
+export const notificationIconStrokeClass = cva('', {
+  variants: {
+    type: {
+      application: 'stroke-[#2563EB]',
+      approval: 'stroke-[#16A34A]',
+      rejection: 'stroke-[#DC2626]',
+      join: 'stroke-[#9333EA]',
+      study_end: 'stroke-[#EA580C]',
+      reminder: 'stroke-gray-400',
+    },
+  },
+  defaultVariants: {
+    type: 'reminder',
+  },
+})
+
+export type NotificationIconClassProps = VariantProps<
+  typeof notificationIconClass
+>
+
+export const tabClass = cva(
+  'flex w-2/3 items-center justify-center pt-3 pb-3.5 text-sm border-b-2 transition-colors cursor-pointer',
+  {
+    variants: {
+      active: {
+        true: 'border-primary-500 text-primary-600',
+        false: 'border-transparent text-gray-500',
+      },
+    },
+  }
+)

--- a/src/index.css
+++ b/src/index.css
@@ -26,6 +26,11 @@ body {
   font-feature-settings: 'liga' 1, 'calt' 1;
 }
 
+/* Logo 폰트 */
+.logo {
+  font-family: 'BMJUA', sans-serif;
+}
+
 /* Chrome / Edge / Safari */
 input[type='date']::-webkit-calendar-picker-indicator {
   opacity: 0; /* 안 보이게 */

--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -94,10 +94,20 @@
   font-family: 'Cafe24Oneprettynight', 'Pretendard', sans-serif;
 } */
 
-@font-face {
-  font-family: 'Pretendard Variable';
-  font-weight: 45 920;
-  font-style: normal;
-  font-display: swap;
-  src: url('/assets/fonts/PretendardVariable.woff2') format('woff2');
+@layer base {
+  @font-face {
+    font-family: 'Pretendard Variable';
+    font-weight: 45 920;
+    font-style: normal;
+    font-display: swap;
+    src: url('@assets/fonts/PretendardVariable.woff2') format('woff2');
+  }
+
+  @font-face {
+    font-family: 'BMJUA';
+    font-weight: 400;
+    font-style: normal;
+    font-display: swap;
+    src: url('@assets/fonts/BMJUA.woff2') format('woff2');
+  }
 }


### PR DESCRIPTION
## 📌 개요
Header 컴포넌트 리팩토링 및 BMJUA 폰트 적용

## 🔧 작업 내용
- Header 컴포넌트를 Logo, SearchBar, Navigation으로 분리
- SearchBar를 공통 Input 컴포넌트 기반으로 리팩토링
- BMJUA 폰트 @font-face 정의 추가 및 Logo에 적용
- Input 컴포넌트에 h-full 클래스 추가하여 높이 제어 개선
- fonts.css를 @layer base로 감싸서 Tailwind 레이어 구조 개선
- 폰트 파일 경로를 @assets alias로 변경

## 📎 관련 이슈

- Close #144 

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| 이미지  | 이미지  |

## 💬 리뷰어 참고 사항

- 리뷰어가 중점적으로 봐주었으면 하는 부분
- 추가 논의가 필요한 부분
