### PR TITLE
refactor: 상품 타입별 탭 필터링 기능 추가(#156)

### DIFF
--- a/src/api/products.ts
+++ b/src/api/products.ts
@@ -13,8 +13,17 @@ import axios from 'axios'
 import { apiFetch } from './apiFetch'
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
 
-export const fetchAllProducts = async (page: number = 0, size: number = 20) => {
-  const response = await axios.get<ProductResponse>(`${API_BASE_URL}/products/search?page=${page}&size=${size}`)
+export const fetchAllProducts = async (page: number = 0, size: number = 20, productType?: string) => {
+  const params = new URLSearchParams({
+    page: page.toString(),
+    size: size.toString(),
+  })
+
+  if (productType) {
+    params.append('productType', productType)
+  }
+
+  const response = await axios.get<ProductResponse>(`${API_BASE_URL}/products/search?${params.toString()}`)
   console.log(response)
 
   return {

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1194,6 +1194,14 @@ export type StateCode = (typeof LOCATIONS)[number]['code']
 export type CityCode = (typeof LOCATIONS)[number]['cities'][number]['code']
 
 // ========== 탭 관련 상수 ==========
+export const PRODUCT_TYPE_TABS = [
+  { id: 'tab-all', label: '전체' },
+  { id: 'tab-sales', label: '판매' },
+  { id: 'tab-purchases', label: '판매요청' },
+] as const
+export type ProductTypeTabId = (typeof PRODUCT_TYPE_TABS)[number]['id']
+
+// 상품 등록용 탭 (기존 호환성)
 export const PRODUCT_POST_TABS = [
   { id: 'sales', label: '판매' },
   { id: 'purchases', label: '판매요청' },


### PR DESCRIPTION
## 📌 개요
상품 타입별 탭 필터링 기능 추가

## 🔧 작업 내용
- 전체/판매/판매요청 탭 UI 추가
- fetchAllProducts API에 productType 파라미터 추가
- React Query queryKey에 activeTab 추가하여 탭 전환 시 데이터 재요청
- PRODUCT_TYPE_TABS 상수 추가

## 📎 관련 이슈

- Close #156 

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| 이미지  | 이미지  |

## 💬 리뷰어 참고 사항

- 리뷰어가 중점적으로 봐주었으면 하는 부분
- 추가 논의가 필요한 부분
