### PR TITLE
feat: 찜하기 기능 개선 및 상품 목록 API 수정(#277)

### DIFF
--- a/src/api/products.ts
+++ b/src/api/products.ts
@@ -11,10 +11,7 @@ import type {
   RequestProductPostRequestData,
 } from '../types'
 import { api } from './api'
-import axios from 'axios'
 import type { TransactionStatus } from '@src/constants/constants'
-
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
 
 // 상품 목록 조회
 export const fetchAllProducts = async (
@@ -80,7 +77,7 @@ export const fetchAllProducts = async (
     params.append('sortOrder', sortOrder)
   }
 
-  const response = await axios.get<ProductResponse>(`${API_BASE_URL}/products/search?${params.toString()}`)
+  const response = await api.get<ProductResponse>(`/products/search?${params.toString()}`)
 
   return {
     data: response.data,

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -161,6 +161,7 @@ function Home() {
 
     // 새로운 데이터를 가져오는 동안 이전 데이터 유지
     placeholderData: (previousData) => previousData,
+    refetchOnMount: 'always',
   })
 
   // 모든 페이지의 상품을 하나의 배열로 합치기


### PR DESCRIPTION
## 📌 개요

- 찜하기 기능에 Optimistic Update를 적용하여 즉각적인 UI 반응 제공
- 상품 목록 API 호출 방식 개선

## 🔧 작업 내용

- [x] useFavorite 훅에 Optimistic Update 적용
- [x] initialIsFavorite 변경 시 로컬 state 동기화
- [x] 찜하기 성공 시 관련 쿼리 무효화 추가
- [x] 상품 목록 API를 api 인스턴스로 변경
- [x] Home 페이지 refetchOnMount 설정 추가

## 📎 관련 이슈

Closes #277

## 📸 스크린샷 (선택)

(필요시 추가)

## 💬 리뷰어 참고 사항

- Optimistic Update로 찜하기 버튼 클릭 시 즉시 UI가 변경되며, API 실패 시 원래 상태로 롤백됩니다