### PR TITLE
feat: 커뮤니티 댓글 등록/삭제 기능 구현(#269)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,19 @@
 // import './App.css';
 // vim 사용예시 커밋 작성
 
+import { useEffect } from 'react'
 import AppRoutes from './routes/index'
 import ConfirmModal from './components/modal/LoginModal'
+import { useUserStore } from './store/userStore'
 
 function App() {
+  const validateAuthState = useUserStore((state) => state.validateAuthState)
+
+  // 앱 시작 시 인증 상태 검증 (토큰-유저 상태 동기화)
+  useEffect(() => {
+    validateAuthState()
+  }, [validateAuthState])
+
   return (
     <>
       <AppRoutes />

--- a/src/api/community.ts
+++ b/src/api/community.ts
@@ -1,4 +1,12 @@
-import type { CommentResponse, CommunityDetailItemResponse, CommunityPostRequestData, CommunityResponse } from '../types'
+import type {
+  CommentDeleteResponse,
+  CommentPostRequestData,
+  CommentPostResponse,
+  CommentResponse,
+  CommunityDetailItemResponse,
+  CommunityPostRequestData,
+  CommunityResponse,
+} from '../types'
 import axios from 'axios'
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
@@ -98,6 +106,18 @@ export const fetchComments = async (postId: string) => {
 // 하위 댓글 목록 조회
 export const fetchReplies = async (commentId: string) => {
   const response = await api.get<CommentResponse>(`/community/comments/${commentId}/replies`)
+  return response.data.data
+}
+
+// 댓글 등록
+export const postReply = async (requestData: CommentPostRequestData, postId: string) => {
+  const response = await api.post<CommentPostResponse>(`/community/posts/${postId}/comments`, requestData)
+  return response.data.data
+}
+
+// 댓글 삭제
+export const deleteReply = async (commentId: number) => {
+  const response = await api.delete<CommentDeleteResponse>(`community/comments/${commentId}`)
   return response.data.data
 }
 

--- a/src/components/header/components/user-section/UserMenu.tsx
+++ b/src/components/header/components/user-section/UserMenu.tsx
@@ -41,7 +41,6 @@ export default function UserMenu({ isNotificationOpen, setIsNotificationOpen, is
     } catch (error) {
       console.error('로그아웃 API 실패:', error)
     } finally {
-      // API 성공/실패 상관없이 로컬 상태 정리
       setIsUserMenuOpen(false)
       clearAll()
     }

--- a/src/pages/community/components/CommentList.tsx
+++ b/src/pages/community/components/CommentList.tsx
@@ -1,8 +1,13 @@
 import { useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
-import { fetchReplies } from '@src/api/community'
-import type { Comment } from '@src/types'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { deleteReply, fetchReplies, postReply } from '@src/api/community'
+import type { Comment, CommentPostRequestData } from '@src/types'
 import { CommentItem } from './CommentItem'
+import { useForm } from 'react-hook-form'
+
+export interface ReplyRequestFormValues {
+  content: string
+}
 
 interface CommentListProps {
   comments: Comment[]
@@ -10,7 +15,19 @@ interface CommentListProps {
 }
 
 export function CommentList({ comments, postId }: CommentListProps) {
+  const queryClient = useQueryClient()
+  const {
+    handleSubmit, // form onSubmit에 들어가는 함수 : 제출 시 실행할 함수를 감싸주는 함수
+    register, // onChange 등의 이벤트 객체 생성 : input에 "이 필드는 폼의 어떤 이름이다"라고 연결해주는 함수
+    reset,
+  } = useForm<ReplyRequestFormValues>({
+    mode: 'onChange',
+    defaultValues: {
+      content: '',
+    },
+  })
   const [openRepliesCommentId, setOpenRepliesCommentId] = useState<number | null>(null)
+  const [replyingToId, setReplyingToId] = useState<number | null>(null)
 
   const { data: repliesData } = useQuery({
     queryKey: ['community', postId, 'replies', openRepliesCommentId],
@@ -18,31 +35,103 @@ export function CommentList({ comments, postId }: CommentListProps) {
     enabled: !!openRepliesCommentId,
   })
 
+  const replyMutation = useMutation({
+    mutationFn: (requestData: CommentPostRequestData) => postReply(requestData, postId),
+    onSuccess: (_data, variables) => {
+      const parentId = variables.parentId
+      // 대댓글 목록 refetch
+      queryClient.invalidateQueries({ queryKey: ['community', postId, 'replies', parentId] })
+      // 댓글 목록도 refetch (childrenCount 업데이트를 위해)
+      queryClient.invalidateQueries({ queryKey: ['community', postId, 'comments'] })
+      // 폼 초기화 및 닫기
+      reset()
+      setReplyingToId(null)
+      // 대댓글 목록 열기
+      setOpenRepliesCommentId(parentId)
+    },
+    onError: () => {
+      alert('답글 등록에 실패했습니다.')
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (commentId: number) => deleteReply(commentId),
+    onSuccess: () => {
+      // 댓글 목록 refetch
+      queryClient.invalidateQueries({ queryKey: ['community', postId, 'comments'] })
+      // 대댓글 목록도 refetch
+      queryClient.invalidateQueries({ queryKey: ['community', postId, 'replies'] })
+    },
+    onError: () => {
+      alert('댓글 삭제에 실패했습니다.')
+    },
+  })
+  const handleOpenReplyForm = (commentId: number) => {
+    if (replyingToId === commentId) {
+      setReplyingToId(null)
+      reset() // 폼 초기화
+    } else {
+      setReplyingToId(commentId)
+    }
+  }
   const handleToggleReplies = (commentId: number) => {
     setOpenRepliesCommentId(openRepliesCommentId === commentId ? null : commentId)
   }
 
+  const onSubmit = (data: ReplyRequestFormValues) => {
+    if (!replyingToId) return
+    const requestData: CommentPostRequestData = {
+      content: data.content,
+      parentId: replyingToId,
+    }
+    replyMutation.mutate(requestData)
+  }
+
   return (
-    <ul className="flex flex-col gap-3.5">
-      {comments.map((comment) => (
-        <li key={comment.id}>
+    <ul className="flex flex-col">
+      {comments.map((comment, index) => (
+        <li key={comment.id} className="flex flex-col">
           <CommentItem
             comment={comment}
             hasChildren={comment.hasChildren}
             childrenCount={comment.childrenCount}
             onToggleReplies={() => handleToggleReplies(comment.id)}
             isRepliesOpen={openRepliesCommentId === comment.id}
+            showBorder={index !== 0}
+            onHandleReply={() => handleOpenReplyForm(comment.id)}
+            onDelete={(commentId) => deleteMutation.mutate(commentId)}
           />
 
           {/* 대댓글 목록 */}
-          {openRepliesCommentId === comment.id && repliesData?.comments && (
-            <ul className="flex flex-col gap-2 pl-4">
-              {repliesData.comments.map((reply) => (
-                <li key={reply.id}>
-                  <CommentItem comment={reply} isReply />
-                </li>
-              ))}
-            </ul>
+          <div className={`grid transition-all duration-300 ${openRepliesCommentId === comment.id ? 'mt-3.5 grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
+            <div className="overflow-hidden">
+              {openRepliesCommentId === comment.id && repliesData?.comments && (
+                <ul className="flex flex-col gap-2 pb-3.5 pl-10">
+                  {repliesData.comments.map((reply, index) => (
+                    <li key={reply.id}>
+                      <CommentItem comment={reply} isReply showBorder={index !== 0} onDelete={(commentId) => deleteMutation.mutate(commentId)} />
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+          {replyingToId === comment.id && (
+            <div className="pb-3.5 pl-10">
+              <form className="bg-primary-50 rounded-lg pt-5 pr-6 pb-4 pl-4" onSubmit={handleSubmit(onSubmit)}>
+                <fieldset>
+                  <legend className="sr-only">답글 작성폼</legend>
+                  <textarea id={String(comment.id)} placeholder="답글을 입력하세요" className="w-full resize-none" {...register('content')} />
+
+                  <div className="flex items-center justify-end gap-3.5">
+                    <button className="cursor-pointer text-sm" type="button">
+                      취소
+                    </button>
+                    <button className="cursor-pointer text-sm">등록</button>
+                  </div>
+                </fieldset>
+              </form>
+            </div>
           )}
         </li>
       ))}

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -21,6 +21,9 @@ interface UserState {
   // ===== 계산된 값 (getter) =====
   isLogin: () => boolean
   getUserId: () => number | null
+
+  // ===== 상태 검증 =====
+  validateAuthState: () => void
 }
 
 export const useUserStore = create<UserState>()(
@@ -127,6 +130,24 @@ export const useUserStore = create<UserState>()(
       getUserId: () => {
         return get().user?.id || null
         // number | null 반환
+      },
+
+      // ===== 상태 검증 =====
+      // 앱 시작 시 토큰과 user 상태의 일관성을 검증
+      // user 정보가 있는데 토큰이 없으면 user 정보도 초기화
+      validateAuthState: () => {
+        const { user, accessToken, refreshToken } = get()
+
+        // 토큰이 없는데 user 정보가 있는 경우 → 상태 불일치
+        if (user && (!accessToken || !refreshToken)) {
+          console.warn('[Auth] 상태 불일치 감지: 토큰 없이 user 정보 존재. 상태 초기화.')
+          set({
+            user: null,
+            accessToken: null,
+            refreshToken: null,
+            redirectUrl: null,
+          })
+        }
       },
     }),
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -523,6 +523,32 @@ export interface Comment {
   childrenCount: number
 }
 
+export interface CommentPostRequestData {
+  content: string
+  parentId: number
+}
+
+export interface CommentPostResponse {
+  code: string
+  message: string
+  data: {
+    id: number
+    postId: number
+    authorId: number
+    authorNickname: string
+    authorProfileImageUrl: string
+    parentId: number
+    content: string
+    depth: number
+    createdAt: string
+    updatedAt: string
+  }
+}
+export interface CommentDeleteResponse {
+  code: string
+  message: string
+  data: null
+}
 // export interface ProductDetailItemResponse {
 //   code: string
 //   message: string


### PR DESCRIPTION
## 📌 개요

- 커뮤니티 게시글의 댓글 및 대댓글 등록/삭제 기능 구현

## 🔧 작업 내용

- [x] 댓글 등록 API 연동 (`postReply`)
- [x] 댓글 삭제 API 연동 (`deleteReply`)
- [x] 대댓글(답글) 작성 폼 UI 구현
- [x] 본인 댓글 삭제 기능 (더보기 메뉴)
- [x] CommentItem/CommentList 컴포넌트 개선

## 📎 관련 이슈

Closes #269

## 📸 스크린샷 (선택)

(필요시 추가)

## 💬 리뷰어 참고 사항

- 댓글 작성 시 쿼리 무효화 로직 확인 부탁드립니다