### PR TITLE
feat: 커뮤니티 게시글 상세 페이지 및 댓글 기능 구현(#267)

### DIFF
--- a/src/api/community.ts
+++ b/src/api/community.ts
@@ -1,4 +1,4 @@
-import type { CommunityPostRequestData, CommunityResponse } from '../types'
+import type { CommentResponse, CommunityDetailItemResponse, CommunityPostRequestData, CommunityResponse } from '../types'
 import axios from 'axios'
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
@@ -81,6 +81,24 @@ export const fetchInfoCommunity = async (
 // 커뮤니티 글 등록
 export const postCommunity = async (requestData: CommunityPostRequestData): Promise<void> => {
   await api.post(`/community/posts`, requestData)
+}
+
+// 커뮤니티 글 상세 조회
+export const fetchCommunityId = async (postId: string) => {
+  const response = await api.get<CommunityDetailItemResponse>(`/community/posts/${postId}`)
+  return response.data.data
+}
+
+// 댓글 목록 조회
+export const fetchComments = async (postId: string) => {
+  const response = await api.get<CommentResponse>(`/community/posts/${postId}/comments`)
+  return response.data.data
+}
+
+// 하위 댓글 목록 조회
+export const fetchReplies = async (commentId: string) => {
+  const response = await api.get<CommentResponse>(`/community/comments/${commentId}/replies`)
+  return response.data.data
 }
 
 // 상품 상세 조회

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -8,6 +8,9 @@ export const ROUTES = {
   // Community
   COMMUNITY: '/community',
   COMMUNITY_POST: '/community-post',
+  COMMUNITY_EDIT: '/community/:id/edit',
+  COMMUNITY_DETAIL: '/community/:id',
+  COMMUNITY_DETAIL_ID: (id: string | number) => `/community/${id}`,
 
   // Product
   PRODUCT_POST: '/product-post',

--- a/src/pages/community/CommunityDetail.tsx
+++ b/src/pages/community/CommunityDetail.tsx
@@ -1,0 +1,112 @@
+import { useNavigate, useParams } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import Footer from '@src/components/footer/Footer'
+import { fetchComments, fetchCommunityId } from '@src/api/community'
+import MdPreview from './components/markdown/MdPreview'
+import { getBoardType } from '@src/utils/getBoardType'
+import { SimpleHeader } from '@src/components/header/SimpleHeader'
+import { Badge } from '@src/components/commons/badge/Badge'
+import { formatDate } from '@src/utils/formatDate'
+import { CommentList } from './components/CommentList'
+// import MainImage from './components/MainImage'
+// import SubImages from './components/SubImages'
+// import SellerProfileCard from './components/SellerProfileCard'
+// import ProductBadges from './components/ProductBadges'
+// import ProductSummary from './components/ProductSummary'
+// import ProductDescription from './components/ProductDescription'
+// import ProductActions from './components/ProductActions'
+// import SellerOtherProducts from './components/SellerOtherProducts'
+
+export default function CommunityDetail() {
+  const navigate = useNavigate()
+  const { id } = useParams<{ id: string }>()
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['community', id],
+    queryFn: () => fetchCommunityId(id!),
+    enabled: !!id,
+  })
+  const { data: commentData } = useQuery({
+    queryKey: ['community', id, 'comments'],
+    queryFn: () => fetchComments(id!),
+    enabled: !!id,
+  })
+
+  const getHeaderContent = () => {
+    switch (data?.boardType) {
+      case 'FREE':
+        return { title: '자유게시판', description: '일상 이야기를 마음껏 나눠보세요!' }
+      case 'QUESTION':
+        return { title: '질문 있어요', description: '궁금한 점을 질문해보세요!' }
+      case 'INFO':
+        return { title: '정보 공유', description: '유용한 정보를 공유해보세요!' }
+      default:
+        return { title: '자유게시판', description: '일상 이야기를 마음껏 나눠보세요!' }
+    }
+  }
+  const { title: headerTitle, description: headerDescription } = getHeaderContent()
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600"></div>
+      </div>
+    )
+  }
+
+  if (error || !data) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="text-center">
+          <button onClick={() => navigate('/')} className="text-blue-600 hover:text-blue-800">
+            목록으로 돌아가기
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <SimpleHeader title={headerTitle} description={headerDescription} />
+      <div className="min-h-screen bg-[#F3F4F6] pt-5">
+        <div className="px-lg pb-4xl mx-auto max-w-[var(--container-max-width)]">
+          <div className="flex flex-col justify-center gap-3.5">
+            <div className="flex flex-col gap-3.5 rounded-lg border border-gray-400 bg-white px-6 py-5 shadow-xl">
+              <Badge className="bg-primary-400 w-fit rounded-full text-white">{getBoardType(data.boardType ?? '')}</Badge>
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3.5">
+                  {/* 프로필 이미지 */}
+                  <div className="flex h-12 w-12 items-center justify-center overflow-hidden rounded-full bg-[#FACC15]">
+                    {data?.authorProfileImageUrl ? (
+                      <img src={data.authorProfileImageUrl} alt={data.authorNickname} className="h-full w-full object-cover" />
+                    ) : (
+                      <div className="heading-h4">{data?.authorNickname.charAt(0).toUpperCase()}</div>
+                    )}
+                  </div>
+                  {/* 유저 정보 */}
+                  <div className="flex flex-col justify-center gap-0.5">
+                    <p>{data.authorNickname}</p>
+                    <p>{formatDate(data.createdAt)}</p>
+                  </div>
+                </div>
+                <p>조회 {data.viewCount}</p>
+              </div>
+              <p className="border-b border-gray-300 pb-3.5 text-lg font-semibold">{data.title}</p>
+              <MdPreview value={data.content} className="p-0" />
+            </div>
+
+            <div className="flex flex-col gap-3.5 rounded-lg border border-gray-400 bg-white px-6 py-5 shadow-xl">
+              <div className="flex items-center gap-1">
+                <span>댓글</span>
+                <span>{data.commentCount}</span>
+              </div>
+
+              {commentData?.comments && <CommentList comments={commentData.comments} postId={id!} />}
+              <textarea name="" id="" placeholder="댓글을 입력하세요" className="bg-primary-50 min-h-"></textarea>
+            </div>
+          </div>
+        </div>
+      </div>
+      <Footer />
+    </>
+  )
+}

