### PR TITLE
feat: URL 쿼리 파라미터 기반 필터 상태 복원 기능 구현(#172)

### DIFF
--- a/src/components/commons/filters/PriceFilter.tsx
+++ b/src/components/commons/filters/PriceFilter.tsx
@@ -11,6 +11,7 @@ interface PriceFilterProps {
 
 export function PriceFilter({ headingClassName, selectedPriceRange, onMinPriceChange }: PriceFilterProps) {
   const [, setSearchParams] = useSearchParams()
+
   const handleMinPrice = (e: React.MouseEvent, priceRange: PriceRange) => {
     e.stopPropagation() // 이벤트 버블링 방지
 

--- a/src/components/commons/filters/ProductStateFilter.tsx
+++ b/src/components/commons/filters/ProductStateFilter.tsx
@@ -3,13 +3,13 @@ import { CONDITION_ITEMS } from '@src/constants/constants'
 import { cn } from '@src/utils/cn'
 import { useSearchParams } from 'react-router-dom'
 
-interface ConditionFilterProps {
+interface ProductStateFilterProps {
   headingClassName?: string
   selectedProductStatus?: string | null
   onProductStatusChange?: (status: string | null) => void
 }
 
-export function ConditionFilter({ headingClassName, selectedProductStatus, onProductStatusChange }: ConditionFilterProps) {
+export function ProductStateFilter({ headingClassName, selectedProductStatus, onProductStatusChange }: ProductStateFilterProps) {
   const [, setSearchParams] = useSearchParams()
 
   const handleProductStatuses = (e: React.MouseEvent, value: string) => {
@@ -18,9 +18,9 @@ export function ConditionFilter({ headingClassName, selectedProductStatus, onPro
     const isDeselecting = selectedProductStatus === value
     setSearchParams((prev) => {
       if (isDeselecting) {
-        prev.delete('categories') // 선택 해제 시 URL에서 제거
+        prev.delete('productStatuses') // 선택 해제 시 URL에서 제거
       } else {
-        prev.set('categories', value) // 선택 시 URL에 추가
+        prev.set('productStatuses', value) // 선택 시 URL에 추가
       }
       return prev
     })

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,5 +1,5 @@
 import { useInfiniteQuery } from '@tanstack/react-query'
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { ProductTypeTabs } from '@src/pages/home/components/ProductTypeTabs'
 import { DetailFilter } from '@src/pages/home/components/DetailFilter'
 import { ProductList } from '@src/pages/home/components/ProductList'
@@ -23,13 +23,21 @@ function Home() {
   const keyword = searchParams.get('keyword') || ''
 
   const [activePetTypeTab, setActivePetTypeTab] = useState<PetTypeTabId>('tab-all')
-  const [activeProductTypeTab, setActiveProductTypeTab] = useState<ProductTypeTabId>('tab-all')
-  const [selectedProductStatus, setSelectedProductStatus] = useState<string | null>(null)
-  const [selectedProductPrice, setSelectedProductPrice] = useState<PriceRange | null>(null)
-  const [selectedLocation, setSelectedLocation] = useState<LocationFilter | null>(null)
-  const [selectedCategory, setSelectedCategory] = useState<CategoryFilterType | null>(null)
-  const [selectedDetailPet, setSelectedDetailPet] = useState<CategoryFilterType | null>(null)
+  const [selectedDetailPet, setSelectedDetailPet] = useState<CategoryFilterType | null>(searchParams.get('petDetailType'))
+  const [selectedCategory, setSelectedCategory] = useState<CategoryFilterType | null>(searchParams.get('categories'))
   const [isDetailFilterOpen, setIsDetailFilterOpen] = useState(false)
+  const [selectedProductStatus, setSelectedProductStatus] = useState<string | null>(searchParams.get('productStatuses'))
+  const [selectedProductPrice, setSelectedProductPrice] = useState<PriceRange | null>(() => {
+    const minPrice = searchParams.get('minPrice')
+    const maxPrice = searchParams.get('maxPrice')
+    if (!minPrice) return null
+    return {
+      min: Number(minPrice),
+      max: maxPrice ? Number(maxPrice) : null,
+    }
+  })
+  const [selectedLocation, setSelectedLocation] = useState<LocationFilter | null>(null)
+  const [activeProductTypeTab, setActiveProductTypeTab] = useState<ProductTypeTabId>('tab-all')
 
   // 세부 필터 토글 함수 메모이제이션
   const handleDetailFilterToggle = useCallback((isOpen: boolean) => {
@@ -152,6 +160,18 @@ function Home() {
 
   // 전체 상품 개수 (API에서 제공)
   const totalElements = data?.pages?.[0]?.total || 0
+
+  // URL의 DetailFilter 필터들을 체크하는 로직
+  useEffect(() => {
+    const hasDetailFilter =
+      searchParams.has('productStatuses') || // ProductStateFilter
+      searchParams.has('minPrice') || // PriceFilter
+      searchParams.has('addressSido') // LocationFilter
+
+    if (hasDetailFilter) {
+      setIsDetailFilterOpen(true) // DetailFilter 안의 필터가 있으면 열기
+    }
+  }, [searchParams])
 
   // 로딩 상태
   if (isLoading && !data) {

--- a/src/pages/home/components/DetailFilter.tsx
+++ b/src/pages/home/components/DetailFilter.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react'
 import { DetailFilterButton } from './DetailFilterButton'
-import { ConditionFilter } from '../../../components/commons/filters/ConditionFilter'
+import { ProductStateFilter } from '../../../components/commons/filters/ProductStateFilter'
 import { PriceFilter } from '../../../components/commons/filters/PriceFilter'
 import { LocationFilter } from '../../../components/commons/filters/LocationFilter'
 import type { PriceRange, LocationFilter as LocationFilterType } from '@src/constants/constants'
@@ -29,7 +29,7 @@ export const DetailFilter = memo(function DetailFilterSection({
       <DetailFilterButton isOpen={isOpen} onClick={() => onToggle(!isOpen)} ariaControls="detail-filter-content" />
       {isOpen && (
         <div className="bg-primary-100 flex gap-10 rounded-lg px-3 py-2.5" role="group" id="detail-filter-content" aria-label="세부 필터 옵션">
-          <ConditionFilter selectedProductStatus={selectedProductStatus} onProductStatusChange={onProductStatusChange} />
+          <ProductStateFilter selectedProductStatus={selectedProductStatus} onProductStatusChange={onProductStatusChange} />
           <PriceFilter selectedPriceRange={selectedPriceRange} onMinPriceChange={onMinPriceChange} />
           <LocationFilter onLocationChange={onLocationChange} />
         </div>


### PR DESCRIPTION
## 📌 개요

- URL 쿼리 파라미터 기반 필터 상태 복원 기능 구현

## 🔧 작업 내용
- Home.tsx에서 모든 필터 state 초기화 시 URL 쿼리 파라미터 읽기
- 페이지 새로고침 시 선택된 필터 디자인 유지
- DetailFilter 관련 쿼리 파라미터 존재 시 자동으로 열기
- ConditionFilter를 ProductStateFilter로 리네이밍 (쿼리 파라미터명 수정)

## 📎 관련 이슈

- Close #172 

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| 이미지  | 이미지  |

## 💬 리뷰어 참고 사항

- 리뷰어가 중점적으로 봐주었으면 하는 부분
- 추가 논의가 필요한 부분
