### PR TITLE
feat: 헤더 검색 기능 구현(#170)

### DIFF
--- a/src/api/products.ts
+++ b/src/api/products.ts
@@ -25,13 +25,17 @@ export const fetchAllProducts = async (
   addressGugun?: string | null,
   selectedCategory?: string | null,
   petType?: string | null,
-  selectedDetailPet?: string | null
+  selectedDetailPet?: string | null,
+  keyword?: string | null
 ) => {
   const params = new URLSearchParams({
     page: page.toString(),
     size: size.toString(),
   })
 
+  if (keyword) {
+    params.append('keyword', keyword)
+  }
   if (petType) {
     params.append('petType', petType)
   }
@@ -67,13 +71,16 @@ export const fetchAllProducts = async (
 
   const response = await axios.get<ProductResponse>(`${API_BASE_URL}/products/search?${params.toString()}`)
 
-  console.log(response.data.data.content)
-
   return {
     data: response.data,
     total: response.data.data.totalElements,
   }
 }
+
+// export const fetchAllCategory = async (): Promise<FilterApiResponse> => {
+//   const data = await apiFetch(`${API_BASE_URL}/categories/all-get`)
+//   return data
+// }
 
 export const fetchAllCategory = async (): Promise<FilterApiResponse> => {
   const data = await apiFetch(`${API_BASE_URL}/categories/all-get`)

--- a/src/components/commons/filters/ConditionFilter.tsx
+++ b/src/components/commons/filters/ConditionFilter.tsx
@@ -1,6 +1,7 @@
 import { Button } from '../button/Button'
 import { CONDITION_ITEMS } from '@src/constants/constants'
 import { cn } from '@src/utils/cn'
+import { useSearchParams } from 'react-router-dom'
 
 interface ConditionFilterProps {
   headingClassName?: string
@@ -9,10 +10,22 @@ interface ConditionFilterProps {
 }
 
 export function ConditionFilter({ headingClassName, selectedProductStatus, onProductStatusChange }: ConditionFilterProps) {
+  const [, setSearchParams] = useSearchParams()
+
   const handleProductStatuses = (e: React.MouseEvent, value: string) => {
     e.stopPropagation() // 이벤트 버블링 방지
     // 같은 상태 클릭 시 선택 해제, 다른 상태 클릭 시 선택
-    onProductStatusChange?.(selectedProductStatus === value ? null : value)
+    const isDeselecting = selectedProductStatus === value
+    setSearchParams((prev) => {
+      if (isDeselecting) {
+        prev.delete('categories') // 선택 해제 시 URL에서 제거
+      } else {
+        prev.set('categories', value) // 선택 시 URL에 추가
+      }
+      return prev
+    })
+
+    onProductStatusChange?.(isDeselecting ? null : value)
   }
 
   return (
@@ -27,8 +40,8 @@ export function ConditionFilter({ headingClassName, selectedProductStatus, onPro
             type="button"
             size="sm"
             className={cn(
-              'bg-primary-100 cursor-pointer',
-              selectedProductStatus === item.value ? 'bg-primary-300 font-bold text-white' : 'hover:bg-primary-100 text-gray-900'
+              'bg-primary-50 cursor-pointer',
+              selectedProductStatus === item.value ? 'bg-primary-300 font-bold text-white' : 'hover:bg-primary-300 text-gray-900 hover:text-white'
             )}
             onClick={(e) => handleProductStatuses(e, item.value)}
             aria-pressed={selectedProductStatus === item.value}

--- a/src/components/commons/filters/PriceFilter.tsx
+++ b/src/components/commons/filters/PriceFilter.tsx
@@ -1,6 +1,7 @@
 import { Button } from '../button/Button'
 import { PRICE_TYPE, type PriceRange } from '@src/constants/constants'
 import { cn } from '@src/utils/cn'
+import { useSearchParams } from 'react-router-dom'
 
 interface PriceFilterProps {
   headingClassName?: string
@@ -9,10 +10,29 @@ interface PriceFilterProps {
 }
 
 export function PriceFilter({ headingClassName, selectedPriceRange, onMinPriceChange }: PriceFilterProps) {
+  const [, setSearchParams] = useSearchParams()
   const handleMinPrice = (e: React.MouseEvent, priceRange: PriceRange) => {
     e.stopPropagation() // 이벤트 버블링 방지
+
     // 같은 가격대 클릭 시 선택 해제, 다른 가격대 클릭 시 선택
-    onMinPriceChange?.(selectedPriceRange?.min === priceRange.min && selectedPriceRange?.max === priceRange.max ? null : priceRange)
+    const isDeselecting = selectedPriceRange?.min === priceRange.min && selectedPriceRange?.max === priceRange.max
+
+    setSearchParams((prev) => {
+      if (isDeselecting) {
+        prev.delete('minPrice')
+        prev.delete('maxPrice')
+      } else {
+        prev.set('minPrice', priceRange.min.toString())
+        if (priceRange.max !== null) {
+          prev.set('maxPrice', priceRange.max.toString())
+        } else {
+          prev.delete('maxPrice')
+        }
+      }
+      return prev
+    })
+
+    onMinPriceChange?.(isDeselecting ? null : priceRange)
   }
   return (
     <div className="flex flex-col gap-2">
@@ -26,10 +46,10 @@ export function PriceFilter({ headingClassName, selectedPriceRange, onMinPriceCh
             type="button"
             size="sm"
             className={cn(
-              'bg-primary-100 cursor-pointer',
+              'bg-primary-50 cursor-pointer',
               selectedPriceRange?.min === item.value.min && selectedPriceRange?.max === item.value.max
                 ? 'bg-primary-300 font-bold text-white'
-                : 'hover:bg-primary-100 text-gray-900'
+                : 'hover:bg-primary-300 text-gray-900 hover:text-white'
             )}
             onClick={(e) => handleMinPrice(e, item.value)}
             aria-pressed={selectedPriceRange?.min === item.value.min && selectedPriceRange?.max === item.value.max}

--- a/src/components/commons/header/components/SearchBar.tsx
+++ b/src/components/commons/header/components/SearchBar.tsx
@@ -1,31 +1,36 @@
 import { Search as SearchIcon } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 // import { useDebounce } from '@hooks/useDebounce'
 import { cn } from '@src/utils/cn'
 import { Input } from '@components/commons/Input'
+import { useSearchParams } from 'react-router-dom'
 
 interface SearchBarProps {
-  value?: string // 초기값
-  // onSearch: (keyword: string) => void // 디바운스 후 검색 실행
   placeholder?: string
   delay?: number // 디바운스 시간 (ms)
   className?: string
 }
 
-export function SearchBar({
-  value = '',
-  // onSearch,
-  placeholder = '원하는 반려동물 용품을 검색해보세요',
-  // delay = 500,
-  className,
-}: SearchBarProps) {
-  const [keyword, setKeyword] = useState(value)
-  // const debouncedKeyword = useDebounce(keyword, delay)
+export function SearchBar({ placeholder = '원하는 반려동물 용품을 검색해보세요', className }: SearchBarProps) {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const currentKeyword = searchParams.get('keyword') || ''
+  const [keyword, setKeyword] = useState(currentKeyword)
 
-  // 디바운스된 키워드가 변경되면 검색 실행
-  // useEffect(() => {
-  //   onSearch(debouncedKeyword)
-  // }, [debouncedKeyword, onSearch])
+  function handleKeywordChange(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') {
+      const target = e.target as HTMLInputElement
+      const keyword = target.value.trim()
+      setSearchParams((prev) => {
+        prev.set('keyword', keyword)
+        return prev
+      })
+    }
+  }
+  // URL이 변경될 때 (뒤로가기, 앞으로가기 등) Input value 동기화
+  useEffect(() => {
+    setKeyword(currentKeyword)
+  }, [currentKeyword])
+
   return (
     <div className={cn('h-10 max-w-[700px] flex-1', className)}>
       <Input
@@ -33,6 +38,7 @@ export function SearchBar({
         value={keyword}
         placeholder={placeholder}
         onChange={(e) => setKeyword(e.target.value)}
+        onKeyDown={handleKeywordChange}
         icon={SearchIcon}
         border
         borderColor="border-gray-100"

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,40 +1,34 @@
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { useState, useCallback } from 'react'
-// import CategoryFilter from '@src/components/layouts/CategoryFilter'
 import { ProductTypeTabs } from '@src/pages/home/components/ProductTypeTabs'
 import { DetailFilter } from '@src/pages/home/components/DetailFilter'
 import { ProductList } from '@src/pages/home/components/ProductList'
 import { fetchAllProducts } from '../../api/products'
 import { useIntersectionObserver } from '../../hooks/useIntersectionObserver'
-import { PRODUCT_TYPE_TABS, PET_TYPE_TABS } from '@src/constants/constants'
-import type { ProductTypeTabId, PriceRange, LocationFilter, CategoryFilter as CategoryFilterType, PetTypeTabId } from '@src/constants/constants'
+import {
+  PRODUCT_TYPE_TABS,
+  PET_TYPE_TABS,
+  type ProductTypeTabId,
+  type PriceRange,
+  type LocationFilter,
+  type PetTypeTabId,
+  type CategoryFilter as CategoryFilterType,
+} from '@src/constants/constants'
 import { PetTypeFilter } from './components/PetTypeFilter'
 import { CategoryFilter } from './components/CategoryFilter'
-// import { useUserStore } from '@store/userStore'
+import { useSearchParams } from 'react-router-dom'
 
 function Home() {
-  // const { accessToken } = useUserStore()
-  // 현재 선택된 탭 상태 ('tab-all' | 'tab-sales' | 'tab-purchases')
+  const [searchParams] = useSearchParams()
+  const keyword = searchParams.get('keyword') || ''
+
   const [activePetTypeTab, setActivePetTypeTab] = useState<PetTypeTabId>('tab-all')
-
   const [activeProductTypeTab, setActiveProductTypeTab] = useState<ProductTypeTabId>('tab-all')
-
-  // 상품 상태 필터
   const [selectedProductStatus, setSelectedProductStatus] = useState<string | null>(null)
-
-  // 가격 필터
   const [selectedProductPrice, setSelectedProductPrice] = useState<PriceRange | null>(null)
-
-  // 지역 필터
   const [selectedLocation, setSelectedLocation] = useState<LocationFilter | null>(null)
-
-  // 카테고리 필터
   const [selectedCategory, setSelectedCategory] = useState<CategoryFilterType | null>(null)
-
-  // 반려동물 세부종류 필터
   const [selectedDetailPet, setSelectedDetailPet] = useState<CategoryFilterType | null>(null)
-
-  // 세부 필터 열림/닫힘 상태
   const [isDetailFilterOpen, setIsDetailFilterOpen] = useState(false)
 
   // 세부 필터 토글 함수 메모이제이션
@@ -67,18 +61,6 @@ function Home() {
     setSelectedDetailPet(pet)
   }, [])
 
-  // const [_filters, setFilters] = useState<FilterState>({
-  //   selectedPetType: null,
-  //   selectedPetDetails: [],
-  //   selectedCategories: [],
-  //   selectedConditions: [],
-  //   selectedPriceRanges: [],
-  //   selectedLocation: {
-  //     state: null,
-  //     city: null,
-  //   },
-  // })
-
   /**
    * 무한 스크롤을 위한 React Query 설정
    * - queryKey: ['products', activeTab, selectedProductStatus] - 필터 변경 시 새로운 쿼리로 인식하여 데이터 refetch
@@ -97,6 +79,7 @@ function Home() {
       selectedLocation,
       selectedCategory,
       activePetTypeTab,
+      keyword,
     ],
 
     // 각 페이지 데이터를 가져오는 함수
@@ -121,7 +104,8 @@ function Home() {
         selectedLocation?.gugun ?? null,
         selectedCategory,
         petType,
-        selectedDetailPet
+        selectedDetailPet,
+        keyword
       )
     },
 
@@ -200,7 +184,7 @@ function Home() {
               activeTab={activePetTypeTab}
               onTabChange={setActivePetTypeTab}
               selectedDetailPet={selectedDetailPet}
-              onCategoryChange={handlePetDetailTypeChange}
+              onPetDetailTypeChange={handlePetDetailTypeChange}
             />
             <CategoryFilter selectedCategory={selectedCategory} onCategoryChange={handleCategoryChange} />
             <DetailFilter

--- a/src/pages/home/components/CategoryFilter.tsx
+++ b/src/pages/home/components/CategoryFilter.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@src/components/commons/button/Button'
 import { PRODUCT_CATEGORIES } from '@src/constants/constants'
 import { cn } from '@src/utils/cn'
+import { useSearchParams } from 'react-router-dom'
 
 interface CategoryFilterProps {
   headingClassName?: string
@@ -9,14 +10,30 @@ interface CategoryFilterProps {
 }
 
 export function CategoryFilter({ headingClassName, selectedCategory, onCategoryChange }: CategoryFilterProps) {
+  const [, setSearchParams] = useSearchParams()
+
   const handleProductCategory = (e: React.MouseEvent, category: string) => {
     e.stopPropagation() // 이벤트 버블링 방지
+
     // 같은 카테고리 클릭 시 선택 해제, 다른 카테고리 클릭 시 선택
-    onCategoryChange?.(selectedCategory === category ? null : category)
+    const isDeselecting = selectedCategory === category
+
+    setSearchParams((prev) => {
+      if (isDeselecting) {
+        prev.delete('categories') // 선택 해제 시 URL에서 제거
+      } else {
+        prev.set('categories', category) // 선택 시 URL에 추가
+      }
+      return prev
+    })
+
+    onCategoryChange?.(isDeselecting ? null : category)
   }
   return (
     <div className="flex flex-col gap-2.5">
-      <span id="category-filter-heading" className={cn('heading-h4', headingClassName)}> 상품 카테고리</span>
+      <span id="category-filter-heading" className={cn('heading-h4', headingClassName)}>
+        상품 카테고리
+      </span>
       <div className="flex flex-wrap gap-2.5" role="group" aria-labelledby="category-filter-heading">
         {PRODUCT_CATEGORIES?.map((category) => (
           <Button
@@ -25,7 +42,7 @@ export function CategoryFilter({ headingClassName, selectedCategory, onCategoryC
             size="sm"
             className={cn(
               'bg-primary-100 cursor-pointer',
-              selectedCategory === category.code ? 'bg-primary-300 font-bold text-white' : 'hover:bg-primary-100 text-gray-900'
+              selectedCategory === category.code ? 'bg-primary-300 font-bold text-white' : 'hover:bg-primary-300 text-gray-900 hover:text-white'
             )}
             onClick={(e) => handleProductCategory(e, category.code)}
             aria-pressed={selectedCategory === category.code}

--- a/src/pages/home/components/PetTypeFilter.tsx
+++ b/src/pages/home/components/PetTypeFilter.tsx
@@ -2,22 +2,35 @@ import { Button } from '@src/components/commons/button/Button'
 import { PET_DETAILS, PET_TYPE_TABS, PETS, type PetTypeTabId } from '@src/constants/constants'
 import { cn } from '@src/utils/cn'
 import { ProductPetTypeTabs } from './ProductPetTypeTabs'
+import { useSearchParams } from 'react-router-dom'
 
 interface PetTypeFilterProps {
   activeTab: PetTypeTabId
   onTabChange: (tabId: PetTypeTabId) => void
   headingClassName?: string
   selectedDetailPet?: string | null
-  onCategoryChange?: (category: string | null) => void
+  onPetDetailTypeChange?: (category: string | null) => void
 }
 
-export function PetTypeFilter({ activeTab, headingClassName, selectedDetailPet, onCategoryChange, onTabChange }: PetTypeFilterProps) {
-  // 현재 선택된 반려동물 타입
+export function PetTypeFilter({ activeTab, headingClassName, selectedDetailPet, onPetDetailTypeChange, onTabChange }: PetTypeFilterProps) {
+  const [, setSearchParams] = useSearchParams()
 
   const handleProductPetDetailType = (e: React.MouseEvent, pet: string) => {
     e.stopPropagation() // 이벤트 버블링 방지
+
     // 같은 반려동물 클릭 시 선택 해제, 다른 반려동물 클릭 시 선택
-    onCategoryChange?.(selectedDetailPet === pet ? null : pet)
+    const isDeselecting = selectedDetailPet === pet
+
+    setSearchParams((prev) => {
+      if (isDeselecting) {
+        prev.delete('petDetailType') // 선택 해제 시 URL에서 제거
+      } else {
+        prev.set('petDetailType', pet) // 선택 시 URL에 추가
+      }
+      return prev
+    })
+
+    onPetDetailTypeChange?.(isDeselecting ? null : pet)
   }
   const selectedPetTypeCode = PET_TYPE_TABS.find((tab) => tab.id === activeTab)?.code
 
@@ -40,7 +53,7 @@ export function PetTypeFilter({ activeTab, headingClassName, selectedDetailPet, 
               size="sm"
               className={cn(
                 'bg-primary-100 cursor-pointer',
-                selectedDetailPet === pet.code ? 'bg-primary-300 font-bold text-white' : 'hover:bg-primary-100 text-gray-900'
+                selectedDetailPet === pet.code ? 'bg-primary-300 font-bold text-white' : 'hover:bg-primary-300 text-gray-900 hover:text-white'
               )}
               onClick={(e) => handleProductPetDetailType(e, pet.code)}
               aria-pressed={selectedDetailPet === pet.code}


### PR DESCRIPTION

## 📌 개요
- 헤더 검색 기능 구현

## 🔧 작업 내용
- SearchBar: URL 쿼리 파라미터 기반 검색 기능 추가
  - useSearchParams를 사용하여 keyword를 URL에 저장
  - Enter 키로 검색 실행
  - 브라우저 뒤로가기/앞으로가기 시 검색어 동기화
- Home: 검색 키워드를 queryKey와 API 호출에 추가
  - URL의 keyword 파라미터를 읽어 상품 검색
  - 검색어 변경 시 자동으로 상품 목록 갱신
- products.ts: fetchAllProducts API에 keyword 파라미터 추가

## 📎 관련 이슈

- Close #170 

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| 이미지  | 이미지  |

## 💬 리뷰어 참고 사항

- 리뷰어가 중점적으로 봐주었으면 하는 부분
- 추가 논의가 필요한 부분
