### PR TITLE
refactor: CascadingSelectField 컴포넌트 리팩토링(#188)

### DIFF
--- a/src/components/commons/RequiredLabel.tsx
+++ b/src/components/commons/RequiredLabel.tsx
@@ -1,11 +1,14 @@
+import { cn } from '@src/utils/cn'
+
 interface RequiredLabelProps {
   htmlFor: string
   children: string
+  labelClass?: string
 }
 
-export function RequiredLabel({ htmlFor, children }: RequiredLabelProps) {
+export function RequiredLabel({ htmlFor, children, labelClass }: RequiredLabelProps) {
   return (
-    <label htmlFor={htmlFor} className="text-gray-900">
+    <label htmlFor={htmlFor} className={cn('text-gray-900', labelClass)}>
       <span>{children}</span>
       <span className="text-danger-500">*</span>
     </label>

--- a/src/components/commons/select/CascadingSelectField.tsx
+++ b/src/components/commons/select/CascadingSelectField.tsx
@@ -1,0 +1,120 @@
+import { Controller, type Control, type FieldValues, type Path } from 'react-hook-form'
+import { SelectDropdown } from './SelectDropdown'
+import { RequiredLabel } from '../RequiredLabel'
+import { cn } from '@src/utils/cn'
+
+export interface SelectOption {
+  value: string
+  label: string
+}
+
+interface CascadingSelectFieldProps<T extends FieldValues> {
+  control: Control<T>
+  // Primary select 설정
+  primaryName: Path<T>
+  primaryOptions: SelectOption[]
+  primaryPlaceholder: string
+  primaryId: string
+  primaryRule?: string
+  // Secondary select 설정
+  secondaryName: Path<T>
+  secondaryOptionsMap: Record<string, SelectOption[]>
+  secondaryPlaceholder: string
+  secondaryPlaceholderDisabled: string
+  secondaryId: string
+  secondaryRule?: string
+  // classname 설정
+  labelClass?: string
+  layoutClass?: string
+  buttonClassName?: string
+  optionClassName?: string
+
+  // 공통 설정
+  label: string
+  labelHtmlFor: string
+  onPrimaryChange?: (value: string) => void
+}
+
+export function CascadingSelectField<T extends FieldValues>({
+  control,
+  primaryName,
+  primaryOptions,
+  primaryPlaceholder,
+  primaryId,
+  primaryRule = '선택해주세요',
+  secondaryName,
+  secondaryOptionsMap,
+  secondaryPlaceholder,
+  secondaryPlaceholderDisabled,
+  secondaryId,
+  secondaryRule = '선택해주세요',
+  labelClass = '',
+  layoutClass = '',
+  buttonClassName = '',
+  optionClassName = '',
+  label,
+  labelHtmlFor,
+  onPrimaryChange,
+}: CascadingSelectFieldProps<T>) {
+  return (
+    <div className={cn('flex flex-col gap-2.5', layoutClass)}>
+      <RequiredLabel htmlFor={labelHtmlFor} labelClass={labelClass}>
+        {label}
+      </RequiredLabel>
+
+      <div className="flex gap-2.5">
+        {/* Primary 선택 */}
+        <Controller
+          name={primaryName}
+          control={control}
+          rules={{ required: primaryRule }}
+          render={({ field, fieldState }) => {
+            const selectedPrimary = field.value as string
+            const secondaryOptions = selectedPrimary ? secondaryOptionsMap[selectedPrimary] || [] : []
+
+            return (
+              <>
+                <div className="flex flex-1 flex-col gap-1">
+                  <SelectDropdown
+                    {...field}
+                    onChange={(value) => {
+                      field.onChange(value)
+                      onPrimaryChange?.(value)
+                    }}
+                    options={primaryOptions}
+                    placeholder={primaryPlaceholder}
+                    id={primaryId}
+                    buttonClassName={buttonClassName}
+                    optionClassName={optionClassName}
+                  />
+                  {fieldState.error && <p className="text-xs font-semibold text-red-500">{fieldState.error.message}</p>}
+                </div>
+
+                {/* Secondary 선택 */}
+                <Controller
+                  name={secondaryName}
+                  control={control}
+                  rules={{ required: secondaryRule }}
+                  render={({ field: secondaryField, fieldState: secondaryFieldState }) => (
+                    <div className="flex flex-1 flex-col gap-1">
+                      <SelectDropdown
+                        {...secondaryField}
+                        options={secondaryOptions}
+                        placeholder={selectedPrimary ? secondaryPlaceholder : secondaryPlaceholderDisabled}
+                        disabled={!selectedPrimary}
+                        id={secondaryId}
+                        buttonClassName={buttonClassName}
+                        optionClassName={optionClassName}
+                      />
+                      {secondaryFieldState.error && <p className="text-xs font-semibold text-red-500">{secondaryFieldState.error.message}</p>}
+                    </div>
+                  )}
+                />
+              </>
+            )
+          }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/pages/signup/components/SignUpForm.tsx
+++ b/src/pages/signup/components/SignUpForm.tsx
@@ -120,7 +120,7 @@ export function SignUpForm() {
         <div className="flex flex-col gap-6">
           <NameField register={register} errors={errors} />
           <NicknameField register={register} errors={errors} watch={watch} setIsNicknameVerified={setIsNicknameVerified} clearErrors={clearErrors} />
-          <AddressField control={control} watch={watch} setValue={setValue} />
+          <AddressField<SignUpFormValues> control={control} setValue={setValue} primaryName="addressSido" secondaryName="addressGugun" />
           <BirthDateField control={control} />
           <EmailValidCode
             register={register}


### PR DESCRIPTION
## 📌 개요
- CascadingSelectField 컴포넌트 리팩토링

## 🔧 작업 내용
- 재사용 가능한 CascadingSelectField 공통 컴포넌트 생성
- AddressField가 CascadingSelectField를 사용하도록 리팩토링
- RequiredLabel 컴포넌트 props 개선 (labelClass 추가)

## 📎 관련 이슈

- Close #188 

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| 이미지  | 이미지  |

## 💬 리뷰어 참고 사항

- 리뷰어가 중점적으로 봐주었으면 하는 부분
- 추가 논의가 필요한 부분