--- a/src/pages/community/CommunityPage.tsx
+++ b/src/pages/community/CommunityPage.tsx
@@ -197,26 +197,28 @@ export default function CommunityPage() {
                   key={post.id}
                   className="flex flex-col justify-center gap-2.5 rounded-lg border border-gray-400 bg-white px-3.5 pt-3.5 pb-5 shadow-xl"
                 >
-                  <p className="font-semibold">{post.title}</p>
-                  <div className="flex items-center gap-2.5">
-                    <div className="flex items-center gap-1 text-gray-500">
-                      <UserRound size={16} className="text-gray-500" strokeWidth={2.3} />
-                      <p>{post.authorNickname}</p>
+                  <Link to={ROUTES.COMMUNITY_DETAIL_ID(post.id)}>
+                    <p className="font-semibold">{post.title}</p>
+                    <div className="flex items-center gap-2.5">
+                      <div className="flex items-center gap-1 text-gray-500">
+                        <UserRound size={16} className="text-gray-500" strokeWidth={2.3} />
+                        <p>{post.authorNickname}</p>
+                      </div>
+                      <div className="flex items-center gap-1 text-gray-500">
+                        <Clock size={16} className="text-gray-500" strokeWidth={2.3} />
+                        <p>{getTimeAgo(post.createdAt)}</p>
+                      </div>
+                      <div className="flex items-center gap-1 text-gray-500">
+                        <MessageSquare size={16} className="text-gray-500" strokeWidth={2.3} />
+                        <p>{post.commentCount}</p>
+                      </div>
+                      <div className="flex items-center gap-1 text-gray-500">
+                        <Eye size={16} className="text-gray-500" strokeWidth={2.3} />
+                        <span>조회</span>
+                        <span>{post.viewCount}</span>
+                      </div>
                     </div>
-                    <div className="flex items-center gap-1 text-gray-500">
-                      <Clock size={16} className="text-gray-500" strokeWidth={2.3} />
-                      <p>{getTimeAgo(post.createdAt)}</p>
-                    </div>
-                    <div className="flex items-center gap-1 text-gray-500">
-                      <MessageSquare size={16} className="text-gray-500" strokeWidth={2.3} />
-                      <p>{post.commentCount}</p>
-                    </div>
-                    <div className="flex items-center gap-1 text-gray-500">
-                      <Eye size={16} className="text-gray-500" strokeWidth={2.3} />
-                      <span>조회</span>
-                      <span>{post.viewCount}</span>
-                    </div>
-                  </div>
+                  </Link>
                 </li>
               ))}
             </ul>

