### PR TITLE
refactor: Input 컴포넌트 inputClass prop 추가(#193)

### DIFF
--- a/src/components/commons/Input.tsx
+++ b/src/components/commons/Input.tsx
@@ -11,6 +11,7 @@ interface InputProps {
   value?: string | number
   size?: string
   id?: string
+  inputClass?: string
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
   [key: string]: any // register에서 전달하는 다른 props들을 받기 위해
 }
@@ -26,6 +27,7 @@ export function Input({
   size = 'text-base',
   onChange,
   id,
+  inputClass,
   ...rest // 나머지 모든 props (register가 전달하는 ref, name 등)
 }: InputProps) {
   return (
@@ -54,7 +56,8 @@ export function Input({
           'w-full py-3 placeholder:text-gray-400 focus:border-transparent focus:outline-none',
           backgroundColor,
           Icon ? 'pl-0' : 'px-3',
-          size
+          size,
+          inputClass
         )}
         {...rest}
       />

--- a/src/components/commons/InputField.tsx
+++ b/src/components/commons/InputField.tsx
@@ -14,14 +14,15 @@ interface InputFieldProps {
   error?: FieldError
   checkResult?: { status: string; message: string }
   classname?: string
+  inputClass?: string
   registration: UseFormRegisterReturn
   id?: string
 }
 
-export function InputField({ error, checkResult, registration, classname, id, ...inputProps }: InputFieldProps) {
+export function InputField({ error, checkResult, registration, classname, inputClass, id, ...inputProps }: InputFieldProps) {
   return (
     <div className={cn('flex flex-col gap-1', classname)}>
-      <Input {...inputProps} {...registration} id={id} />
+      <Input {...inputProps} {...registration} inputClass={inputClass} id={id} />
       {error && <p className="text-danger-500 text-xs font-semibold">{error.message}</p>}
       {checkResult && (
         <p className={cn('text-xs font-semibold', checkResult.status === 'error' ? 'text-danger-500' : 'text-[#22c55e]')}>{checkResult.message}</p>


### PR DESCRIPTION
## 📌 개요
- Input 컴포넌트 inputClass prop 추가

## 🔧 작업 내용
- Input 컴포넌트에 inputClass prop 추가
- InputField 컴포넌트에서 inputClass를 Input으로 전달
- 가격 입력 필드 등에서 스타일 커스터마이징 가능

## 📎 관련 이슈

- Close #193 

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| 이미지  | 이미지  |

## 💬 리뷰어 참고 사항

- 리뷰어가 중점적으로 봐주었으면 하는 부분
- 추가 논의가 필요한 부분
