### PR TITLE
refactor: 이미지 업로드 컴포넌트 재사용성 개선(#243)

### DIFF
--- a/src/pages/product-post/components/FormSectionHeader.tsx
+++ b/src/pages/product-post/components/FormSectionHeader.tsx
@@ -1,13 +1,14 @@
 interface FormSectionHeaderProps {
   heading?: string
   description?: string
+  headingClassName?: string
 }
 
-export default function FormSectionHeader({ heading, description }: FormSectionHeaderProps) {
+export default function FormSectionHeader({ heading, description, headingClassName }: FormSectionHeaderProps) {
   return (
     <div className="flex flex-col gap-1">
-      <h4 className="heading-h3">{heading}</h4>
-      <p>{description}</p>
+      <h4 className={headingClassName ?? 'heading-h3'}>{heading}</h4>
+      {description && <p>{description}</p>}
     </div>
   )
 }

--- a/src/pages/product-post/components/ProductPostForm.tsx
+++ b/src/pages/product-post/components/ProductPostForm.tsx
@@ -123,7 +123,16 @@ export function ProductPostForm({ isEditMode, productId: id, initialData }: Prod
           <div className="flex flex-col gap-5">
             <BasicInfoSection control={control} setValue={setValue} register={register} errors={errors} titleLength={watch('title')?.length ?? 0} />
             <PriceAndStatusSection control={control} register={register} errors={errors} />
-            <ProductImageUpload initialImages={initialImages} setValue={setValue} errors={errors} setError={setError} clearErrors={clearErrors} />
+            <ProductImageUpload
+              initialImages={initialImages}
+              setValue={setValue}
+              errors={errors}
+              setError={setError}
+              clearErrors={clearErrors}
+              mainImageField="mainImageUrl"
+              subImagesField="subImageUrls"
+              description="상품 이미지를 업로드 해주세요. 첫번째 이미지가 대표 이미지가 됩니다. (최대 5장)"
+            />
             <TradeInfoSection control={control} setValue={setValue} register={register} />
           </div>
           <div className="flex items-center gap-4">

--- a/src/pages/product-post/components/ProductRequestForm.tsx
+++ b/src/pages/product-post/components/ProductRequestForm.tsx
@@ -134,7 +134,15 @@ export function ProductRequestForm({ isEditMode, productId: id, initialData }: P
               priceLabel="희망 가격"
               heading="가격"
             />
-            <ProductImageUpload initialImages={initialImages} setValue={setValue} errors={errors} setError={setError} clearErrors={clearErrors} />
+            <ProductImageUpload
+              initialImages={initialImages}
+              setValue={setValue}
+              errors={errors}
+              setError={setError}
+              clearErrors={clearErrors}
+              mainImageField="mainImageUrl"
+              subImagesField="subImageUrls"
+            />
             <TradeInfoSection control={control} setValue={setValue} showProductTradeFilter={false} register={register} />
           </div>
           <div className="flex items-center gap-4">

--- a/src/pages/product-post/components/imageUploadField/ImageUploadField.tsx
+++ b/src/pages/product-post/components/imageUploadField/ImageUploadField.tsx
@@ -1,27 +1,60 @@
-import type { ProductPostFormValues } from '../ProductPostForm'
-import { type FieldErrors, type UseFormClearErrors, type UseFormSetValue, type UseFormSetError } from 'react-hook-form'
+import { type FieldErrors, type UseFormClearErrors, type UseFormSetValue, type UseFormSetError, type FieldValues, type Path } from 'react-hook-form'
 import DropzoneArea from './components/DropzoneArea'
 import FormSectionHeader from '../FormSectionHeader'
+import { cn } from '@src/utils/cn'
 
-interface ImageUploadFieldProps {
-  setValue: UseFormSetValue<ProductPostFormValues>
-  errors: FieldErrors<ProductPostFormValues>
-  setError: UseFormSetError<ProductPostFormValues>
-  clearErrors: UseFormClearErrors<ProductPostFormValues>
+interface ImageUploadFieldProps<T extends FieldValues> {
+  setValue: UseFormSetValue<T>
+  errors: FieldErrors<T>
+  setError: UseFormSetError<T>
+  clearErrors: UseFormClearErrors<T>
+  mainImageField: Path<T>
+  subImagesField?: Path<T>
   initialImages?: string[]
+  maxFiles?: number
+  heading?: string
+  description?: string
+  showSection?: boolean
+  headingClassName?: string
+  className?: string
 }
 
-export default function ImageUploadField({ setValue, errors, setError, clearErrors, initialImages }: ImageUploadFieldProps) {
-  return (
-    <section className="flex flex-col gap-6 rounded-xl border border-gray-100 bg-white px-6 py-5">
-      <div className="flex flex-col gap-5">
-        <FormSectionHeader
-          heading="상품 이미지 (선택항목)"
-          description="상품 이미지를 업로드 해주세요. 첫번째 이미지가 대표 이미지가 됩니다. (최대 5장) "
-        />
-        <DropzoneArea initialImages={initialImages} setValue={setValue} setError={setError} clearErrors={clearErrors} />
-        {errors.mainImageUrl && <p className="text-danger-500 text-sm font-semibold">{errors.mainImageUrl.message}</p>}
-      </div>
-    </section>
+export default function ImageUploadField<T extends FieldValues>({
+  setValue,
+  errors,
+  setError,
+  clearErrors,
+  mainImageField,
+  subImagesField,
+  initialImages,
+  maxFiles,
+  heading = '상품 이미지 (선택항목)',
+  description,
+  showSection = true,
+  headingClassName,
+  className,
+}: ImageUploadFieldProps<T>) {
+  const errorMessage = errors[mainImageField]?.message as string | undefined
+
+  const content = (
+    <div className={cn('flex flex-col gap-5', className)}>
+      <FormSectionHeader heading={heading} description={description} headingClassName={headingClassName} />
+      <DropzoneArea
+        initialImages={initialImages}
+        setValue={setValue}
+        setError={setError}
+        clearErrors={clearErrors}
+        mainImageField={mainImageField}
+        subImagesField={subImagesField}
+        maxFiles={maxFiles}
+      />
+      {errorMessage && <p className="text-danger-500 text-sm font-semibold">{errorMessage}</p>}
+    </div>
   )
+
+  if (!showSection) {
+    return content
+  }
+
+  return <section className="flex flex-col gap-6 rounded-xl border border-gray-100 bg-white px-6 py-5">{content}</section>
 }

--- a/src/pages/product-post/components/imageUploadField/components/DropzoneGuide.tsx
+++ b/src/pages/product-post/components/imageUploadField/components/DropzoneGuide.tsx
@@ -1,12 +1,16 @@
 import { FileUp } from 'lucide-react'
 
-export default function DropzoneGuide() {
+interface DropzoneGuideProps {
+  maxFiles?: number
+}
+
+export default function DropzoneGuide({ maxFiles = 5 }: DropzoneGuideProps) {
   return (
     <div className="flex flex-col items-center gap-2">
       <FileUp size={30} strokeWidth={1.5} className="text-gray-400" />
       <div className="flex flex-col items-center text-sm text-gray-400">
         <p>파일을 드래그하거나 클릭하여 업로드</p>
-        <p>최대 5개 파일, 각 5MB 이하</p>
+        <p>최대 {maxFiles}개 파일, 각 5MB 이하</p>
       </div>
     </div>
   )


### PR DESCRIPTION
## 작업 내용
- ImageUploadField, DropzoneArea에 제네릭 타입 지원 추가
- mainImageField, subImagesField props로 필드명 커스터마이징 가능
- maxFiles, heading, description, showSection 등 옵션 확장
- FormSectionHeader에 headingClassName props 추가
- DropzoneGuide에 maxFiles props 추가

## 관련 이슈
- closes #243