### PR TITLE
refactor: 커뮤니티 페이지 코드 정리(#283)

### DIFF
--- a/src/pages/community/CommunityPage.tsx
+++ b/src/pages/community/CommunityPage.tsx
@@ -162,16 +162,6 @@ export default function CommunityPage() {
             {/* 모바일: 필터 영역 */}
             {!isMd && (
               <div className="sticky top-32 z-25 bg-white">
-                {/* 토글 버튼 */}
-                {/* <button
-                  type="button"
-                  onClick={toggleFilter}
-                  className="flex w-full items-center justify-center gap-2 border-b border-gray-200 py-2 text-gray-600"
-                >
-                  <span className="text-sm">{isFilterCollapsed ? '필터 펼치기' : '필터 접기'}</span>
-                  {isFilterCollapsed ? <ChevronDown size={16} /> : <ChevronUp size={16} />}
-                </button> */}
-
                 {/* 접히는 필터 영역 */}
                 <div className={cn('overflow-hidden transition-all duration-300 ease-out', isFilterCollapsed ? 'max-h-0' : 'max-h-[300px]')}>
                   <div className="flex items-center justify-between border-b border-gray-200 p-3.5">

--- a/src/pages/community/components/CommunityTabs.tsx
+++ b/src/pages/community/components/CommunityTabs.tsx
@@ -17,7 +17,6 @@ interface TabsProps {
 
 export function CommunityTabs({ tabs, activeTab, onTabChange, ariaLabel, excludeTabId }: TabsProps) {
   const filteredTabs = excludeTabId ? tabs.filter((tab) => tab.id !== excludeTabId) : tabs
-
   return (
     <div role="tablist" aria-label={ariaLabel} className={cn('border-b-primary-200 flex w-fit gap-2.5 md:border-b-2 md:pb-1')}>
       {filteredTabs.map((tab) => (


### PR DESCRIPTION
## 📌 개요

- 커뮤니티 페이지의 불필요한 주석 코드와 공백을 정리합니다.

## 🔧 작업 내용

- [x] 주석 처리된 토글 버튼 코드 제거
- [x] 불필요한 공백 라인 제거

## 📎 관련 이슈

- Close #283

## 📸 스크린샷 (선택)

- 해당 없음 (코드 정리)

## 💬 리뷰어 참고 사항

- 기능 변경 없이 코드 정리만 수행했습니다.