### PR TITLE
refactor: ProductTypeTabs 컴포넌트 생성(#158)

### DIFF
--- a/src/components/commons/button/Button.tsx
+++ b/src/components/commons/button/Button.tsx
@@ -3,16 +3,14 @@ import type { ReactNode } from 'react'
 import type { LucideIcon } from 'lucide-react'
 import { buttonVariants, iconSizeMap, type ButtonVariants } from './buttonClass'
 
-interface ButtonProps extends ButtonVariants {
+interface ButtonProps extends Omit<React.ComponentPropsWithoutRef<'button'>, 'disabled'>, ButtonVariants {
   children?: ReactNode
   icon?: LucideIcon
   iconSrc?: string
-  type?: 'button' | 'submit' | 'reset'
-  onClick?: () => void
-  className?: string
+  disabled?: boolean
 }
 
-export function Button({ children, icon: Icon, iconSrc, size = 'md', disabled = false, type = 'button', onClick, className }: ButtonProps) {
+export function Button({ children, icon: Icon, iconSrc, size = 'md', disabled = false, type = 'button', className, ...rest }: ButtonProps) {
   // 아이콘 위치 결정
   const iconPosition = (Icon || iconSrc) && !children ? 'only' : (Icon || iconSrc) && children ? 'left' : 'none'
 
@@ -22,9 +20,9 @@ export function Button({ children, icon: Icon, iconSrc, size = 'md', disabled = 
   return (
     <button
       type={type}
-      onClick={onClick}
       disabled={disabled ?? false}
       className={cn(buttonVariants({ size, iconPosition, disabled: disabled || undefined }), className)}
+      {...rest}
     >
       {Icon && <Icon size={iconSize} />}
       {iconSrc && <img src={iconSrc} alt="" className="h-4 w-4 object-contain" />}

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1195,9 +1195,9 @@ export type CityCode = (typeof LOCATIONS)[number]['cities'][number]['code']
 
 // ========== 탭 관련 상수 ==========
 export const PRODUCT_TYPE_TABS = [
-  { id: 'tab-all', label: '전체' },
-  { id: 'tab-sales', label: '판매' },
-  { id: 'tab-purchases', label: '판매요청' },
+  { id: 'tab-all', label: '전체', code: 'ALL' },
+  { id: 'tab-sales', label: '판매', code: 'SELL' },
+  { id: 'tab-purchases', label: '판매요청', code: 'REQUEST' },
 ] as const
 export type ProductTypeTabId = (typeof PRODUCT_TYPE_TABS)[number]['id']
 

--- a/src/pages/home/components/ProductTypeTabs.tsx
+++ b/src/pages/home/components/ProductTypeTabs.tsx
@@ -1,0 +1,34 @@
+import { Button } from '../../../components/commons/button/Button'
+import { PRODUCT_TYPE_TABS, type ProductTypeTabId } from '@src/constants/constants'
+import { cn } from '@src/utils/cn'
+
+interface ProductTypeTabsProps {
+  activeTab: ProductTypeTabId
+  onTabChange: (tabId: ProductTypeTabId) => void
+}
+
+export function ProductTypeTabs({ activeTab, onTabChange }: ProductTypeTabsProps) {
+  return (
+    <div role="tablist" aria-label="상품 타입 분류" className={cn('border-b-primary-200 flex gap-2.5 border-b-2 pb-1')}>
+      {PRODUCT_TYPE_TABS.map((tab) => (
+        <Button
+          key={tab.id}
+          id={tab.id}
+          size="md"
+          role="tab"
+          type="button"
+          onClick={() => onTabChange(tab.id)}
+          className={cn(
+            'flex-1 cursor-pointer rounded-2xl text-base',
+            activeTab === tab.id ? 'bg-primary-300 font-bold text-white' : 'hover:bg-primary-100 text-gray-900'
+          )}
+          aria-selected={activeTab === tab.id}
+          aria-controls={`panel-${tab.code}`}
+          tabIndex={activeTab === tab.id ? 0 : -1}
+        >
+          {tab.label}
+        </Button>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## 📌 개요
Home.tsx에 인라인으로 작성된 ProductTypeTabs UI를 재사용 가능한 컴포넌트로 분리하였습니다.

## 🔧 작업 내용
- ProductTypeTabs 컴포넌트 생성 (src/pages/home/components/ProductTypeTabs.tsx)
- Props 인터페이스 정의 (activeTab, onTabChange)
- ARIA 속성 추가 (role="tab", aria-selected, aria-controls, tabIndex)
- cn() 유틸리티 적용으로 클래스명 관리 개선


## 📎 관련 이슈

- Close #158 

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| 이미지  | 이미지  |

## 💬 리뷰어 참고 사항

- 리뷰어가 중점적으로 봐주었으면 하는 부분
- 추가 논의가 필요한 부분
