### PR TITLE
refactor: 공통 컴포넌트 및 상수 개선(#247)

### DIFF
--- a/src/components/commons/button/buttonClass.ts
+++ b/src/components/commons/button/buttonClass.ts
@@ -2,6 +2,11 @@ import { cva, type VariantProps } from 'class-variance-authority'
 
 export const buttonVariants = cva('flex items-center justify-center rounded-lg font-medium transition-colors', {
   variants: {
+    variant: {
+      default: '',
+      ghost: 'bg-transparent hover:bg-gray-100',
+      link: 'bg-transparent p-0 hover:underline',
+    },
     size: {
       xs: 'px-3 py-2 text-sm',
       sm: 'px-3 py-2 text-sm',
@@ -41,6 +46,7 @@ export const buttonVariants = cva('flex items-center justify-center rounded-lg f
     },
   ],
   defaultVariants: {
+    variant: 'default',
     size: 'md',
     iconPosition: 'none',
   },

--- a/src/components/modal/WithdrawModal.tsx
+++ b/src/components/modal/WithdrawModal.tsx
@@ -19,7 +19,7 @@ interface WithdrawModalProps {
   onCancel: () => void
 }
 
-function WithdrawModal({ isOpen, onConfirm, onCancel }: WithdrawModalProps) {
+export default function WithdrawModal({ isOpen, onConfirm, onCancel }: WithdrawModalProps) {
   const {
     control,
     handleSubmit,
@@ -125,5 +125,3 @@ function WithdrawModal({ isOpen, onConfirm, onCancel }: WithdrawModalProps) {
     </div>
   )
 }
-
-export default WithdrawModal

--- a/src/components/product/ProductListItem.tsx
+++ b/src/components/product/ProductListItem.tsx
@@ -22,11 +22,8 @@ export function ProductListItem({ product, children }: ProductListItemProps) {
 
   return (
     <li id={id.toString()} className="w-full">
-      <Link
-        to={ROUTES.DETAIL_ID(id)}
-        className="flex w-full items-center justify-center gap-6 rounded-lg border border-gray-300 p-3.5"
-      >
-        <div className="aspect-square w-32 shrink-0 overflow-hidden rounded-lg">
+      <Link to={ROUTES.DETAIL_ID(id)} className="flex w-full items-center justify-center gap-6 rounded-lg border border-gray-300 p-3.5">
+        <div className="aspect-square w-[10%] shrink-0 overflow-hidden rounded-lg">
           <img
             src={mainImageUrl || PlaceholderImage}
             alt={title}
@@ -45,13 +42,7 @@ export function ProductListItem({ product, children }: ProductListItemProps) {
               <ProductMetaItem icon={Eye} label={`조회 ${viewCount}`} className="text-sm text-gray-400" />
             </div>
           </div>
-          {children ? (
-            children
-          ) : (
-            tradeStatus && (
-              <Badge className={cn('bg-[#48BB78] text-white', tradeStatusColor)}>{tradeStatusText}</Badge>
-            )
-          )}
+          {children ? children : tradeStatus && <Badge className={cn('bg-[#48BB78] text-white', tradeStatusColor)}>{tradeStatusText}</Badge>}
         </div>
       </Link>
     </li>

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1271,6 +1271,18 @@ export const WiTH_DRAW_REASON = [
 ]
 export type WiTH_DRAW_LABEL = (typeof WiTH_DRAW_REASON)[number]['label']
 
+// ========== 회원신고 이유 관련 상수 ==========
+export const USER_REPORT_REASON = [
+  { id: 'HARASSMENT', label: '욕설, 비방, 괴롭힘' },
+  { id: 'FRAUD', label: '사기, 허위 거래 시도' },
+  { id: 'INAPPROPRIATE_CONTENT', label: '음람눌 또는 불건전 행위' },
+  { id: 'SPAM', label: '스팸/광고성 메시지' },
+  { id: 'OFFENSIVE_PROFILE', label: '불뫠한 사용자 정보 내용' },
+  { id: 'UNDERAGE', label: '만 14세 미만 유저' },
+  { id: 'OTHER', label: '기타' },
+]
+export type REPORT_LABEL = (typeof USER_REPORT_REASON)[number]['label']
+
 // ========== 주의사항 항목들 상수 ==========
 
 export const WITH_DRAW_ALERT_LIST = [
@@ -1279,11 +1291,17 @@ export const WITH_DRAW_ALERT_LIST = [
   '찜한 상품 목록이 삭제됩니다',
   '진행 중인 거래가 있다면 먼저 완료해 주세요',
 ]
-
 export const PRODUCT_DELETE_ALERT_LIST = ['삭제된 상품은 복구할 수 없습니다']
 
 export const PASSWORD_UPDATE_ALERT_LIST = [
   '영문 대/소문자, 숫자, 특수문자를 조합하세요',
   '개인정보(이름, 생일 등)는 사용하지 마세요',
   '다른 사이트와 같은 비밀번호를 사용하지 마세요',
+]
+
+export const USER_BLOCK_ALERT_LIST = [
+  '차단한 사용자는 더 이상 채팅을 보내거나 상품을 볼 수 없습니다',
+  '해당 사용자의 게시글과 프로필이 숨김 처리됩니다',
+  '이미 진행 중인 거래는 영향을 받지 않습니다.',
+  `차단은 언제든 '마이페이지 > 차단 목록'에서 해제할 수 있습니다`,
 ]


### PR DESCRIPTION
## Summary
- Button 컴포넌트에 ghost, link variant 추가
- WithdrawModal export 방식을 default export로 변경
- ProductListItem 이미지 크기를 반응형(10%)으로 조정
- 회원신고 이유 상수(USER_REPORT_REASON) 추가
- 사용자 차단 안내 상수(USER_BLOCK_ALERT_LIST) 추가

## Test plan
- [ ] Button 컴포넌트에서 ghost, link variant 사용 가능 여부 확인
- [ ] WithdrawModal import가 정상 동작하는지 확인
- [ ] ProductListItem 이미지가 반응형으로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)