### PR TITLE
feat: 마이페이지 상품등록 버튼 및 상품등록 페이지 개선(#210)

### DIFF
--- a/src/pages/MyPagePanel.tsx
+++ b/src/pages/MyPagePanel.tsx
@@ -23,6 +23,8 @@ const TAB_CONFIG: {
     emptyIcon: LucideIcon
     emptyTitle: string
     emptyDescription?: string
+    buttonLabel?: string
+    navigateTo?: string
   }
 } = {
   'tab-sales': {
@@ -31,6 +33,8 @@ const TAB_CONFIG: {
     emptyIcon: Package,
     emptyTitle: '등록한 상품이 없습니다',
     emptyDescription: '상품을 등록해보세요',
+    buttonLabel: '상품등록',
+    navigateTo: '/product-post?tab=tab-sales',
   },
   'tab-purchases': {
     heading: '내가 등록한 상품',
@@ -38,6 +42,8 @@ const TAB_CONFIG: {
     emptyIcon: Package,
     emptyTitle: '등록한 구매 요청이 없습니다',
     emptyDescription: '구매 요청을 등록해보세요',
+    buttonLabel: '판매요청 등록',
+    navigateTo: '/product-post?tab=tab-purchases',
   },
   'tab-wishlist': {
     heading: '내가 찜한 상품',
@@ -80,7 +86,7 @@ export default function MyPagePanel({
       className="border-border p-lg flex flex-col gap-6 rounded-xl border"
     >
       {config ? (
-        <MyPageTitle heading={config.heading} count={productData?.total} description={config.description} />
+        <MyPageTitle heading={config.heading} count={productData?.total} description={config.description} buttonLabel={config.buttonLabel} navigateTo={config.navigateTo} />
       ) : (
         <MyPageTitle heading="차단 유저" description={`차단한 유저 ${myBlockedData?.total ?? 0}명`} />
       )}
@@ -96,25 +102,23 @@ export default function MyPagePanel({
           ) : (
             config && <EmptyState icon={config.emptyIcon} title={config.emptyTitle} description={config.emptyDescription} />
           )
-        ) : (
-          myBlockedData?.content?.length ? (
-            <ul className="flex max-h-[60vh] flex-col items-center justify-start gap-2.5">
-              {myBlockedData.content.map((user) => (
-                <li key={user.blockedUserId} className="flex w-full items-center justify-between gap-6 rounded-lg border border-gray-300 p-3.5">
-                  <div className="flex items-center gap-4">
-                    <div className="aspect-square w-12 shrink-0 overflow-hidden rounded-full">
-                      <img src={user.profileImageUrl || PlaceholderImage} alt={user.nickname} className="h-full w-full object-cover" />
-                    </div>
-                    <span className="font-medium">{user.nickname}</span>
+        ) : myBlockedData?.content?.length ? (
+          <ul className="flex max-h-[60vh] flex-col items-center justify-start gap-2.5">
+            {myBlockedData.content.map((user) => (
+              <li key={user.blockedUserId} className="flex w-full items-center justify-between gap-6 rounded-lg border border-gray-300 p-3.5">
+                <div className="flex items-center gap-4">
+                  <div className="aspect-square w-12 shrink-0 overflow-hidden rounded-full">
+                    <img src={user.profileImageUrl || PlaceholderImage} alt={user.nickname} className="h-full w-full object-cover" />
                   </div>
-                  <Button size="sm" className="border border-gray-300">
-                    차단 해제
-                  </Button>
-                </li>
-              ))}
-            </ul>
-          ) : null
-        )}
+                  <span className="font-medium">{user.nickname}</span>
+                </div>
+                <Button size="sm" className="border border-gray-300">
+                  차단 해제
+                </Button>
+              </li>
+            ))}
+          </ul>
+        ) : null}
       </div>
     </div>
   )

--- a/src/pages/MyPageTitle.tsx
+++ b/src/pages/MyPageTitle.tsx
@@ -1,14 +1,33 @@
+import { Button } from '@src/components/commons/button/Button'
+import { Plus } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+
 interface MyPageTitleProps {
   heading: string
   count?: number
   description: string
+  buttonLabel?: string
+  navigateTo?: string
 }
 
-export default function MyPageTitle({ heading, count, description }: MyPageTitleProps) {
+export default function MyPageTitle({ heading, count, description, buttonLabel, navigateTo }: MyPageTitleProps) {
+  const navigate = useNavigate()
+  const goToProductPost = () => {
+    if (navigateTo) {
+      navigate(navigateTo)
+    }
+  }
   return (
-    <div>
-      <h4 className="flex items-center gap-2">{heading}</h4>
-      {description && <p>{count !== undefined ? `총 ${count}${description}` : description}</p>}
+    <div className="flex justify-between">
+      <div>
+        <h4 className="flex items-center gap-2">{heading}</h4>
+        {description && <p>{count !== undefined ? `총 ${count}${description}` : description}</p>}
+      </div>
+      {buttonLabel && (
+        <Button size="sm" icon={Plus} className="bg-primary-200 h-fit cursor-pointer font-bold text-white" onClick={goToProductPost} type="button">
+          {buttonLabel}
+        </Button>
+      )}
     </div>
   )
 }

--- a/src/pages/product-post/ProductPost.tsx
+++ b/src/pages/product-post/ProductPost.tsx
@@ -1,6 +1,6 @@
 import { SimpleHeader } from '@src/components/header/SimpleHeader'
 import { useEffect, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, useSearchParams } from 'react-router-dom'
 import { PRODUCT_TYPE_TABS, type ProductTypeTabId } from '../../constants/constants'
 import { Tabs } from '@src/components/Tabs'
 import { ProductPostForm } from './components/ProductPostForm'
@@ -9,10 +9,27 @@ import { fetchProductById } from '@src/api/products'
 import type { ProductDetailItem } from '@src/types'
 
 function ProductPost() {
-  const [activeProductTypeTab, setActiveProductTypeTab] = useState<ProductTypeTabId>('tab-sales')
+  const [searchParams, setSearchParams] = useSearchParams()
+  const tabParam = searchParams.get('tab') as ProductTypeTabId | null
+  const initialTab = tabParam === 'tab-purchases' ? 'tab-purchases' : 'tab-sales'
+
+  const [activeProductTypeTab, setActiveProductTypeTab] = useState<ProductTypeTabId>(initialTab)
   const [productData, setProductData] = useState<ProductDetailItem | null>(null)
   const { id } = useParams()
   const isEditMode = !!id
+
+  const handleTabChange = (tabId: string) => {
+    setActiveProductTypeTab(tabId as ProductTypeTabId)
+    setSearchParams({ tab: tabId }, { replace: true })
+  }
+
+  const isSalesTab = activeProductTypeTab === 'tab-sales'
+  const headerTitle = isSalesTab
+    ? isEditMode ? '판매 상품 수정' : '판매 상품 등록'
+    : isEditMode ? '판매 요청 수정' : '판매 요청 등록'
+  const headerDescription = isSalesTab
+    ? isEditMode ? '등록된 상품 정보를 수정할 수 있습니다.' : '상품을 등록하여 다른 사용자들에게 판매할 수 있습니다.'
+    : isEditMode ? '등록된 판매 요청 정보를 수정할 수 있습니다.' : '원하는 상품이 없을 때 판매를 요청할 수 있습니다.'
 
   useEffect(() => {
     const loadProduct = async () => {
@@ -28,11 +45,17 @@ function ProductPost() {
 
   return (
     <>
-      <SimpleHeader title={isEditMode ? '상품 수정' : '상품 등록'} />
+      <SimpleHeader title={headerTitle} description={headerDescription} />
       <div className="bg-[#F3F4F6] pt-5">
         <div className="px-lg pb-4xl mx-auto max-w-[var(--container-max-width)]">
           <div className="gap-2xl flex w-full flex-col">
-            <Tabs tabs={PRODUCT_TYPE_TABS} activeTab={activeProductTypeTab} onTabChange={(tabId) => setActiveProductTypeTab(tabId as ProductTypeTabId)} ariaLabel="상품 타입" excludeTabId="tab-all" />
+            <Tabs
+              tabs={PRODUCT_TYPE_TABS}
+              activeTab={activeProductTypeTab}
+              onTabChange={handleTabChange}
+              ariaLabel="상품 타입"
+              excludeTabId="tab-all"
+            />
             {activeProductTypeTab === 'tab-sales' && <ProductPostForm isEditMode={isEditMode} productId={id} initialData={productData} />}
             {activeProductTypeTab === 'tab-purchases' && <ProductRequestForm isEditMode={isEditMode} productId={id} initialData={productData} />}
           </div>


### PR DESCRIPTION
## 📌 개요

- 마이페이지 상품등록 버튼 및 상품등록 페이지 개선

## 🔧 작업 내용
- 마이페이지 탭별 상품등록/판매요청 등록 버튼 추가
- TAB_CONFIG에 buttonLabel, navigateTo 속성 추가
- 상품등록 페이지 URL 쿼리 파라미터로 탭 상태 관리
- 탭 전환 시 URL 동기화 및 동적 헤더 텍스트 적용

## 📎 관련 이슈

- Close #210 

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| 이미지  | 이미지  |

## 💬 리뷰어 참고 사항

- 리뷰어가 중점적으로 봐주었으면 하는 부분
- 추가 논의가 필요한 부분