--- a/src/pages/community/components/CommentItem.tsx
+++ b/src/pages/community/components/CommentItem.tsx
@@ -1,0 +1,42 @@
+import { formatDate } from '@src/utils/formatDate'
+import type { Comment } from '@src/types'
+
+interface CommentItemProps {
+  comment: Comment
+  isReply?: boolean
+  hasChildren?: boolean
+  childrenCount?: number
+  onToggleReplies?: () => void
+  isRepliesOpen?: boolean
+}
+
+export function CommentItem({ comment, isReply = false, hasChildren, childrenCount, onToggleReplies, isRepliesOpen }: CommentItemProps) {
+  return (
+    <div className={`flex items-start gap-3.5 ${isReply ? '' : 'border-b border-gray-300 pb-3.5'}`}>
+      {/* 프로필 이미지 */}
+      <div className={`flex items-center justify-center overflow-hidden rounded-full bg-[#FACC15] ${isReply ? 'h-6 w-6' : 'h-8 w-8'}`}>
+        {comment.authorProfileImageUrl ? (
+          <img src={comment.authorProfileImageUrl} alt={comment.authorNickname} className="h-full w-full object-cover" />
+        ) : (
+          <div className={isReply ? 'text-xs' : 'text-sm'}>{comment.authorNickname.charAt(0).toUpperCase()}</div>
+        )}
+      </div>
+
+      {/* 유저 정보 및 내용 */}
+      <div className="flex flex-col justify-center gap-1">
+        <div className="flex items-center gap-3.5">
+          <p className={isReply ? 'text-sm' : ''}>{comment.authorNickname}</p>
+          <p className={`text-gray-400 ${isReply ? 'text-xs' : 'text-sm'}`}>{formatDate(comment.createdAt)}</p>
+        </div>
+        <p className={isReply ? 'text-sm' : ''}>{comment.content}</p>
+
+        {/* 답글 버튼 (대댓글이 아니고, hasChildren이 있을 때만) */}
+        {!isReply && hasChildren && (
+          <button className="self-start text-sm text-blue-500 hover:underline" type="button" onClick={onToggleReplies}>
+            {isRepliesOpen ? '답글 숨기기' : `답글 ${childrenCount}개`}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/community/components/CommentList.tsx
+++ b/src/pages/community/components/CommentList.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { fetchReplies } from '@src/api/community'
+import type { Comment } from '@src/types'
+import { CommentItem } from './CommentItem'
+
+interface CommentListProps {
+  comments: Comment[]
+  postId: string
+}
+
+export function CommentList({ comments, postId }: CommentListProps) {
+  const [openRepliesCommentId, setOpenRepliesCommentId] = useState<number | null>(null)
+
+  const { data: repliesData } = useQuery({
+    queryKey: ['community', postId, 'replies', openRepliesCommentId],
+    queryFn: () => fetchReplies(String(openRepliesCommentId)),
+    enabled: !!openRepliesCommentId,
+  })
+
+  const handleToggleReplies = (commentId: number) => {
+    setOpenRepliesCommentId(openRepliesCommentId === commentId ? null : commentId)
+  }
+
+  return (
+    <ul className="flex flex-col gap-3.5">
+      {comments.map((comment) => (
+        <li key={comment.id}>
+          <CommentItem
+            comment={comment}
+            hasChildren={comment.hasChildren}
+            childrenCount={comment.childrenCount}
+            onToggleReplies={() => handleToggleReplies(comment.id)}
+            isRepliesOpen={openRepliesCommentId === comment.id}
+          />
+
+          {/* 대댓글 목록 */}
+          {openRepliesCommentId === comment.id && repliesData?.comments && (
+            <ul className="flex flex-col gap-2 pl-4">
+              {repliesData.comments.map((reply) => (
+                <li key={reply.id}>
+                  <CommentItem comment={reply} isReply />
+                </li>
+              ))}
+            </ul>
+          )}
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/pages/community/components/CommunityPostForm.tsx
+++ b/src/pages/community/components/CommunityPostForm.tsx
@@ -18,7 +18,7 @@ export interface CommunityPostFormValues {
   imageUrls?: string[]
 }
 
-export function CommunityPostForm() {
+export default function CommunityPostForm() {
   const {
     control,
     handleSubmit, // form onSubmit에 들어가는 함수 : 제출 시 실행할 함수를 감싸주는 함수

--- a/src/pages/community/components/markdown/Markdown.tsx
+++ b/src/pages/community/components/markdown/Markdown.tsx
@@ -139,7 +139,7 @@ export default function Markdown({ value, onChange, placeholder = DEFAULT_PLACEH
         )}
 
         {/* 미리보기 모드: 렌더링된 마크다운 */}
-        {currentTab === 'preview' && <MdPreview embedded value={value} height={height} />}
+        {currentTab === 'preview' && <MdPreview value={value} height={height} />}
 
         {/* 푸터: 마크다운 문법 안내 */}
         <MdFooter>

--- a/src/pages/community/components/markdown/MdPreview.tsx
+++ b/src/pages/community/components/markdown/MdPreview.tsx
@@ -3,9 +3,15 @@ import rehypeSanitize from 'rehype-sanitize'
 import { cn } from '@src/utils/cn'
 import { mdSanitizeSchema } from './sanitizeSchema'
 
-export default function MdPreview({ value, height }: { value: string; embedded?: boolean; height?: number }) {
+interface MdPreviewProps {
+  value: string
+  height?: number
+  className?: string
+}
+
+export default function MdPreview({ value, height, className }: MdPreviewProps) {
   return (
-    <div className={cn('overflow-y-auto bg-white p-3')} style={height ? { height, overflowY: 'auto' } : undefined}>
+    <div className={cn('overflow-y-auto bg-white p-3', className)} style={height ? { height, overflowY: 'auto' } : undefined}>
       <ReactMarkdown
         rehypePlugins={[[rehypeSanitize, mdSanitizeSchema]]}
         components={{

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -20,7 +20,8 @@ import ProfileUpdate from '@src/pages/profile-update/ProfileUpdate'
 import UserPage from '@src/pages/UserPage'
 import FindPasswordPage from '@src/pages/find-password/FindPasswordPage'
 import CommunityPage from '@src/pages/community/CommunityPage'
-import { CommunityPostForm } from '@src/pages/community/components/CommunityPostForm'
+import CommunityPostForm from '@src/pages/community/components/CommunityPostForm'
+import CommunityDetail from '@src/pages/community/CommunityDetail'
 
 const routes = [
   { path: ROUTES.HOME, element: <Home /> },
@@ -35,6 +36,8 @@ const routes = [
   { path: ROUTES.USER_PROFILE, element: <UserPage /> },
   { path: ROUTES.COMMUNITY, element: <CommunityPage /> },
   { path: ROUTES.COMMUNITY_POST, element: <CommunityPostForm /> },
+  { path: ROUTES.COMMUNITY_EDIT, element: <CommunityPostForm /> },
+  { path: ROUTES.COMMUNITY_DETAIL, element: <CommunityDetail /> },
 ]
 
 function AppRoutes() {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -489,20 +489,39 @@ export interface CommunityPostRequestData {
   imageUrls: string[]
 }
 
-// export interface ProductDetailItem extends Product {
-//   category: string
-//   description: string
-//   subImageUrls: string[]
-//   addressSido: string
-//   addressGugun: string
-//   viewCount: number
-//   sellerInfo: {
-//     sellerId: number
-//     sellerNickname: string
-//     sellerProfileImageUrl: string
-//   }
-//   sellerOtherProducts: Product[]
-// }
+export interface CommunityDetailItemResponse {
+  code: string
+  message: string
+  data: CommunityDetailItem
+}
+
+export interface CommunityDetailItem extends CommunityItem {
+  authorId: string
+  authorProfileImageUrl: string
+  content: string
+  imageUrls: string[]
+}
+
+export interface CommentResponse {
+  code: string
+  message: string
+  data: {
+    comments: Comment[]
+  }
+}
+
+export interface Comment {
+  id: number
+  authorId: string
+  authorNickname: string
+  authorProfileImageUrl: string
+  content: string
+  createdAt: string
+  depth: number
+  parentId: number
+  hasChildren: boolean
+  childrenCount: number
+}
 
 // export interface ProductDetailItemResponse {
 //   code: string

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,9 @@
+export const formatDate = (dateString: string): string => {
+  const date = new Date(dateString)
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  const hours = String(date.getHours()).padStart(2, '0')
+  const minutes = String(date.getMinutes()).padStart(2, '0')
+  return `${year}-${month}-${day} ${hours}:${minutes}`
+}

--- a/src/utils/getBoardType.ts
+++ b/src/utils/getBoardType.ts
@@ -1,0 +1,6 @@
+import { COMMUNITY_TABS } from '@src/constants/constants'
+
+export const getBoardType = (boardType: string) => {
+  const board = COMMUNITY_TABS.find((type) => type.code === boardType)
+  return board?.label || boardType
+}


### PR DESCRIPTION
## 📌 개요

- 커뮤니티 게시글 상세 페이지 UI 및 댓글 기능 구현

## 🔧 작업 내용

- [x] 커뮤니티 게시글 상세 페이지 구현 (CommunityDetail)
- [x] 댓글 목록/아이템 컴포넌트 구현 (CommentList, CommentItem)
- [x] 커뮤니티 관련 API 추가
- [x] 유틸 함수 추가 (formatDate, getBoardType)
- [x] 라우트 및 타입 정의 추가

## 📎 관련 이슈

Closes #267

## 💬 리뷰어 참고 사항

- 댓글 컴포넌트 구조 검토 부탁드립니다