### PR TITLE
feat: 로그아웃 확인 모달 기능 추가(#259)

### DIFF
--- a/src/components/header/components/user-section/UserMenu.tsx
+++ b/src/components/header/components/user-section/UserMenu.tsx
@@ -7,6 +7,7 @@ import { useState, useEffect } from 'react'
 import { ROUTES } from '@src/constants/routes'
 import { useUserStore } from '@src/store/userStore'
 import { logout } from '@src/api/auth'
+import { useLoginModalStore } from '@src/store/modalStore'
 
 interface UserMenuProps {
   isNotificationOpen: boolean
@@ -19,6 +20,7 @@ interface UserMenuProps {
 export default function UserMenu({ isNotificationOpen, setIsNotificationOpen, isUserMenuOpen, setIsUserMenuOpen }: UserMenuProps) {
   const { user, clearAll } = useUserStore()
   const [imgSrc, setImgSrc] = useState(user?.profileImageUrl || CuddleMarketLogo)
+  const { openLogoutModal } = useLoginModalStore()
 
   useEffect(() => {
     setImgSrc(user?.profileImageUrl || CuddleMarketLogo)
@@ -31,13 +33,17 @@ export default function UserMenu({ isNotificationOpen, setIsNotificationOpen, is
     setIsUserMenuOpen(!isUserMenuOpen)
   }
 
-  const handleLogout = async () => {
+  // 로그아웃 실행 함수
+  const onLogout = async () => {
     await logout()
-    clearAll()
-    if (isNotificationOpen) {
-      setIsNotificationOpen(false)
-    }
     setIsUserMenuOpen(false)
+    clearAll()
+  }
+
+  // 로그아웃 버튼 클릭 시 확인 모달 열기
+  const handleLogoutClick = () => {
+    setIsUserMenuOpen(false)
+    openLogoutModal(onLogout)
   }
 
   return (
@@ -66,7 +72,7 @@ export default function UserMenu({ isNotificationOpen, setIsNotificationOpen, is
             마이페이지
           </a>
           <button
-            onClick={handleLogout}
+            onClick={handleLogoutClick}
             className="hover:bg-primary-50 text-danger-500 flex w-full cursor-pointer items-center gap-3 px-4 py-2.5 text-sm"
           >
             <LogOutIcon className="h-5 w-5 rotate-180" />

--- a/src/components/modal/LoginModal.tsx
+++ b/src/components/modal/LoginModal.tsx
@@ -1,30 +1,51 @@
 import { Link } from 'react-router-dom'
 import { Button } from '@src/components/commons/button/Button'
 import { ROUTES } from '@src/constants/routes'
-interface LoginModalProps {
-  isOpen: boolean
-  onCancel: () => void
-}
+import { useLoginModalStore } from '@src/store/modalStore'
 
-export default function LoginModal({ isOpen, onCancel }: LoginModalProps) {
-  const handleCancel = () => {
-    onCancel()
-  }
+export default function ConfirmModal() {
+  const { isOpen, modalType, onConfirm, closeModal } = useLoginModalStore()
+
   if (!isOpen) return null
+
+  // 모달 타입에 따른 텍스트 설정
+  const isLogin = modalType === 'login'
+  const heading = isLogin ? '로그인이 필요합니다' : '로그아웃'
+  const description = isLogin ? '로그인 하시겠습니까?' : '정말로 로그아웃 하시겠습니까?'
+  const confirmText = isLogin ? '로그인' : '로그아웃'
+
+  // 확인 버튼 클릭 핸들러
+  const handleConfirm = () => {
+    if (onConfirm) {
+      onConfirm()
+    }
+    closeModal()
+  }
+
   return (
     <div className="fixed inset-0 z-100 flex items-center justify-center bg-gray-900/70">
-      <div className="flex w-[10vw] flex-col items-center gap-6 rounded-lg bg-white p-5">
+      <div className="flex min-w-80 flex-col items-center gap-6 rounded-lg bg-white p-5">
         <div className="flex w-full flex-col items-center gap-2">
-          <h3 className="heading-h4">로그인이 필요합니다</h3>
-          <p>로그인 하시겠습니까?</p>
+          <h3 className="heading-h4">{heading}</h3>
+          <p>{description}</p>
         </div>
         <div className="flex w-full gap-3">
-          <Button size="md" className="flex-1 cursor-pointer border border-gray-300" onClick={handleCancel}>
+          <Button size="md" className="flex-1 cursor-pointer border border-gray-300" onClick={closeModal}>
             취소
           </Button>
-          <Link to={ROUTES.LOGIN} className="bg-primary-300 flex flex-1 items-center justify-center rounded-lg px-4 py-2.5 text-white">
-            로그인
-          </Link>
+          {isLogin ? (
+            <Link
+              to={ROUTES.LOGIN}
+              className="bg-primary-300 flex flex-1 items-center justify-center rounded-lg px-4 py-2.5 text-white"
+              onClick={closeModal}
+            >
+              {confirmText}
+            </Link>
+          ) : (
+            <Button size="md" className="bg-primary-300 flex-1 cursor-pointer text-white" onClick={handleConfirm}>
+              {confirmText}
+            </Button>
+          )}
         </div>
       </div>
     </div>

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -22,12 +22,10 @@ import { useNavigate, useSearchParams } from 'react-router-dom'
 import { Plus } from 'lucide-react'
 import { Button } from '@src/components/commons/button/Button'
 import { useUserStore } from '@src/store/userStore'
-import { useLoginModalStore } from '@src/store/modalStore'
-import LoginModal from '@src/components/modal/LoginModal'
+import ConfirmModal from '@src/components/modal/LoginModal'
 
 function Home() {
   const { isLogin } = useUserStore()
-  const { isLoginModalOpen, closeLoginModal } = useLoginModalStore()
   const isLoggedIn = isLogin()
   const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
@@ -292,7 +290,7 @@ function Home() {
           </Button>
         </div>
       )}
-      <LoginModal isOpen={isLoginModalOpen} onCancel={closeLoginModal} />
+      <ConfirmModal />
     </>
   )
 }

--- a/src/pages/product-detail/ProductDetail.tsx
+++ b/src/pages/product-detail/ProductDetail.tsx
@@ -10,12 +10,10 @@ import ProductSummary from './components/ProductSummary'
 import ProductDescription from './components/ProductDescription'
 import ProductActions from './components/ProductActions'
 import SellerOtherProducts from './components/SellerOtherProducts'
-import LoginModal from '@src/components/modal/LoginModal'
-import { useLoginModalStore } from '@src/store/modalStore'
+import ConfirmModal from '@src/components/modal/LoginModal'
 
 function ProductDetail() {
   const navigate = useNavigate()
-  const { isLoginModalOpen, closeLoginModal } = useLoginModalStore()
   const { id } = useParams<{ id: string }>()
 
   const { data, isLoading, error } = useQuery({
@@ -71,7 +69,7 @@ function ProductDetail() {
         </div>
       </div>
       <Footer />
-      <LoginModal isOpen={isLoginModalOpen} onCancel={closeLoginModal} />
+      <ConfirmModal />
     </>
   )
 }

--- a/src/store/modalStore.ts
+++ b/src/store/modalStore.ts
@@ -1,31 +1,62 @@
 import { create } from 'zustand'
 
-// ===== 로그인 모달 상태 타입 =====
-interface LoginModalState {
+// ===== 확인 모달 상태 타입 =====
+interface ConfirmModalState {
   // 모달 열림/닫힘 상태
-  isLoginModalOpen: boolean
+  isOpen: boolean
 
-  // 모달 열기
+  // 모달 타입: 'login' (로그인 유도) 또는 'logout' (로그아웃 확인)
+  modalType: 'login' | 'logout'
+
+  // 로그아웃 시 실행할 콜백 함수
+  onConfirm: (() => void) | null
+
+  // 로그인 모달 열기
   // 사용: openLoginModal()
-  // 결과: isLoginModalOpen이 true로 변경되어 모달이 화면에 표시됨
+  // 결과: 로그인 유도 모달이 화면에 표시됨
   openLoginModal: () => void
 
+  // 로그아웃 확인 모달 열기
+  // 사용: openLogoutModal(onLogout)
+  // 결과: 로그아웃 확인 모달이 화면에 표시되고, 확인 시 onLogout 실행
+  openLogoutModal: (onConfirm: () => void) => void
+
   // 모달 닫기
-  // 사용: closeLoginModal()
-  // 결과: isLoginModalOpen이 false로 변경되어 모달이 화면에서 사라짐
-  closeLoginModal: () => void
+  // 사용: closeModal()
+  // 결과: 모달이 화면에서 사라짐
+  closeModal: () => void
 }
 
-// ===== 로그인 모달 스토어 =====
-// 미로그인 상태에서 로그인이 필요한 기능 사용 시 LoginModal을 띄우기 위한 전역 상태
-// 어떤 페이지에서든 openLoginModal()을 호출하면 모달이 열림
-export const useLoginModalStore = create<LoginModalState>((set) => ({
-  // 초기 상태: 모달 닫힘
-  isLoginModalOpen: false,
+// ===== 확인 모달 스토어 =====
+// 로그인 유도, 로그아웃 확인 등 다양한 확인 모달에 사용
+// 어떤 페이지에서든 openLoginModal() 또는 openLogoutModal()을 호출하면 모달이 열림
+export const useLoginModalStore = create<ConfirmModalState>((set) => ({
+  // 초기 상태
+  isOpen: false,
+  modalType: 'login',
+  onConfirm: null,
 
-  // 모달 열기 액션
-  openLoginModal: () => set({ isLoginModalOpen: true }),
+  // 로그인 모달 열기 액션
+  openLoginModal: () =>
+    set({
+      isOpen: true,
+      modalType: 'login',
+      onConfirm: null,
+    }),
+
+  // 로그아웃 모달 열기 액션
+  // onConfirm: 확인 버튼 클릭 시 실행할 함수 (예: 로그아웃 API 호출)
+  openLogoutModal: (onConfirm) =>
+    set({
+      isOpen: true,
+      modalType: 'logout',
+      onConfirm,
+    }),
 
   // 모달 닫기 액션
-  closeLoginModal: () => set({ isLoginModalOpen: false }),
+  closeModal: () =>
+    set({
+      isOpen: false,
+      onConfirm: null,
+    }),
 }))


### PR DESCRIPTION
## 📌 개요

- 기존 로그인 모달을 확장하여 로그아웃 확인 기능 추가
- 모달 타입(login/logout)에 따라 동적으로 UI 렌더링

## 🔧 작업 내용

- [x] modalStore 확장 (로그인/로그아웃 타입 지원)
- [x] LoginModal 컴포넌트 범용 확인 모달로 개선
- [x] UserMenu에 로그아웃 모달 연동
- [x] 관련 컴포넌트 스토어 변경사항 적용

## 📎 관련 이슈

Closes #259

## 💬 리뷰어 참고 사항

- modalStore에 modalType('login' | 'logout')과 onConfirm 콜백이 추가되었습니다
- 로그아웃 시 openLogoutModal(콜백함수)를 호출하면 확인 모달이 표시됩니다