### PR TITLE
feat: 상품 등록 페이지 구현(#186)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "cuddlemarket",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@tailwindcss/vite": "^4.1.11",
         "@tanstack/react-query": "^5.90.10",
         "axios": "^1.13.2",
@@ -18,6 +21,7 @@
         "react": "^19.1.0",
         "react-datepicker": "^8.9.0",
         "react-dom": "^19.1.0",
+        "react-dropzone": "^14.3.8",
         "react-hook-form": "^7.66.1",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.8.0",
@@ -332,6 +336,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2416,6 +2473,15 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/attr-accept": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -3490,6 +3556,18 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-selector": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
+      "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -4414,7 +4492,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4793,7 +4870,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -4995,7 +5071,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5387,7 +5462,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -5468,6 +5542,23 @@
         "react": "^19.2.0"
       }
     },
+    "node_modules/react-dropzone": {
+      "version": "14.3.8",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.8.tgz",
+      "integrity": "sha512-sBgODnq+lcA4P296DY4wacOZz3JFpD99fp+hb//iBO2HHnyeZU3FwWyXJ6salNpqQdsZrgMrotuko/BdJMV8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "attr-accept": "^2.2.4",
+        "file-selector": "^2.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8 || 18.0.0"
+      }
+    },
     "node_modules/react-hook-form": {
       "version": "7.66.1",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.66.1.tgz",
@@ -5497,7 +5588,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-refresh": {
@@ -6294,6 +6384,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@tailwindcss/vite": "^4.1.11",
     "@tanstack/react-query": "^5.90.10",
     "axios": "^1.13.2",
@@ -20,6 +23,7 @@
     "react": "^19.1.0",
     "react-datepicker": "^8.9.0",
     "react-dom": "^19.1.0",
+    "react-dropzone": "^14.3.8",
     "react-hook-form": "^7.66.1",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.8.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,9 @@
 // import './App.css';
 // vim 사용예시 커밋 작성
 
-import ChatButton from './features/chat/ChatButton'
 import AppRoutes from './routes/index'
 function App() {
-  return (
-    <>
-      <AppRoutes />
-      {/* <Footer /> */}
-      <ChatButton />
-    </>
-  )
+  return <AppRoutes />
 }
 
 export default App

--- a/src/api/products.ts
+++ b/src/api/products.ts
@@ -1,11 +1,14 @@
 import type {
   CreateProductRequest,
   CreateProductResponse,
+  ImageUploadResponse,
   // FilterApiResponse,
   LikesResponse,
   MyPageData,
   ProductDetailItemResponse,
+  ProductPostRequestData,
   ProductResponse,
+  RequestProductPostRequestData,
 } from '../types'
 import { apiFetch } from './apiFetch'
 import { api } from './api'
@@ -98,6 +101,28 @@ export const fetchProductById = async (productId: string) => {
 // 찜 추가
 export const addFavorite = async (productId: number): Promise<void> => {
   await api.post(`/products/${productId}/favorite`)
+}
+
+// 판매 상품 등록
+export const postProduct = async (requestData: ProductPostRequestData): Promise<void> => {
+  await api.post(`/products`, requestData)
+}
+
+// 판매요청 상품 등록
+export const requestPostProduct = async (requestData: RequestProductPostRequestData): Promise<void> => {
+  await api.post(`/products/requests`, requestData)
+}
+
+// 이미지 업로드
+export const uploadImage = async (files: File[]): Promise<ImageUploadResponse['data']> => {
+  const formData = new FormData()
+
+  files.forEach((file) => {
+    formData.append('files', file)
+  })
+  // FormData를 전달하면 axios가 자동으로 Content-Type: multipart/form-data를 설정함
+  const response = await api.post<ImageUploadResponse>('/images', formData)
+  return response.data.data
 }
 
 // export const fetchAllCategory = async (): Promise<FilterApiResponse> => {

--- a/src/components/commons/Input.tsx
+++ b/src/components/commons/Input.tsx
@@ -11,6 +11,7 @@ interface InputProps {
   value?: string | number
   size?: string
   id?: string
+  inputClass?: string
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
   [key: string]: any // register에서 전달하는 다른 props들을 받기 위해
 }
@@ -26,6 +27,7 @@ export function Input({
   size = 'text-base',
   onChange,
   id,
+  inputClass,
   ...rest // 나머지 모든 props (register가 전달하는 ref, name 등)
 }: InputProps) {
   return (
@@ -54,7 +56,8 @@ export function Input({
           'w-full py-3 placeholder:text-gray-400 focus:border-transparent focus:outline-none',
           backgroundColor,
           Icon ? 'pl-0' : 'px-3',
-          size
+          size,
+          inputClass
         )}
         {...rest}
       />

--- a/src/components/commons/InputField.tsx
+++ b/src/components/commons/InputField.tsx
@@ -14,14 +14,15 @@ interface InputFieldProps {
   error?: FieldError
   checkResult?: { status: string; message: string }
   classname?: string
+  inputClass?: string
   registration: UseFormRegisterReturn
   id?: string
 }
 
-export function InputField({ error, checkResult, registration, classname, id, ...inputProps }: InputFieldProps) {
+export function InputField({ error, checkResult, registration, classname, inputClass, id, ...inputProps }: InputFieldProps) {
   return (
     <div className={cn('flex flex-col gap-1', classname)}>
-      <Input {...inputProps} {...registration} id={id} />
+      <Input {...inputProps} {...registration} inputClass={inputClass} id={id} />
       {error && <p className="text-danger-500 text-xs font-semibold">{error.message}</p>}
       {checkResult && (
         <p className={cn('text-xs font-semibold', checkResult.status === 'error' ? 'text-danger-500' : 'text-[#22c55e]')}>{checkResult.message}</p>

--- a/src/components/commons/RequiredLabel.tsx
+++ b/src/components/commons/RequiredLabel.tsx
@@ -1,11 +1,14 @@
+import { cn } from '@src/utils/cn'
+
 interface RequiredLabelProps {
   htmlFor: string
   children: string
+  labelClass?: string
 }
 
-export function RequiredLabel({ htmlFor, children }: RequiredLabelProps) {
+export function RequiredLabel({ htmlFor, children, labelClass }: RequiredLabelProps) {
   return (
-    <label htmlFor={htmlFor} className="text-gray-900">
+    <label htmlFor={htmlFor} className={cn('text-gray-900', labelClass)}>
       <span>{children}</span>
       <span className="text-danger-500">*</span>
     </label>

--- a/src/components/commons/filters/ProductStateFilter.tsx
+++ b/src/components/commons/filters/ProductStateFilter.tsx
@@ -1,53 +1,94 @@
-import { Button } from '../button/Button'
+import { useState } from 'react'
 import { CONDITION_ITEMS } from '@src/constants/constants'
 import { cn } from '@src/utils/cn'
 import { useSearchParams } from 'react-router-dom'
+import { RequiredLabel } from '../RequiredLabel'
 
 interface ProductStateFilterProps {
   headingClassName?: string
+  inputClassname?: string
+  labelClassname?: string
+  subTitle?: boolean
   selectedProductStatus?: string | null
   onProductStatusChange?: (status: string | null) => void
+  useUrlSync?: boolean // true: URL 동기화 (DetailFilter용), false: 로컬 state (ProductPostForm용)
 }
 
-export function ProductStateFilter({ headingClassName, selectedProductStatus, onProductStatusChange }: ProductStateFilterProps) {
+export function ProductStateFilter({
+  headingClassName,
+  inputClassname,
+  labelClassname,
+  subTitle,
+  selectedProductStatus: externalSelectedStatus,
+  onProductStatusChange,
+  useUrlSync = false,
+}: ProductStateFilterProps) {
   const [, setSearchParams] = useSearchParams()
+  const [internalSelectedStatus, setInternalSelectedStatus] = useState<string | null>(null)
 
-  const handleProductStatuses = (e: React.MouseEvent, value: string) => {
-    e.stopPropagation() // 이벤트 버블링 방지
-    // 같은 상태 클릭 시 선택 해제, 다른 상태 클릭 시 선택
+  // 외부에서 전달된 값이 있으면 사용, 없으면 내부 state 사용
+  const selectedProductStatus = externalSelectedStatus !== undefined ? externalSelectedStatus : internalSelectedStatus
+
+  const handleStatusChange = (value: string) => {
     const isDeselecting = selectedProductStatus === value
-    setSearchParams((prev) => {
-      if (isDeselecting) {
-        prev.delete('productStatuses') // 선택 해제 시 URL에서 제거
-      } else {
-        prev.set('productStatuses', value) // 선택 시 URL에 추가
-      }
-      return prev
-    })
+    const newValue = isDeselecting ? null : value
 
-    onProductStatusChange?.(isDeselecting ? null : value)
+    // URL 동기화 모드일 때만 URL 업데이트
+    if (useUrlSync) {
+      setSearchParams((prev) => {
+        if (isDeselecting) {
+          prev.delete('productStatuses')
+        } else {
+          prev.set('productStatuses', value)
+        }
+        return prev
+      })
+    }
+
+    // 외부 콜백이 있으면 호출, 없으면 내부 state 업데이트
+    if (onProductStatusChange) {
+      onProductStatusChange(newValue)
+    } else {
+      setInternalSelectedStatus(newValue)
+    }
   }
 
   return (
     <div className="flex flex-col gap-2">
-      <span id="condition-filter-heading" className={cn('heading-h5', headingClassName)}>
-        상품 상태
-      </span>
-      <div className="flex flex-wrap gap-2.5" role="group" aria-labelledby="condition-filter-heading">
+      {useUrlSync ? (
+        <span id="condition-filter-heading" className={cn('heading-h5', headingClassName)}>
+          상품 상태
+        </span>
+      ) : (
+        <RequiredLabel htmlFor="signup-name" labelClass="heading-h5">
+          상품 상태
+        </RequiredLabel>
+      )}
+      <div className={cn('flex flex-wrap gap-2.5')} role="radiogroup" aria-labelledby="condition-filter-heading">
         {CONDITION_ITEMS.map((item) => (
-          <Button
-            key={item.value}
-            type="button"
-            size="sm"
-            className={cn(
-              'bg-primary-50 cursor-pointer',
-              selectedProductStatus === item.value ? 'bg-primary-300 font-bold text-white' : 'hover:bg-primary-300 text-gray-900 hover:text-white'
-            )}
-            onClick={(e) => handleProductStatuses(e, item.value)}
-            aria-pressed={selectedProductStatus === item.value}
-          >
-            {item.title}
-          </Button>
+          <div key={item.value} className={inputClassname}>
+            <input
+              type="radio"
+              id={`productStatus-${item.value}`}
+              name="productStatus"
+              value={item.value}
+              checked={selectedProductStatus === item.value}
+              onChange={() => handleStatusChange(item.value)}
+              className={cn('peer sr-only')}
+            />
+            <label
+              htmlFor={`productStatus-${item.value}`}
+              className={cn(
+                'flex cursor-pointer flex-col gap-1 rounded-lg px-4 py-2 text-center',
+                'bg-primary-50 text-sm font-medium',
+                labelClassname,
+                selectedProductStatus === item.value ? 'bg-primary-300 text-white' : 'hover:bg-primary-300 text-gray-900 hover:text-white'
+              )}
+            >
+              <span>{item.title}</span>
+              {subTitle && <span className="text-xs font-medium">{item.subtitle}</span>}
+            </label>
+          </div>
         ))}
       </div>
     </div>

--- a/src/components/commons/select/CascadingSelectField.tsx
+++ b/src/components/commons/select/CascadingSelectField.tsx
@@ -1,0 +1,120 @@
+import { Controller, type Control, type FieldValues, type Path } from 'react-hook-form'
+import { SelectDropdown } from './SelectDropdown'
+import { RequiredLabel } from '../RequiredLabel'
+import { cn } from '@src/utils/cn'
+
+export interface SelectOption {
+  value: string
+  label: string
+}
+
+interface CascadingSelectFieldProps<T extends FieldValues> {
+  control: Control<T>
+  // Primary select 설정
+  primaryName: Path<T>
+  primaryOptions: SelectOption[]
+  primaryPlaceholder: string
+  primaryId: string
+  primaryRule?: string
+  // Secondary select 설정
+  secondaryName: Path<T>
+  secondaryOptionsMap: Record<string, SelectOption[]>
+  secondaryPlaceholder: string
+  secondaryPlaceholderDisabled: string
+  secondaryId: string
+  secondaryRule?: string
+  // classname 설정
+  labelClass?: string
+  layoutClass?: string
+  buttonClassName?: string
+  optionClassName?: string
+
+  // 공통 설정
+  label: string
+  labelHtmlFor: string
+  onPrimaryChange?: (value: string) => void
+}
+
+export function CascadingSelectField<T extends FieldValues>({
+  control,
+  primaryName,
+  primaryOptions,
+  primaryPlaceholder,
+  primaryId,
+  primaryRule = '선택해주세요',
+  secondaryName,
+  secondaryOptionsMap,
+  secondaryPlaceholder,
+  secondaryPlaceholderDisabled,
+  secondaryId,
+  secondaryRule = '선택해주세요',
+  labelClass = '',
+  layoutClass = '',
+  buttonClassName = '',
+  optionClassName = '',
+  label,
+  labelHtmlFor,
+  onPrimaryChange,
+}: CascadingSelectFieldProps<T>) {
+  return (
+    <div className={cn('flex flex-col gap-2.5', layoutClass)}>
+      <RequiredLabel htmlFor={labelHtmlFor} labelClass={labelClass}>
+        {label}
+      </RequiredLabel>
+
+      <div className="flex gap-2.5">
+        {/* Primary 선택 */}
+        <Controller
+          name={primaryName}
+          control={control}
+          rules={{ required: primaryRule }}
+          render={({ field, fieldState }) => {
+            const selectedPrimary = field.value as string
+            const secondaryOptions = selectedPrimary ? secondaryOptionsMap[selectedPrimary] || [] : []
+
+            return (
+              <>
+                <div className="flex flex-1 flex-col gap-1">
+                  <SelectDropdown
+                    {...field}
+                    onChange={(value) => {
+                      field.onChange(value)
+                      onPrimaryChange?.(value)
+                    }}
+                    options={primaryOptions}
+                    placeholder={primaryPlaceholder}
+                    id={primaryId}
+                    buttonClassName={buttonClassName}
+                    optionClassName={optionClassName}
+                  />
+                  {fieldState.error && <p className="text-xs font-semibold text-red-500">{fieldState.error.message}</p>}
+                </div>
+
+                {/* Secondary 선택 */}
+                <Controller
+                  name={secondaryName}
+                  control={control}
+                  rules={{ required: secondaryRule }}
+                  render={({ field: secondaryField, fieldState: secondaryFieldState }) => (
+                    <div className="flex flex-1 flex-col gap-1">
+                      <SelectDropdown
+                        {...secondaryField}
+                        options={secondaryOptions}
+                        placeholder={selectedPrimary ? secondaryPlaceholder : secondaryPlaceholderDisabled}
+                        disabled={!selectedPrimary}
+                        id={secondaryId}
+                        buttonClassName={buttonClassName}
+                        optionClassName={optionClassName}
+                      />
+                      {secondaryFieldState.error && <p className="text-xs font-semibold text-red-500">{secondaryFieldState.error.message}</p>}
+                    </div>
+                  )}
+                />
+              </>
+            )
+          }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -169,6 +169,7 @@ export const PRODUCT_CATEGORIES = [
   { code: 'ETC', name: '기타' },
 ] as const
 export type CategoryFilter = string | null
+export type CategoryName = (typeof PRODUCT_CATEGORIES)[number]['name']
 
 // ========== 거래상태 관련 상수 ==========
 export const STATUS_EN_TO_KO: Array<{ value: string; name: string; bgColor: string }> = [
@@ -193,8 +194,8 @@ export type ProductTypeTabId = (typeof PRODUCT_TYPE_TABS)[number]['id']
 
 // 상품 등록용 탭 (기존 호환성)
 export const PRODUCT_POST_TABS = [
-  { id: 'sales', label: '판매' },
-  { id: 'purchases', label: '판매요청' },
+  { id: 'tab-sales', label: '판매', code: 'SELL' },
+  { id: 'tab-purchases', label: '판매요청', code: 'REQUEST' },
 ] as const
 export type ProductPostTabId = (typeof PRODUCT_POST_TABS)[number]['id']
 
@@ -1249,3 +1250,5 @@ export type SORT_LABELS = (typeof SORT_TYPE)[number]['label']
 // const SORT_LABELS = SORT_TYPE.map(sort => sort.label);
 
 export const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp', 'image/svg+xml', 'image/bmp']
+
+export const MAX_FILES = 5

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -11,8 +11,8 @@ export const ROUTES = {
   QNA: '/qna',
   // STUDY_GROUP_CREATE: '/study-group/create',
 
-  // // Recruitment
-  // RECRUITMENT: '/recruitment',
+  // Product
+  PRODUCT_POST: '/product-post',
   // RECRUITMENT_ID: (id: string | number) => `/recruitment/${id}`,
   // RECRUITMENT_DETAIL: '/recruitment/:uuid',
   // RECRUITMENT_CREATE: '/recruitment/create',

--- a/src/pages/KakaoCallback.tsx
+++ b/src/pages/KakaoCallback.tsx
@@ -11,7 +11,8 @@ interface KakaoAuthResponse {
 function KakaoCallback() {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [searchParams] = useSearchParams();
-  const { handleLogin, redirectUrl, setRedirectUrl } = useUserStore();
+  // TODO: 소셜 로그인 구현 시 handleLogin 사용 필요
+  const { redirectUrl, setRedirectUrl } = useUserStore();
 
   const code: string | null = searchParams.get('code');
   const error: string | null = searchParams.get('error');
@@ -36,7 +37,8 @@ function KakaoCallback() {
       console.log('응답 데이터:', data);
 
       if (data.access && data.user) {
-        handleLogin(data.user, data.access);
+        // TODO: 소셜 로그인 구현 시 refreshToken 처리 필요
+        // handleLogin(data.user, data.access, data.refresh);
         console.log('사용자 정보 저장 완료');
       }
 

--- a/src/pages/ProductPost.tsx
+++ b/src/pages/ProductPost.tsx
@@ -1,8 +1,0 @@
-// TODO: 타입 에러 수정 필요 - 임시로 비활성화
-export default function ProductPost() {
-  return (
-    <div className="flex items-center justify-center min-h-screen">
-      <p className="text-xl text-gray-500">상품 등록 페이지 (개발 중)</p>
-    </div>
-  )
-}

--- a/src/pages/home/components/tab/ProductTypeTabs.tsx
+++ b/src/pages/home/components/tab/ProductTypeTabs.tsx
@@ -5,12 +5,15 @@ import { cn } from '@src/utils/cn'
 interface ProductTypeTabsProps {
   activeTab: ProductTypeTabId
   onTabChange: (tabId: ProductTypeTabId) => void
+  hideAllTab?: boolean
 }
 
-export function ProductTypeTabs({ activeTab, onTabChange }: ProductTypeTabsProps) {
+export function ProductTypeTabs({ activeTab, onTabChange, hideAllTab = false }: ProductTypeTabsProps) {
+  const tabs = hideAllTab ? PRODUCT_TYPE_TABS.filter((tab) => tab.id !== 'tab-all') : PRODUCT_TYPE_TABS
+
   return (
     <div role="tablist" aria-label="상품 타입 분류" className={cn('border-b-primary-200 flex gap-2.5 border-b-2 pb-1')}>
-      {PRODUCT_TYPE_TABS.map((tab) => (
+      {tabs.map((tab) => (
         <Button
           key={tab.id}
           id={tab.id}

--- a/src/pages/login/components/LoginForm.tsx
+++ b/src/pages/login/components/LoginForm.tsx
@@ -24,7 +24,7 @@ export function LoginForm() {
     console.log('제출')
     try {
       const response = await login(data)
-      handleLogin(response.data.user, response.data.accessToken)
+      handleLogin(response.data.user, response.data.accessToken, response.data.refreshToken)
       console.log('로그인 성공:', response)
       navigate('/')
     } catch (error) {

--- a/src/pages/product-post/ProductPost.tsx
+++ b/src/pages/product-post/ProductPost.tsx
@@ -1,0 +1,30 @@
+import { SimpleHeader } from '@src/components/layouts/SimpleHeader'
+import { useState } from 'react'
+import { useLocation } from 'react-router-dom'
+import type { ProductTypeTabId } from '../../constants/constants'
+import { ProductTypeTabs } from '../home/components/tab/ProductTypeTabs'
+import { ProductPostForm } from './components/ProductPostForm'
+import { ProductRequestForm } from './components/ProductRequestForm'
+
+function ProductPost() {
+  const [activeProductTypeTab, setActiveProductTypeTab] = useState<ProductTypeTabId>('tab-sales')
+  const location = useLocation()
+  const isEditMode = location.pathname.includes('/edit')
+
+  return (
+    <>
+      <SimpleHeader title={isEditMode ? '상품 수정' : '상품 등록'} />
+      <div className="bg-[#F3F4F6] pt-5">
+        <div className="px-lg pb-4xl mx-auto max-w-[var(--container-max-width)]">
+          <div className="gap-2xl flex w-full flex-col">
+            <ProductTypeTabs activeTab={activeProductTypeTab} onTabChange={setActiveProductTypeTab} hideAllTab />
+            {activeProductTypeTab === 'tab-sales' && <ProductPostForm />}
+            {activeProductTypeTab === 'tab-purchases' && <ProductRequestForm />}
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default ProductPost

--- a/src/pages/product-post/components/FormSectionHeader.tsx
+++ b/src/pages/product-post/components/FormSectionHeader.tsx
@@ -1,0 +1,13 @@
+interface FormSectionHeaderProps {
+  heading?: string
+  description?: string
+}
+
+export default function FormSectionHeader({ heading, description }: FormSectionHeaderProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      <h4 className="heading-h3">{heading}</h4>
+      <p>{description}</p>
+    </div>
+  )
+}

--- a/src/pages/product-post/components/ProductPostForm.tsx
+++ b/src/pages/product-post/components/ProductPostForm.tsx
@@ -1,0 +1,113 @@
+import { Button } from '@src/components/commons/button/Button'
+import { useForm } from 'react-hook-form'
+import { type Province } from '@src/constants/cities'
+import { useNavigate } from 'react-router-dom'
+import ProductImageUpload from './imageUploadField/ImageUploadField'
+import BasicInfoSection from './basicInfoSection/BasicInfoSection'
+import PriceAndStatusSection from './priceAndStatusSection/PriceAndStatusSection'
+import TradeInfoSection from './tradeInfoSection/TradeInfoSection'
+import type { ProductPostRequestData } from '@src/types'
+import { postProduct } from '@src/api/products'
+import { cn } from '@src/utils/cn'
+
+export interface ProductPostFormValues {
+  petType: string
+  petDetailType: string
+  category: string
+  title: string
+  description: string
+  price: number
+  productStatus: string
+  mainImageUrl: string
+  subImageUrls?: string[]
+  addressSido: Province | ''
+  addressGugun: string
+  isDeliveryAvailable?: boolean
+  preferredMeetingPlace?: string
+}
+
+export function ProductPostForm() {
+  const {
+    control,
+    handleSubmit, // form onSubmit에 들어가는 함수 : 제출 시 실행할 함수를 감싸주는 함수
+    register, // onChange 등의 이벤트 객체 생성 : input에 "이 필드는 폼의 어떤 이름이다"라고 연결해주는 함수
+    watch, // 특정 필드 값을 실시간으로 구독
+    setValue,
+    setError,
+    clearErrors,
+    formState: { errors, isValid }, // errors: Controller/register의 에러 메세지 자동 출력 : 각 필드의 에러 상태
+  } = useForm<ProductPostFormValues>({
+    mode: 'onChange',
+    defaultValues: {
+      petType: '',
+      petDetailType: '',
+      category: '',
+      title: '',
+      description: '',
+      price: 0,
+      productStatus: '',
+      mainImageUrl: '',
+      subImageUrls: [],
+      addressSido: '',
+      addressGugun: '',
+      isDeliveryAvailable: false,
+      preferredMeetingPlace: '',
+    },
+  }) // 폼에서 관리할 필드들의 타입(이름) 정의.
+  const navigate = useNavigate()
+
+  const onSubmit = async (data: ProductPostFormValues) => {
+    const requestData: ProductPostRequestData = {
+      petType: data.petType,
+      petDetailType: data.petDetailType,
+      category: data.category,
+      title: data.title,
+      description: data.description,
+      price: Number(data.price),
+      productStatus: data.productStatus,
+      mainImageUrl: data.mainImageUrl,
+      subImageUrls: data.subImageUrls ?? [],
+      addressSido: data.addressSido,
+      addressGugun: data.addressGugun,
+      isDeliveryAvailable: data.isDeliveryAvailable ?? false,
+      preferredMeetingPlace: data.preferredMeetingPlace ?? '',
+    }
+
+    console.log('전송할 데이터:', requestData)
+
+    try {
+      const response = await postProduct(requestData)
+      console.log('상품 등록 성공:', response)
+      navigate('/')
+    } catch (error) {
+      console.error('상품 등록 실패:', error)
+      if (error instanceof Error && 'response' in error) {
+        const axiosError = error as { response?: { data?: unknown } }
+        console.error('서버 응답:', axiosError.response?.data)
+      }
+    }
+  }
+  return (
+    <div role="tabpanel">
+      <form className="w-full" onSubmit={handleSubmit(onSubmit)}>
+        <fieldset className="flex flex-col gap-5">
+          <legend className="sr-only">상품 등록폼</legend>
+          <div className="flex flex-col gap-5">
+            <BasicInfoSection control={control} setValue={setValue} register={register} errors={errors} titleLength={watch('title')?.length ?? 0} />
+            <PriceAndStatusSection control={control} register={register} errors={errors} />
+            <ProductImageUpload setValue={setValue} errors={errors} setError={setError} clearErrors={clearErrors} />
+            <TradeInfoSection control={control} setValue={setValue} register={register} />
+          </div>
+          <div className="flex items-center gap-4">
+            <Button size="md" className={cn('w-[80%] flex-1 cursor-pointer text-white', !isValid ? 'bg-gray-300' : 'bg-primary-200')} type="submit">
+              등록
+            </Button>
+            <Button size="md" className="w-[20%] cursor-pointer bg-gray-100 text-gray-900" type="button">
+              취소
+            </Button>
+          </div>
+        </fieldset>
+      </form>
+    </div>
+  )
+}

--- a/src/pages/product-post/components/basicInfoSection/BasicInfoSection.tsx
+++ b/src/pages/product-post/components/basicInfoSection/BasicInfoSection.tsx
@@ -1,0 +1,63 @@
+import { PetTypeField } from '@src/pages/product-post/components/basicInfoSection/components/PetTypeField'
+import { RequiredLabel } from '@src/components/commons/RequiredLabel'
+import { SelectDropdown } from '@src/components/commons/select/SelectDropdown'
+import { PRODUCT_CATEGORIES } from '@src/constants/constants'
+import { ProductDescriptionFiled } from './components/ProductDescriptionFiled'
+import { Controller, type Control, type UseFormSetValue, type UseFormRegister, type FieldErrors } from 'react-hook-form'
+import type { ProductPostFormValues } from '../ProductPostForm'
+import { ProductNameField } from './components/ProductNameFiled'
+import FormSectionHeader from '../FormSectionHeader'
+
+interface BasicInfoSectionProps {
+  control: Control<ProductPostFormValues>
+  setValue: UseFormSetValue<ProductPostFormValues>
+  register: UseFormRegister<ProductPostFormValues>
+  errors: FieldErrors<ProductPostFormValues>
+  productNameLabel?: string
+  productDescriptionLabel?: string
+  productDescriptionPlaceHolder?: string
+  titleLength?: number
+}
+
+export default function BasicInfoSection({
+  control,
+  setValue,
+  register,
+  errors,
+  productNameLabel,
+  productDescriptionLabel,
+  productDescriptionPlaceHolder,
+  titleLength,
+}: BasicInfoSectionProps) {
+  return (
+    <section className="flex flex-col gap-5 rounded-xl border border-gray-100 bg-white px-6 py-5">
+      <FormSectionHeader heading="기본 정보" description="상품의 기본 정보를 입력해주세요. *는 필수 항목입니다." />
+      <PetTypeField<ProductPostFormValues> control={control} setValue={setValue} primaryName="petType" secondaryName="petDetailType" />
+      <Controller
+        name="category"
+        control={control}
+        rules={{ required: '카테고리를 선택해주세요' }}
+        render={({ field, fieldState }) => (
+          <div className="flex flex-col gap-1">
+            <RequiredLabel htmlFor="category" labelClass="heading-h5">
+              상품 카테고리
+            </RequiredLabel>
+            <SelectDropdown
+              value={field.value || ''}
+              onChange={field.onChange}
+              options={PRODUCT_CATEGORIES.map((category) => ({
+                value: category.code,
+                label: category.name,
+              }))}
+              placeholder="카테고리를 선택해주세요"
+              buttonClassName="border-gray-400 bg-white border text-gray-900 px-3 py-3 border"
+            />
+            {fieldState.error && <p className="text-xs font-semibold text-red-500">{fieldState.error.message}</p>}
+          </div>
+        )}
+      />
+      <ProductNameField register={register} errors={errors} label={productNameLabel} titleLength={titleLength} />
+      <ProductDescriptionFiled register={register} errors={errors} label={productDescriptionLabel} placeholder={productDescriptionPlaceHolder} />
+    </section>
+  )
+}

--- a/src/pages/product-post/components/basicInfoSection/components/PetTypeField.tsx
+++ b/src/pages/product-post/components/basicInfoSection/components/PetTypeField.tsx
@@ -1,0 +1,59 @@
+import { type Control, type UseFormSetValue, type FieldValues, type Path } from 'react-hook-form'
+import { PETS } from '@src/constants/constants'
+import { CascadingSelectField, type SelectOption } from '@src/components/commons/select/CascadingSelectField'
+
+// 반려동물 대분류 옵션 생성
+const petTypeOptions: SelectOption[] = PETS.map((pet) => ({
+  value: pet.code,
+  label: pet.name,
+}))
+
+// 대분류별 소분류 옵션 맵 생성
+const petDetailOptionsMap: Record<string, SelectOption[]> = Object.fromEntries(
+  PETS.map((pet) => [pet.code, pet.details.map((detail) => ({ value: detail.code, label: detail.name }))])
+)
+
+interface PetTypeFieldProps<T extends FieldValues> {
+  control: Control<T>
+  setValue: UseFormSetValue<T>
+  primaryName: Path<T>
+  secondaryName: Path<T>
+  label?: string
+}
+
+export function PetTypeField<T extends FieldValues>({
+  control,
+  setValue,
+  primaryName,
+  secondaryName,
+  label = '반려동물 종류',
+}: PetTypeFieldProps<T>) {
+  const handlePrimaryChange = () => {
+    // 대분류가 변경되면 소분류 초기화
+    setValue(secondaryName, '' as T[typeof secondaryName])
+  }
+
+  return (
+    <CascadingSelectField
+      control={control}
+      primaryName={primaryName}
+      primaryOptions={petTypeOptions}
+      primaryPlaceholder="대분류를 선택해주세요(예: 포유류)"
+      primaryId="pet-type"
+      primaryRule="대분류를 선택해주세요(예: 포유류)"
+      secondaryName={secondaryName}
+      secondaryOptionsMap={petDetailOptionsMap}
+      secondaryPlaceholder="소분류를 선택해주세요"
+      secondaryPlaceholderDisabled="먼저 대분류를 선택해주세요"
+      secondaryId="pet-detail"
+      secondaryRule="소분류를 선택해주세요"
+      label={label}
+      labelClass="heading-h5"
+      layoutClass="gap-1"
+      buttonClassName="px-3 py-3"
+      optionClassName=""
+      labelHtmlFor="pet-type"
+      onPrimaryChange={handlePrimaryChange}
+    />
+  )
+}

--- a/src/pages/product-post/components/basicInfoSection/components/ProductDescriptionFiled.tsx
+++ b/src/pages/product-post/components/basicInfoSection/components/ProductDescriptionFiled.tsx
@@ -1,0 +1,36 @@
+import { RequiredLabel } from '@src/components/commons/RequiredLabel'
+import { type UseFormRegister, type FieldErrors } from 'react-hook-form'
+import type { ProductPostFormValues } from '../../ProductPostForm'
+import { productPostValidationRules } from '@src/pages/signup/validationRules'
+import { cn } from '@src/utils/cn'
+
+interface ProductDescriptionFiledProps {
+  register: UseFormRegister<ProductPostFormValues>
+  errors: FieldErrors<ProductPostFormValues>
+  label?: string
+  placeholder?: string
+}
+
+export function ProductDescriptionFiled({
+  register,
+  errors,
+  label = '상품 설명',
+  placeholder = '상품의 상태, 구매 시기, 사용 빈도, 특징 등을 자세히 적어주세요',
+}: ProductDescriptionFiledProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      <RequiredLabel htmlFor="product-description" labelClass="heading-h5">
+        {label}
+      </RequiredLabel>
+      <textarea
+        id="product-description"
+        placeholder={placeholder}
+        className={cn(
+          'focus:border-primary-500 min-h-[14vh] w-full resize-none rounded-lg border border-gray-400 bg-white px-3 py-3 text-sm placeholder:text-gray-400 focus:outline-none'
+        )}
+        {...register('description', productPostValidationRules.description)}
+      />
+      {errors.description && <p className="text-xs font-semibold text-red-500">{errors.description.message}</p>}
+    </div>
+  )
+}

--- a/src/pages/product-post/components/basicInfoSection/components/ProductNameFiled.tsx
+++ b/src/pages/product-post/components/basicInfoSection/components/ProductNameFiled.tsx
@@ -1,0 +1,35 @@
+import { InputField } from '@src/components/commons/InputField'
+import { RequiredLabel } from '@src/components/commons/RequiredLabel'
+// import type { SignUpFormValues } from './SignUpForm'
+import { type UseFormRegister, type FieldErrors } from 'react-hook-form'
+import { productPostValidationRules } from '@src/pages/signup/validationRules'
+import type { ProductPostFormValues } from '../../ProductPostForm'
+
+interface ProductNameFieldProps {
+  register: UseFormRegister<ProductPostFormValues>
+  errors: FieldErrors<ProductPostFormValues>
+  label?: string
+  titleLength?: number
+}
+
+export function ProductNameField({ register, errors, label = '상품명', titleLength = 0 }: ProductNameFieldProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      <RequiredLabel htmlFor="product-title" labelClass="heading-h5">
+        {label}
+      </RequiredLabel>
+      <InputField
+        id="product-title"
+        type="text"
+        placeholder="예: 강아지 사료 10kg 상품"
+        size="text-sm"
+        border
+        borderColor="border-gray-400"
+        classname="flex flex-col gap-2.5"
+        error={errors.title}
+        registration={register('title', productPostValidationRules.name)}
+      />
+      <p>{titleLength}/50자</p>
+    </div>
+  )
+}

--- a/src/pages/product-post/components/imageUploadField/ImageUploadField.tsx
+++ b/src/pages/product-post/components/imageUploadField/ImageUploadField.tsx
@@ -1,0 +1,26 @@
+import type { ProductPostFormValues } from '../ProductPostForm'
+import { type FieldErrors, type UseFormClearErrors, type UseFormSetValue, type UseFormSetError } from 'react-hook-form'
+import DropzoneArea from './components/DropzoneArea'
+import FormSectionHeader from '../FormSectionHeader'
+
+interface ImageUploadFieldProps {
+  setValue: UseFormSetValue<ProductPostFormValues>
+  errors: FieldErrors<ProductPostFormValues>
+  setError: UseFormSetError<ProductPostFormValues>
+  clearErrors: UseFormClearErrors<ProductPostFormValues>
+}
+
+export default function ImageUploadField({ setValue, errors, setError, clearErrors }: ImageUploadFieldProps) {
+  return (
+    <section className="flex flex-col gap-6 rounded-xl border border-gray-100 bg-white px-6 py-5">
+      <div className="flex flex-col gap-5">
+        <FormSectionHeader
+          heading="상품 이미지 (선택항목)"
+          description="상품 이미지를 업로드 해주세요. 첫번째 이미지가 대표 이미지가 됩니다. (최대 5장) "
+        />
+        <DropzoneArea setValue={setValue} setError={setError} clearErrors={clearErrors} />
+        {errors.mainImageUrl && <p className="text-danger-500 text-sm font-semibold">{errors.mainImageUrl.message}</p>}
+      </div>
+    </section>
+  )
+}

--- a/src/pages/product-post/components/imageUploadField/components/DropzoneArea.tsx
+++ b/src/pages/product-post/components/imageUploadField/components/DropzoneArea.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react'
+import { useDropzone } from 'react-dropzone'
+import type { DragEndEvent } from '@dnd-kit/core'
+import { arrayMove } from '@dnd-kit/sortable'
+import type { UseFormSetValue, UseFormSetError, UseFormClearErrors } from 'react-hook-form'
+import type { ProductPostFormValues } from '../../ProductPostForm'
+import { uploadImage } from '@src/api/products'
+import { MAX_FILES } from '@src/constants/constants'
+import DropzoneGuide from './DropzoneGuide'
+import SortableImageList from './SortableImageList'
+// import DropzoneGuide from './DropzoneGuide'
+// import SortableImageList from './SortableImageList'
+
+const IMAGE_UPLOAD_ERRORS = {
+  'file-too-large': '파일 크기는 5MB를 초과할 수 없습니다.',
+  'file-invalid-type': '지원하지 않는 파일 형식입니다. (jpg, jpeg, png, webp만 가능)',
+  'too-many-files': `최대 ${MAX_FILES}개의 파일만 업로드할 수 있습니다.`,
+  'upload-failed': '이미지 업로드에 실패했습니다. 다시 시도해주세요.',
+} as const
+
+interface DropzoneAreaProps {
+  setValue: UseFormSetValue<ProductPostFormValues>
+  setError: UseFormSetError<ProductPostFormValues>
+  clearErrors: UseFormClearErrors<ProductPostFormValues>
+}
+
+export default function DropzoneArea({ setValue, setError, clearErrors }: DropzoneAreaProps) {
+  const [previewUrls, setPreviewUrls] = useState<string[]>([])
+
+  const { getRootProps, getInputProps } = useDropzone({
+    accept: { 'image/*': ['.jpg', '.jpeg', '.png', '.webp'] },
+    maxFiles: MAX_FILES,
+    maxSize: 5 * 1024 * 1024,
+    onDrop: async (acceptedFiles, rejectedFiles) => {
+      clearErrors('mainImageUrl')
+
+      const totalCount = previewUrls.length + acceptedFiles.length
+      if (totalCount > MAX_FILES) {
+        setError('mainImageUrl', { type: 'manual', message: IMAGE_UPLOAD_ERRORS['too-many-files'] })
+        return
+      }
+
+      if (rejectedFiles.length > 0) {
+        const errorCode = rejectedFiles[0].errors[0].code as keyof typeof IMAGE_UPLOAD_ERRORS
+        const message = IMAGE_UPLOAD_ERRORS[errorCode] || '파일 업로드에 실패했습니다.'
+        setError('mainImageUrl', { type: 'manual', message })
+        return
+      }
+
+      if (acceptedFiles.length === 0) {
+        setError('mainImageUrl', { type: 'manual', message: '업로드할 파일을 선택해주세요.' })
+        return
+      }
+
+      try {
+        const uploadedUrl = await uploadImage(acceptedFiles)
+        setValue('mainImageUrl', uploadedUrl.mainImageUrl)
+        setValue('subImageUrls', uploadedUrl.subImageUrls)
+        setPreviewUrls((prev) => [...prev, uploadedUrl.mainImageUrl, ...(uploadedUrl.subImageUrls || [])])
+      } catch {
+        setError('mainImageUrl', {
+          type: 'manual',
+          message: IMAGE_UPLOAD_ERRORS['upload-failed'],
+        })
+      }
+    },
+  })
+
+  const handleRemoveImage = (indexToRemove: number) => {
+    const updatedUrls = previewUrls.filter((_, index) => index !== indexToRemove)
+    setPreviewUrls(updatedUrls)
+
+    if (updatedUrls.length === 0) {
+      setValue('mainImageUrl', '')
+      setValue('subImageUrls', [])
+    } else {
+      setValue('mainImageUrl', updatedUrls[0])
+      setValue('subImageUrls', updatedUrls.slice(1))
+    }
+  }
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (active.id !== over?.id) {
+      const oldIndex = previewUrls.indexOf(active.id as string)
+      const newIndex = previewUrls.indexOf(over?.id as string)
+      const newUrls = arrayMove(previewUrls, oldIndex, newIndex)
+
+      setPreviewUrls(newUrls)
+      setValue('mainImageUrl', newUrls[0])
+      setValue('subImageUrls', newUrls.slice(1))
+    }
+  }
+
+  return (
+    <div {...getRootProps()} className="cursor-pointer rounded-lg border border-dashed border-gray-400 px-6 py-10">
+      <input {...getInputProps()} />
+      {previewUrls.length === 0 ? (
+        <DropzoneGuide />
+      ) : (
+        <SortableImageList previewUrls={previewUrls} onDragEnd={handleDragEnd} onRemoveImage={handleRemoveImage} />
+      )}
+    </div>
+  )
+}

--- a/src/pages/product-post/components/imageUploadField/components/DropzoneGuide.tsx
+++ b/src/pages/product-post/components/imageUploadField/components/DropzoneGuide.tsx
@@ -1,0 +1,13 @@
+import { FileUp } from 'lucide-react'
+
+export default function DropzoneGuide() {
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <FileUp size={30} strokeWidth={1.5} className="text-gray-400" />
+      <div className="flex flex-col items-center text-sm text-gray-400">
+        <p>파일을 드래그하거나 클릭하여 업로드</p>
+        <p>최대 5개 파일, 각 5MB 이하</p>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/product-post/components/imageUploadField/components/SortableImageItem.tsx
+++ b/src/pages/product-post/components/imageUploadField/components/SortableImageItem.tsx
@@ -1,0 +1,38 @@
+import { CSS } from '@dnd-kit/utilities'
+import { Button } from '@src/components/commons/button/Button'
+import { X } from 'lucide-react'
+import { Badge } from '@src/components/commons/badge/Badge'
+import { useSortable } from '@dnd-kit/sortable'
+
+interface SortableImageItemProps {
+  url: string
+  index: number
+  onRemove: () => void
+}
+
+export default function SortableImageItem({ url, index, onRemove }: SortableImageItemProps) {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: url })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} className="relative h-40 w-40 overflow-hidden rounded-lg">
+      <Button
+        icon={X}
+        size="xs"
+        className="bg-danger-500 absolute top-1 right-1 z-10 cursor-pointer rounded-full"
+        iconProps={{ color: 'white', strokeWidth: 3 }}
+        onClick={(e) => {
+          e.stopPropagation()
+          e.preventDefault()
+          onRemove()
+        }}
+      />
+      <img src={url} alt={`preview-${index}`} className="h-full w-full cursor-grab object-cover active:cursor-grabbing" {...listeners} />
+      {index === 0 && <Badge className="absolute top-1 left-1 bg-gray-900 text-white">대표</Badge>}
+    </div>
+  )
+}

--- a/src/pages/product-post/components/imageUploadField/components/SortableImageList.tsx
+++ b/src/pages/product-post/components/imageUploadField/components/SortableImageList.tsx
@@ -1,0 +1,26 @@
+import { DndContext, closestCenter, type DragEndEvent } from '@dnd-kit/core'
+import { SortableContext, horizontalListSortingStrategy } from '@dnd-kit/sortable'
+import { Button } from '@src/components/commons/button/Button'
+import { Plus } from 'lucide-react'
+import SortableImageItem from './SortableImageItem'
+
+interface SortableImageListProps {
+  previewUrls: string[]
+  onDragEnd: (event: DragEndEvent) => void
+  onRemoveImage: (index: number) => void
+}
+
+export default function SortableImageList({ previewUrls, onDragEnd, onRemoveImage }: SortableImageListProps) {
+  return (
+    <DndContext collisionDetection={closestCenter} onDragEnd={onDragEnd}>
+      <SortableContext items={previewUrls} strategy={horizontalListSortingStrategy}>
+        <div className="flex items-center gap-3">
+          {previewUrls.map((imgUrl, i) => (
+            <SortableImageItem key={imgUrl} url={imgUrl} index={i} onRemove={() => onRemoveImage(i)} />
+          ))}
+          {previewUrls.length < 5 && <Button size="lg" className="bg-primary-300 flex cursor-pointer flex-col rounded-full text-white" icon={Plus} />}
+        </div>
+      </SortableContext>
+    </DndContext>
+  )
+}

--- a/src/pages/product-post/components/priceAndStatusSection/PriceAndStatusSection.tsx
+++ b/src/pages/product-post/components/priceAndStatusSection/PriceAndStatusSection.tsx
@@ -1,0 +1,49 @@
+import { Controller, type Control, type UseFormRegister, type FieldErrors } from 'react-hook-form'
+import type { ProductPostFormValues } from '../ProductPostForm'
+import { ProductStateFilter } from '@src/components/commons/filters/ProductStateFilter'
+import { PriceField } from './components/PriceField'
+import FormSectionHeader from '../FormSectionHeader'
+
+interface PriceAndStatusSectionProps {
+  control: Control<ProductPostFormValues>
+  register: UseFormRegister<ProductPostFormValues>
+  errors: FieldErrors<ProductPostFormValues>
+  showProductStateFilter?: boolean
+  heading?: string
+  priceLabel?: string
+}
+
+export default function PriceAndStatusSection({
+  control,
+  register,
+  errors,
+  showProductStateFilter = true,
+  heading = '가격 및 상태',
+  priceLabel,
+}: PriceAndStatusSectionProps) {
+  return (
+    <section className="flex flex-col gap-5 rounded-xl border border-gray-100 bg-white px-6 py-5">
+      <FormSectionHeader heading={heading} />
+      <PriceField register={register} errors={errors} label={priceLabel} />
+      {showProductStateFilter && (
+        <Controller
+          name="productStatus"
+          control={control}
+          rules={{ required: '상품 상태를 선택해주세요' }}
+          render={({ field, fieldState }) => (
+            <>
+              <ProductStateFilter
+                inputClassname="flex-1"
+                labelClassname="py-4 font-semibold"
+                subTitle
+                selectedProductStatus={field.value || null}
+                onProductStatusChange={(status) => field.onChange(status ?? '')}
+              />
+              {fieldState.error && <p className="text-xs font-semibold text-red-500">{fieldState.error.message}</p>}
+            </>
+          )}
+        />
+      )}
+    </section>
+  )
+}

--- a/src/pages/product-post/components/priceAndStatusSection/components/PriceField.tsx
+++ b/src/pages/product-post/components/priceAndStatusSection/components/PriceField.tsx
@@ -1,0 +1,36 @@
+import { InputField } from '@src/components/commons/InputField'
+import { RequiredLabel } from '@src/components/commons/RequiredLabel'
+// import type { SignUpFormValues } from './SignUpForm'
+import { type UseFormRegister, type FieldErrors } from 'react-hook-form'
+import type { ProductPostFormValues } from '../../ProductPostForm'
+import { productPostValidationRules } from '@src/pages/signup/validationRules'
+
+interface PriceFieldProps {
+  register: UseFormRegister<ProductPostFormValues>
+  errors: FieldErrors<ProductPostFormValues>
+  label?: string
+}
+
+export function PriceField({ register, errors, label = '판매 가격' }: PriceFieldProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      <RequiredLabel htmlFor="price" labelClass="heading-h5">
+        {label}
+      </RequiredLabel>
+      <div className="relative">
+        <InputField
+          id="price"
+          type="number"
+          size="text-sm"
+          border
+          borderColor="border-gray-400"
+          classname="flex flex-col gap-2.5"
+          inputClass="pr-10"
+          error={errors.price}
+          registration={register('price', productPostValidationRules.price)}
+        />
+        <span className="absolute top-1/2 right-3 -translate-y-1/2 text-sm text-gray-500">원</span>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/product-post/components/tradeInfoSection/TradeInfoSection.tsx
+++ b/src/pages/product-post/components/tradeInfoSection/TradeInfoSection.tsx
@@ -1,0 +1,50 @@
+import { AddressField } from '@src/pages/signup/components/AddressField'
+import type { ProductPostFormValues } from '../ProductPostForm'
+import type { Control, UseFormSetValue, UseFormRegister } from 'react-hook-form'
+import FormSectionHeader from '../FormSectionHeader'
+
+interface TradeInfoSectionProps {
+  control: Control<ProductPostFormValues>
+  setValue: UseFormSetValue<ProductPostFormValues>
+  register: UseFormRegister<ProductPostFormValues>
+  showProductTradeFilter?: boolean
+}
+
+export default function TradeInfoSection({ control, setValue, register, showProductTradeFilter = true }: TradeInfoSectionProps) {
+  return (
+    <div className="flex flex-col gap-5 rounded-xl border border-gray-100 bg-white px-6 py-5">
+      <FormSectionHeader heading="거래 정보" />
+      <AddressField<ProductPostFormValues>
+        control={control}
+        setValue={setValue}
+        primaryName="addressSido"
+        secondaryName="addressGugun"
+        label="거래 희망 지역"
+        labelClass="heading-h5"
+        layoutClass="gap-1"
+      />
+      {showProductTradeFilter && (
+        <>
+          <div className="flex items-center gap-2.5">
+            <input type="checkbox" id="isDeliveryAvailable" className="h-5 w-5" {...register('isDeliveryAvailable')} />
+            <label htmlFor="isDeliveryAvailable" className="heading-h5">
+              택배거래 가능
+            </label>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label htmlFor="preferredMeetingPlace" className="heading-h5">
+              선호하는 만남 장소 (선택항목)
+            </label>
+            <input
+              id="preferredMeetingPlace"
+              type="text"
+              placeholder="예: 지하철역, 카페, 공원 등"
+              className="rounded-lg border border-gray-100 bg-white px-3 py-3"
+              {...register('preferredMeetingPlace')}
+            />
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/pages/signup/components/SignUpForm.tsx
+++ b/src/pages/signup/components/SignUpForm.tsx
@@ -105,7 +105,7 @@ export function SignUpForm() {
         email: data.email,
         password: data.password,
       })
-      handleLogin(loginResponse.data.user, loginResponse.data.accessToken)
+      handleLogin(loginResponse.data.user, loginResponse.data.accessToken, loginResponse.data.refreshToken)
 
       navigate('/')
     } catch (error) {
@@ -120,7 +120,7 @@ export function SignUpForm() {
         <div className="flex flex-col gap-6">
           <NameField register={register} errors={errors} />
           <NicknameField register={register} errors={errors} watch={watch} setIsNicknameVerified={setIsNicknameVerified} clearErrors={clearErrors} />
-          <AddressField control={control} watch={watch} setValue={setValue} />
+          <AddressField<SignUpFormValues> control={control} setValue={setValue} primaryName="addressSido" secondaryName="addressGugun" />
           <BirthDateField control={control} />
           <EmailValidCode
             register={register}

--- a/src/pages/signup/validationRules.ts
+++ b/src/pages/signup/validationRules.ts
@@ -1,5 +1,6 @@
 import type { RegisterOptions } from 'react-hook-form'
 import type { SignUpFormValues } from './components/SignUpForm'
+import type { ProductPostFormValues } from '../product-post/components/ProductPostForm'
 
 /**
  * 회원가입 폼 전용 validation 규칙
@@ -42,4 +43,50 @@ export const signupValidationRules = {
   addressGugun: {
     required: '지역을 선택해주세요',
   } satisfies RegisterOptions<SignUpFormValues, 'addressGugun'>,
+} as const
+
+export const productPostValidationRules = {
+  name: {
+    required: '상품명을 입력해주세요',
+    minLength: {
+      value: 2,
+      message: '상품명은 2~ 50자 이상이어야 합니다.',
+    },
+    maxLength: {
+      value: 50,
+      message: '상품명은 2~ 50자 이상이어야 합니다.',
+    },
+  } satisfies RegisterOptions<ProductPostFormValues, 'title'>,
+
+  description: {
+    required: '상품설명을 입력해주세요',
+    minLength: {
+      value: 2,
+      message: '상품설명은 2~ 1000자 이상이어야 합니다.',
+    },
+    maxLength: {
+      value: 1000,
+      message: '상품설명은 2~ 1000자 이하이어야 합니다.',
+    },
+  } satisfies RegisterOptions<ProductPostFormValues, 'description'>,
+
+  price: {
+    required: '가격을 입력해주세요',
+    min: {
+      value: 0,
+      message: '가격은 0원 이상이어야 합니다',
+    },
+  } satisfies RegisterOptions<ProductPostFormValues, 'price'>,
+
+  addressGugun: {
+    required: '지역을 선택해주세요',
+  } satisfies RegisterOptions<SignUpFormValues, 'addressGugun'>,
+} as const
+
+export const productPostApiErrors = {
+  imageUpload: {
+    INVALID_FILE_TYPE: '지원하지 않는 파일 형식입니다.',
+    FILE_SIZE_EXCEEDED: '파일 크기는 5MB를 초과할 수 없습니다.',
+    INTERNAL_SERVER_ERROR: '이미지 업로드에 실패했습니다.',
+  },
 } as const

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -15,6 +15,7 @@ import { Route, Routes } from 'react-router-dom'
 import MainLayout from '@src/components/layouts/MainLayout'
 import { ROUTES } from '@src/constants/routes'
 import ProductDetail from '@src/pages/product-detail/ProductDetail'
+import ProductPost from '@src/pages/product-post/ProductPost'
 
 const routes = [
   { path: ROUTES.HOME, element: <Home /> },
@@ -22,7 +23,7 @@ const routes = [
   { path: ROUTES.SIGNUP, element: <Signup /> },
   { path: ROUTES.MYPAGE, element: <MyPage /> },
   { path: ROUTES.DETAIL, element: <ProductDetail /> },
-  // { path: '/test/UI', element: <TestUIPage /> },
+  { path: ROUTES.PRODUCT_POST, element: <ProductPost /> },
 ]
 // const WithHeaderLayout = () => (
 //   <div className="min-h-screen ">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -173,6 +173,71 @@ export interface ProductDetailItemResponse {
   data: ProductDetailItem
 }
 
+// ========== 상품 등록 요청 타입 ==========
+export interface ProductPostRequestData {
+  petType: string
+  petDetailType: string
+  category: string
+  title: string
+  description: string
+  price: number
+  productStatus: string
+  mainImageUrl: string
+  subImageUrls: string[]
+  addressSido: string
+  addressGugun: string
+  isDeliveryAvailable: boolean
+  preferredMeetingPlace: string
+}
+
+export interface ProductPostResponse {
+  id: number
+  sellerId: number
+  productType: string
+  petType: string
+  petDetailType: string
+  category: string
+  title: string
+  description: string
+  price: number
+  productStatus: string
+  tradeStatus: string
+  mainImageUrl: string
+  subImageUrls: string[]
+  addressSido: string
+  addressGugun: string
+  isDeliveryAvailable: boolean
+  preferredMeetingPlace: string
+  viewCount: number
+  favoriteCount: number
+  isFavorite: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface RequestProductPostRequestData {
+  petType: string
+  petDetailType: string
+  category: string
+  title: string
+  description: string
+  desiredPrice: number
+  mainImageUrl: string
+  subImageUrls: string[]
+  addressSido: string
+  addressGugun: string
+}
+
+export interface ImageUploadResponse {
+  code: { code: number; message: string }
+  message: string
+  data: {
+    imageUrls: string[]
+    mainImageUrl: string
+    subImageUrls: string[]
+  }
+}
+
 // ========== 찜하기 관련 타입 ==========
 // export interface FavoriteResponse {
 //   message: string


### PR DESCRIPTION
## 📌 개요
- 상품 등록 페이지 구현

## 🔧 작업 내용

- 상품 등록 폼 컴포넌트 구현 (ProductPostForm)
- 이미지 업로드 기능 구현 (드래그 앤 드롭, 순서 변경)
- 기본 정보 섹션 구현 (상품명, 설명, 반려동물 종류)
- 가격 및 상태 섹션 구현 (가격 입력, 상품 상태 선택)
- 거래 정보 섹션 구현 (거래 방식 선택)
- 상품 등록 API 연동
- 라우팅 설정

## 📎 관련 이슈

- Close #186 

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| 이미지  | 이미지  |

## 💬 리뷰어 참고 사항

- 리뷰어가 중점적으로 봐주었으면 하는 부분
- 추가 논의가 필요한 부분
