### PR TITLE
feat: 커뮤니티 댓글 작성 폼 및 프로필 아바타 컴포넌트 구현(#271)

### DIFF
--- a/src/components/commons/ProfileAvatar.tsx
+++ b/src/components/commons/ProfileAvatar.tsx
@@ -1,0 +1,32 @@
+import { cn } from '@src/utils/cn'
+
+interface ProfileAvatarProps {
+  imageUrl?: string | null
+  nickname: string
+  size?: 'sm' | 'md' | 'lg'
+  className?: string
+}
+
+const sizeClasses = {
+  sm: 'h-8 w-8 text-sm',
+  md: 'h-10 w-10 text-base',
+  lg: 'h-12 w-12 text-lg',
+}
+
+export function ProfileAvatar({ imageUrl, nickname, size = 'md', className }: ProfileAvatarProps) {
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-center overflow-hidden rounded-full bg-[#FACC15]',
+        sizeClasses[size],
+        className
+      )}
+    >
+      {imageUrl ? (
+        <img src={imageUrl} alt={nickname} className="h-full w-full object-cover" />
+      ) : (
+        <span>{nickname.charAt(0).toUpperCase()}</span>
+      )}
+    </div>
+  )
+}

--- a/src/components/header/components/user-section/UserMenu.tsx
+++ b/src/components/header/components/user-section/UserMenu.tsx
@@ -1,13 +1,12 @@
 // import Icon from '@components/commons/Icon'
 import { Z_INDEX } from '@constants/ui'
 import { cn } from '@utils/cn'
-import CuddleMarketLogo from '@assets/images/CuddleMarketLogoImage.png'
 import { UserRound as UserRoundIcon, LogOut as LogOutIcon } from 'lucide-react'
-import { useState, useEffect } from 'react'
 import { ROUTES } from '@src/constants/routes'
 import { useUserStore } from '@src/store/userStore'
 import { logout } from '@src/api/auth'
 import { useLoginModalStore } from '@src/store/modalStore'
