### PR TITLE
feat: ProductCard에 상품 타입 정보 표시 기능 추가(#177)

### DIFF
--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -1,4 +1,4 @@
-import { CONDITION_ITEMS, PET_DETAILS, STATUS_EN_TO_KO } from '@constants/constants'
+import { CONDITION_ITEMS, PET_DETAILS, PRODUCT_TYPE_TABS, STATUS_EN_TO_KO } from '@constants/constants'
 // import { CiClock2 } from 'react-icons/ci'
 // import { GoHeart } from 'react-icons/go'
 import { Link } from 'react-router-dom'
@@ -26,6 +26,11 @@ const getTradeStatus = (tradeStatus: string) => {
   return condition?.name || tradeStatus
 }
 
+const getProductType = (productType: string) => {
+  const type = PRODUCT_TYPE_TABS.find((type) => type.code === productType)
+  return type?.label || productType
+}
+
 const getTradeStatusColor = (tradeStatus: string) => {
   const condition = STATUS_EN_TO_KO.find((status) => status.value === tradeStatus)
   return condition?.bgColor || 'bg-sale'
@@ -34,10 +39,11 @@ const getTradeStatusColor = (tradeStatus: string) => {
 function ProductCard({ data, 'data-index': dataIndex }: ProductCardProps) {
   if (!data) return null
 
-  const { id, title, price, mainImageUrl, petDetailType, productStatus, tradeStatus, createdAt, favoriteCount } = data
+  const { id, title, price, mainImageUrl, petDetailType, productStatus, tradeStatus, createdAt, favoriteCount, productType } = data
   const petTypeName = getPetTypeName(petDetailType)
   const productStatusName = getProductStatus(productStatus)
   const productTradeName = getTradeStatus(tradeStatus)
+  const productTypeName = getProductType(productType)
   const productTradeColor = getTradeStatusColor(tradeStatus)
 
   const handleLikeClick = (e: React.MouseEvent) => {
@@ -60,7 +66,7 @@ function ProductCard({ data, 'data-index': dataIndex }: ProductCardProps) {
       // onKeyDown={handleKeyDown}
       to={`/products/${id}`}
     >
-      <ProductInfo title={title} price={price} createdAt={createdAt} favoriteCount={favoriteCount} />
+      <ProductInfo title={title} price={price} createdAt={createdAt} favoriteCount={favoriteCount} productTypeName={productTypeName} />
       <ProductThumbnail
         imageUrl={mainImageUrl}
         title={title}

--- a/src/components/product/ProductHeading.tsx
+++ b/src/components/product/ProductHeading.tsx
@@ -5,14 +5,18 @@ const formatPrice = (price: number): string => {
 interface ProductHeadingProps {
   title: string
   price: number
+  productTypeName: string
 }
 
-export function ProductHeading({ title, price }: ProductHeadingProps) {
+export function ProductHeading({ title, price, productTypeName }: ProductHeadingProps) {
   return (
     <div className="flex flex-col gap-2">
       <span className="heading-h5 line-clamp line-1 text-gray-900">{title}</span>
-      <p className="text-primary-300 flex items-center font-bold">
-        <span className="max-w-[90%] overflow-hidden">{formatPrice(price)}</span>원
+      <p className="flex w-full flex-col">
+        <p className="font-semibold text-gray-500">{productTypeName}</p>
+        <p className="text-primary-300 max-w-[90%] overflow-hidden font-bold">
+          <span>{formatPrice(price)}</span>원
+        </p>
       </p>
     </div>
   )

--- a/src/components/product/ProductInfo.tsx
+++ b/src/components/product/ProductInfo.tsx
@@ -6,12 +6,13 @@ interface ProductInfoProps {
   price: number
   createdAt: string
   favoriteCount: number
+  productTypeName: string
 }
 
-export function ProductInfo({ title, price, createdAt, favoriteCount }: ProductInfoProps) {
+export function ProductInfo({ title, price, createdAt, favoriteCount, productTypeName }: ProductInfoProps) {
   return (
     <div className="flex h-full flex-col justify-between gap-5 p-3">
-      <ProductHeading title={title} price={price} />
+      <ProductHeading title={title} price={price} productTypeName={productTypeName} />
       <ProductMeta createdAt={createdAt} favoriteCount={favoriteCount} />
     </div>
   )

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -149,6 +149,7 @@ export interface Product {
   createdAt: string
   favoriteCount: number
   isFavorite: boolean
+  productType: string
 }
 
 // ========== 필터링 관련 타입 ==========


### PR DESCRIPTION
## 📌 개요
- ProductCard에 상품 타입 정보 표시 기능 추가

## 🔧 작업 내용
- [ ] ProductCard에 productType 정보 추가
- [ ] ProductHeading에 productTypeName 표시 기능 구현
- [ ] Product 타입에 productType 필드 추가
- 상품 타입에 따라 '판매', '판매요청', 등 표시

## 📎 관련 이슈
- Close #178 

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| 이미지  | 이미지  |

## 💬 리뷰어 참고 사항

- 리뷰어가 중점적으로 봐주었으면 하는 부분
- 추가 논의가 필요한 부분
