### PR TITLE
refactor: SimpleHeader 컴포넌트 변경(#195)

### DIFF
--- a/src/components/layouts/SimpleHeader.tsx
+++ b/src/components/layouts/SimpleHeader.tsx
@@ -1,22 +1,13 @@
-import { Link } from 'react-router-dom';
-import logoImage from '@assets/images/CuddleMarketLogoImage.png';
-
 interface SimpleHeaderProps {
-  title: string;
+  title: string
+  description?: string
 }
 
-export function SimpleHeader({ title }: SimpleHeaderProps) {
+export function SimpleHeader({ title, description }: SimpleHeaderProps) {
   return (
-    <header className="sticky top-0 z-1 bg-primary">
-      <div className="w-full max-w-[var(--container-max-width)] mx-auto px-lg py-md flex items-center gap-xl">
-        {/* 로고 */}
-        <Link to="/">
-          <img src={logoImage} alt="커들마켓" className="w-auto h-15 tablet:h-22 object-contain" />
-        </Link>
-
-        {/* 페이지 타이틀 */}
-        <h2 className="text-heading4 tablet:text-heading3 font-bold">{title}</h2>
-      </div>
-    </header>
-  );
+    <div className="mx-auto flex max-w-[var(--container-max-width)] flex-col gap-2 bg-white px-3.5 py-2.5">
+      <h2 className="heading-h2">{title}</h2>
+      {description && <p>{description}</p>}
+    </div>
+  )
 }


### PR DESCRIPTION
## 📌 개요
- SimpleHeader 컴포넌트 변경

## 🔧 작업 내용
- 로고 제거, 타이틀+설명 구조로 변경
- description prop 추가
- sticky 헤더에서 일반 헤더로 변경

## 📎 관련 이슈

- Close #195 

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| 이미지  | 이미지  |

## 💬 리뷰어 참고 사항

- 리뷰어가 중점적으로 봐주었으면 하는 부분
- 추가 논의가 필요한 부분