+import { ProfileAvatar } from '@src/components/commons/ProfileAvatar'
 import { Link } from 'react-router-dom'
 
 interface UserMenuProps {
@@ -20,12 +19,7 @@ interface UserMenuProps {
 
 export default function UserMenu({ isNotificationOpen, setIsNotificationOpen, isUserMenuOpen, setIsUserMenuOpen }: UserMenuProps) {
   const { user, clearAll } = useUserStore()
-  const [imgSrc, setImgSrc] = useState(user?.profileImageUrl || CuddleMarketLogo)
   const { openLogoutModal } = useLoginModalStore()
-
-  useEffect(() => {
-    setImgSrc(user?.profileImageUrl || CuddleMarketLogo)
-  }, [user?.profileImageUrl])
 
   const handleAvatarToggle = () => {
     if (isNotificationOpen) {
@@ -54,17 +48,7 @@ export default function UserMenu({ isNotificationOpen, setIsNotificationOpen, is
 
   return (
     <div className="relative flex cursor-pointer items-center gap-2" onClick={handleAvatarToggle}>
-      <div className="bg-primary-100 flex h-8 w-8 items-center justify-center overflow-hidden rounded-full">
-        <img
-          src={imgSrc}
-          alt={user?.nickname}
-          className="h-full w-full object-cover"
-          onError={() => {
-            setImgSrc(CuddleMarketLogo)
-          }}
-        />
-      </div>
-
+      <ProfileAvatar imageUrl={user?.profileImageUrl} nickname={user?.nickname || ''} size="sm" />
       <p className="text-base text-gray-700">{user?.nickname}</p>
       {isUserMenuOpen && (
         <div

--- a/src/pages/community/components/CommentForm.tsx
+++ b/src/pages/community/components/CommentForm.tsx
@@ -1,0 +1,39 @@
+import type { UseFormRegister } from 'react-hook-form'
+import { Button } from '@src/components/commons/button/Button'
+
+interface CommentFormValues {
+  content: string
+}
+
+interface CommentFormProps {
+  id: string
+  placeholder: string
+  legendText: string
+  register: UseFormRegister<CommentFormValues>
+  onSubmit: () => void
+  onCancel?: () => void
+}
+
+export function CommentForm({ id, placeholder, legendText, register, onSubmit, onCancel }: CommentFormProps) {
+  return (
+    <form className="bg-primary-50 rounded-lg pt-5 pr-6 pb-4 pl-4" onSubmit={onSubmit}>
+      <fieldset>
+        <legend className="sr-only">{legendText}</legend>
+        <textarea
+          id={id}
+          placeholder={placeholder}
+          className="bg-primary-50 w-full resize-none focus:outline-none"
+          {...register('content')}
+        />
+        <div className="flex items-center justify-end gap-3.5">
+          <Button size="md" className="cursor-pointer rounded-full bg-gray-100 text-sm shadow" type="button" onClick={onCancel}>
+            취소
+          </Button>
+          <Button size="md" className="cursor-pointer rounded-full bg-white text-sm shadow" type="submit">
+            등록
+          </Button>
+        </div>
+      </fieldset>
+    </form>
+  )
+}

--- a/src/pages/community/components/CommentItem.tsx
+++ b/src/pages/community/components/CommentItem.tsx
@@ -3,6 +3,7 @@ import { cn } from '@src/utils/cn'
 import type { Comment } from '@src/types'
 import { EllipsisVertical } from 'lucide-react'
 import { IconButton } from '@src/components/commons/button/IconButton'
+import { ProfileAvatar } from '@src/components/commons/ProfileAvatar'
 import { useState } from 'react'
 import { useUserStore } from '@src/store/userStore'
 
@@ -43,14 +44,7 @@ export function CommentItem({
 
   return (
     <div className={cn('flex items-start gap-3.5', showBorder && 'border-t border-gray-300 pt-3.5', !isReply && !isRepliesOpen && 'pb-3.5')}>
-      {/* 프로필 이미지 */}
-      <div className={`flex h-8 w-8 items-center justify-center overflow-hidden rounded-full bg-[#FACC15]`}>
-        {comment.authorProfileImageUrl ? (
-          <img src={comment.authorProfileImageUrl} alt={comment.authorNickname} className="h-full w-full object-cover" />
-        ) : (
-          <p>{comment.authorNickname.charAt(0).toUpperCase()}</p>
-        )}
-      </div>
+      <ProfileAvatar imageUrl={comment.authorProfileImageUrl} nickname={comment.authorNickname} size="sm" />
 
       {/* 유저 정보 및 내용 */}
       <div className="flex flex-col justify-center gap-1">

--- a/src/pages/community/components/CommentList.tsx
+++ b/src/pages/community/components/CommentList.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { deleteReply, fetchReplies, postReply } from '@src/api/community'
 import type { Comment, CommentPostRequestData } from '@src/types'
 import { CommentItem } from './CommentItem'
+import { CommentForm } from './CommentForm'
 import { useForm } from 'react-hook-form'
 
 export interface ReplyRequestFormValues {
@@ -47,7 +48,7 @@ export function CommentList({ comments, postId }: CommentListProps) {
       reset()
       setReplyingToId(null)
       // 대댓글 목록 열기
-      setOpenRepliesCommentId(parentId)
+      setOpenRepliesCommentId(parentId ?? null)
     },
     onError: () => {
       alert('답글 등록에 실패했습니다.')
@@ -118,19 +119,14 @@ export function CommentList({ comments, postId }: CommentListProps) {
           </div>
           {replyingToId === comment.id && (
             <div className="pb-3.5 pl-10">
-              <form className="bg-primary-50 rounded-lg pt-5 pr-6 pb-4 pl-4" onSubmit={handleSubmit(onSubmit)}>
-                <fieldset>
-                  <legend className="sr-only">답글 작성폼</legend>
-                  <textarea id={String(comment.id)} placeholder="답글을 입력하세요" className="w-full resize-none" {...register('content')} />
-
-                  <div className="flex items-center justify-end gap-3.5">
-                    <button className="cursor-pointer text-sm" type="button">
-                      취소
-                    </button>
-                    <button className="cursor-pointer text-sm">등록</button>
-                  </div>
-                </fieldset>
-              </form>
+              <CommentForm
+                id={String(comment.id)}
+                placeholder="답글을 입력하세요"
+                legendText="대댓글 작성폼"
+                register={register}
+                onSubmit={handleSubmit(onSubmit)}
+                onCancel={() => handleOpenReplyForm(comment.id)}
+              />
             </div>
           )}
         </li>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -525,7 +525,7 @@ export interface Comment {
 
 export interface CommentPostRequestData {
   content: string
-  parentId: number
+  parentId?: number
 }
 
 export interface CommentPostResponse {


### PR DESCRIPTION
## 📌 개요

- 커뮤니티 상세 페이지에서 댓글을 작성할 수 있는 폼 컴포넌트와 재사용 가능한 프로필 아바타 컴포넌트를 구현

## 🔧 작업 내용

- [x] CommentForm 컴포넌트 생성 (댓글 작성 폼)
- [x] ProfileAvatar 공통 컴포넌트 분리
- [x] CommunityDetail 페이지에 댓글 등록 API 연동
- [x] CommentList, CommentItem 컴포넌트 정리

## 📎 관련 이슈

Closes #271

## 📸 스크린샷 (선택)

(필요시 추가)

## 💬 리뷰어 참고 사항

- ProfileAvatar 컴포넌트는 UserMenu에서도 재사용 가능하도록 공통 컴포넌트로 분리했습니다