### PR TITLE
fix: ProductThumbnail 기본 이미지 변경(#197)

### DIFF
--- a/src/components/product/ProductThumbnail.tsx
+++ b/src/components/product/ProductThumbnail.tsx
@@ -2,7 +2,8 @@ import { ProductBadge } from './ProductBadge'
 import { Button } from '../commons/button/Button'
 import { Heart } from 'lucide-react'
 import { Badge } from '../commons/badge/Badge'
-import bowl from '@assets/images/bowl.jpg'
+// import bowl from '@assets/images/bowl.jpg'
+import PlaceholderImage from '@assets/images/placeholder.png'
 import { cn } from '@src/utils/cn'
 
 interface ProductThumbnailProps {
@@ -38,7 +39,7 @@ export function ProductThumbnail({
       </div>
       <Badge className={cn('bottom-sm right-sm absolute z-1 text-white', productTradeColor)}>{tradeStatus}</Badge>
       <img
-        src={imageUrl || bowl}
+        src={imageUrl || PlaceholderImage}
         alt={title}
         className="t-0 l-0 absolute h-full w-full object-cover transition-all duration-300 ease-in-out group-hover:scale-105"
       />


### PR DESCRIPTION
## 📌 개요
- ProductThumbnail 기본 이미지 변경 

## 🔧 작업 내용
- ProductThumbnail 컴포넌트의 기본 이미지를 placeholder 이미지로 변경
- 기본 이미지를 bowl.jpg에서 placeholder.png로 변경

## 📎 관련 이슈

- Close #197 
## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| 이미지  | 이미지  |

## 💬 리뷰어 참고 사항

- 리뷰어가 중점적으로 봐주었으면 하는 부분
- 추가 논의가 필요한 부분
