### PR TITLE
feat: 회원가입 만 14세 이상 유효성 검사 추가(#261)

### DIFF
--- a/src/pages/FindPasswordForm.tsx
+++ b/src/pages/FindPasswordForm.tsx
@@ -52,12 +52,9 @@ export function FindPasswordForm() {
   const passwordConfirm = watch('passwordConfirm')
   const navigate = useNavigate()
 
-  const currentStep: 1 | 2 | 3 =
-    checkValidCodeResult.status !== 'idle' ? 3 : sendValidCodeResult.status !== 'idle' ? 2 : 1
+  const currentStep: 1 | 2 | 3 = checkValidCodeResult.status !== 'idle' ? 3 : sendValidCodeResult.status !== 'idle' ? 2 : 1
 
   const onSubmit = async () => {
-    console.log('인증코드 전송 호출')
-
     try {
       await sendValidCode(email)
       setSendValidCodeResult({
@@ -73,7 +70,6 @@ export function FindPasswordForm() {
   }
 
   const onVerifyCode = async () => {
-    console.log('인증하기 전송 호출')
     try {
       await checkValidCode(email, String(code))
       // 성공 시: 다음 단계로 이동 (비밀번호 재설정)
@@ -89,7 +85,6 @@ export function FindPasswordForm() {
     }
   }
   const onReSettingPassword = async () => {
-    console.log('비밀번호 변경 완료 전송 호출')
     try {
       await reSettingPassword({
         email,

--- a/src/pages/signup/components/BirthDateField.tsx
+++ b/src/pages/signup/components/BirthDateField.tsx
@@ -109,23 +109,40 @@ export function BirthDateField({ control }: BirthDateFieldProps) {
         <Controller
           name="birthDate"
           control={control}
-          render={({ field }) => (
-            <DatePicker
-              dateFormat="yyyy-MM-dd"
-              shouldCloseOnSelect
-              maxDate={new Date()}
-              selected={field.value && field.value !== '' ? new Date(field.value) : null}
-              onChange={(date) => {
-                // Date 객체를 'yyyy-MM-dd' 문자열로 변환
-                const formatted = date ? date.toISOString().split('T')[0] : ''
-                field.onChange(formatted)
-              }}
-              popperPlacement="bottom-start"
-              locale={ko}
-              placeholderText="YYYY-MM-DD"
-              customInput={<CustomInput className="example-custom-input" placeholder="YYYY-MM-DD" />}
-              renderCustomHeader={renderCustomHeader}
-            />
+          rules={{
+            required: '생년월일을 입력해주세요',
+            validate: (value) => {
+              const birthDate = new Date(value)
+              const today = new Date()
+              const age = today.getFullYear() - birthDate.getFullYear()
+              // 생일이 아직 안 지났으면 나이 -1
+              const isBeforeBirthday =
+                today.getMonth() < birthDate.getMonth() || (today.getMonth() === birthDate.getMonth() && today.getDate() < birthDate.getDate())
+              const actualAge = isBeforeBirthday ? age - 1 : age
+
+              return actualAge >= 14 || '만 14세 이상만 가입 가능합니다'
+            },
+          }}
+          render={({ field, fieldState }) => (
+            <div className="flex flex-col gap-1">
+              <DatePicker
+                dateFormat="yyyy-MM-dd"
+                maxDate={new Date()}
+                shouldCloseOnSelect
+                selected={field.value && field.value !== '' ? new Date(field.value) : null}
+                onChange={(date) => {
+                  // Date 객체를 'yyyy-MM-dd' 문자열로 변환
+                  const formatted = date ? date.toISOString().split('T')[0] : ''
+                  field.onChange(formatted)
+                }}
+                popperPlacement="bottom-start"
+                locale={ko}
+                placeholderText="YYYY-MM-DD"
+                customInput={<CustomInput className="example-custom-input" placeholder="YYYY-MM-DD" />}
+                renderCustomHeader={renderCustomHeader}
+              />
+              {fieldState.error && <p className="text-danger-500 text-xs font-semibold">{fieldState.error.message}</p>}
+            </div>
           )}
         />
       </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -119,6 +119,11 @@ export interface LoginResponse {
     }
   }
 }
+export interface LogoutResponse {
+  code: string
+  message: string
+  data: string
+}
 
 export interface ResettingPasswordResponse {
   code: string


### PR DESCRIPTION
## 📌 개요

- 회원가입 시 만 14세 이상만 가입 가능하도록 생년월일 유효성 검사 추가
- 관련 코드 정리

## 🔧 작업 내용

- [x] BirthDateField에 만 14세 이상 유효성 검사 추가
- [x] 유효성 검사 실패 시 에러 메시지 표시
- [x] LogoutResponse 타입 추가
- [x] FindPasswordForm 불필요한 console.log 제거

## 📎 관련 이슈

Closes #261

## 💬 리뷰어 참고 사항

- 만 나이 계산 시 생일이 아직 지나지 않은 경우도 고려하여 정확한 나이를 계산합니다