### PR TITLE
feat: 마이페이지 모바일 UI 구현(#284)

### DIFF
--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@src/components/commons/button/Button'
 import { cn } from '@src/utils/cn'
-
+import { useMediaQuery } from '@src/hooks/useMediaQuery'
 interface Tab {
   id: string
   label: string
@@ -17,20 +17,22 @@ interface TabsProps {
 
 export function Tabs({ tabs, activeTab, onTabChange, ariaLabel, excludeTabId }: TabsProps) {
   const filteredTabs = excludeTabId ? tabs.filter((tab) => tab.id !== excludeTabId) : tabs
-
+  const isMd = useMediaQuery('(min-width: 768px)')
   return (
-    <div role="tablist" aria-label={ariaLabel} className={cn('border-b-primary-200 flex gap-2.5 border-b-2 pb-1')}>
+    <div role="tablist" aria-label={ariaLabel} className={cn('border-b-primary-200 flex gap-1 px-3.5 md:gap-2.5 md:border-b-2 md:p-0 md:pb-1')}>
       {filteredTabs.map((tab) => (
         <Button
           key={tab.id}
           id={tab.id}
-          size="md"
+          size={isMd ? 'md' : 'sm'}
           role="tab"
           type="button"
           onClick={() => onTabChange(tab.id)}
           className={cn(
-            'flex-1 cursor-pointer rounded-2xl text-base',
-            activeTab === tab.id ? 'bg-primary-300 font-bold text-white' : 'hover:bg-primary-100 text-gray-900'
+            'flex-1 cursor-pointer rounded-full bg-white text-base whitespace-nowrap md:rounded-2xl md:bg-transparent',
+            activeTab === tab.id
+              ? 'md:bg-primary-300 bg-primary-500 font-bold text-white'
+              : 'md:hover:bg-primary-100 bg-gray-100 text-gray-900 md:bg-transparent'
           )}
           aria-selected={activeTab === tab.id}
           aria-controls={`panel-${tab.code}`}

--- a/src/components/profile/ProfileData.tsx
+++ b/src/components/profile/ProfileData.tsx
@@ -8,6 +8,7 @@ import { Button } from '@src/components/commons/button/Button'
 import { userUnBlocked } from '@src/api/profile'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { ROUTES } from '@src/constants/routes'
+import { useMediaQuery } from '@src/hooks/useMediaQuery'
 
 export interface MyPageData {
   id: number
@@ -36,7 +37,7 @@ export default function ProfileData({ setIsWithdrawModalOpen, setIsReportModalOp
   const { user } = useUserStore()
   const isMyProfile = user?.id === data?.id
   const queryClient = useQueryClient()
-
+  const isMd = useMediaQuery('(min-width: 768px)')
   const { mutate: unblockUser } = useMutation({
     mutationFn: () => userUnBlocked(Number(data?.id)),
     onSuccess: () => {
@@ -46,11 +47,14 @@ export default function ProfileData({ setIsWithdrawModalOpen, setIsReportModalOp
       console.error('차단 해제 실패:', error)
     },
   })
+
+  const formattedJoinDate = data?.createdAt ? formatJoinDate(data.createdAt) : ''
+
   return (
-    <section className="border-border flex h-fit min-w-72 flex-col rounded-xl border p-5">
+    <section className="flex h-fit flex-col rounded-none border-b border-gray-200 px-5 py-0 pt-5 md:max-w-72 md:min-w-72 md:rounded-xl md:border md:py-5">
       <div className="text-text-primary sticky top-24 flex flex-col rounded-xl">
-        <div className="flex flex-col gap-6 border-b border-gray-300 pb-6">
-          <div className="flex flex-col items-center gap-3.5 pb-7">
+        <div className="flex flex-col gap-3 md:gap-6">
+          <div className="flex flex-row items-center gap-3.5 md:flex-col">
             <div className="flex h-16 w-16 items-center justify-center overflow-hidden rounded-full bg-[#FACC15]">
               {data?.profileImageUrl ? (
                 <img src={data.profileImageUrl} alt={data.nickname} className="h-full w-full object-cover" />
@@ -58,92 +62,106 @@ export default function ProfileData({ setIsWithdrawModalOpen, setIsReportModalOp
                 <div className="heading-h4">{data?.nickname.charAt(0).toUpperCase()}</div>
               )}
             </div>
-            <h3 className="heading-h5 text-text-primary">{data?.nickname}</h3>
-            <p className="w-full text-sm font-semibold text-gray-500">{data?.introduction || '소개글을 작성해주세요'}</p>
-          </div>
-          {isMyProfile ? (
-            <div className="flex flex-col gap-3.5">
-              <div className="flex flex-col gap-2.5">
-                <ProductMetaItem icon={MapPin} iconSize={17} label={`${data?.addressSido} ${data?.addressGugun}`} className="gap-2" />
-                <ProductMetaItem
-                  icon={Calendar}
-                  iconSize={17}
-                  label={`가입일: ${data?.createdAt ? formatJoinDate(data.createdAt) : ''}`}
-                  className="gap-2"
-                />
+
+            {isMd ? (
+              // 데스크탑 공통 표시
+              <h3 className="heading-h5 text-text-primary">{data?.nickname}</h3>
+            ) : (
+              // 모바일 내 정보
+              <div>
+                <h3 className="heading-h5 text-text-primary pb-0.5">{data?.nickname}</h3>
+                <p className="text-sm font-semibold text-gray-500">
+                  {data?.addressSido} {data?.addressGugun}
+                </p>
+                <p className="text-sm font-semibold text-gray-500">{formattedJoinDate} 가입</p>
               </div>
-              <Link
-                to={ROUTES.PROFILE_UPDATE}
-                className="bg-primary-200 flex items-center justify-center gap-2.5 rounded-lg px-3 py-2 text-white transition-all"
-              >
-                <Settings size={19} />
-                <span>내 정보 수정</span>
-              </Link>
-            </div>
-          ) : (
-            <div className="flex flex-col gap-3.5">
-              {data?.isBlocked ? (
-                <>
-                  <div className="bg-danger-100/30 border-danger-100 text-danger-800 flex items-center justify-center gap-2 rounded-lg border p-2.5 font-medium">
-                    <ShieldAlert />
-                    <span>이 사용자를 차단했습니다</span>
+            )}
+          </div>
+          <p className="w-full text-sm font-semibold text-gray-500">{data?.introduction || '소개글을 작성해주세요'}</p>
+          {/* 데스크탑 내 정보 */}
+          {isMyProfile && (
+            <>
+              <div className="flex flex-col gap-3.5">
+                {isMd && (
+                  <div className="flex flex-col gap-2.5">
+                    <ProductMetaItem icon={MapPin} iconSize={17} label={`${data?.addressSido} ${data?.addressGugun}`} className="gap-2" />
+                    <ProductMetaItem icon={Calendar} iconSize={17} label={`가입일: ${formattedJoinDate}`} className="gap-2" />
                   </div>
-                  <Button
-                    icon={LockOpen}
-                    onClick={() => unblockUser()}
-                    className="bg-primary-200 flex cursor-pointer items-center justify-center gap-2.5 rounded-lg px-3 py-2 text-white transition-all"
-                  >
-                    차단 해제하기
-                  </Button>
-                </>
-              ) : (
-                <Link to="#" className="bg-primary-200 flex items-center justify-center gap-2.5 rounded-lg px-3 py-2 text-white transition-all">
-                  <MessageCircle size={19} />
-                  <span>채팅하기</span>
+                )}
+                <Link
+                  to={ROUTES.PROFILE_UPDATE}
+                  className="bg-primary-200 flex items-center justify-center gap-2.5 rounded-lg px-3 py-2 text-white transition-all"
+                >
+                  <Settings size={19} />
+                  <span>내 정보 수정</span>
                 </Link>
-              )}
-            </div>
+              </div>
+              <button
+                type="button"
+                className="w-full cursor-pointer rounded-lg border-gray-300 pb-5 text-right text-sm text-gray-500 hover:underline md:border-t md:pt-6 md:pb-0 md:text-left"
+                onClick={() => setIsWithdrawModalOpen?.(true)}
+              >
+                회원탈퇴
+              </button>
+            </>
+          )}
+
+          {/* 다른 유저 프로필 */}
+          {!isMyProfile && (
+            <>
+              <div className="flex flex-col gap-3.5">
+                {data?.isBlocked ? (
+                  <>
+                    <div className="bg-danger-100/30 border-danger-100 text-danger-800 flex items-center justify-center gap-2 rounded-lg border p-2.5 font-medium">
+                      <ShieldAlert />
+                      <span>이 사용자를 차단했습니다</span>
+                    </div>
+                    <Button
+                      icon={LockOpen}
+                      onClick={() => unblockUser()}
+                      className="bg-primary-200 flex cursor-pointer items-center justify-center gap-2.5 rounded-lg px-3 py-2 text-white transition-all"
+                    >
+                      차단 해제하기
+                    </Button>
+                  </>
+                ) : (
+                  <Link to="#" className="bg-primary-200 flex items-center justify-center gap-2.5 rounded-lg px-3 py-2 text-white transition-all">
+                    <MessageCircle size={19} />
+                    <span>채팅하기</span>
+                  </Link>
+                )}
+              </div>
+              <div className="flex items-center justify-between">
+                {data?.isReported ? (
+                  <div className="flex w-full items-center justify-start gap-2 px-3 py-1.5 text-sm text-gray-500">
+                    <Flag size={16} className="text-gray-500" />
+                    <span>신고완료</span>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    className="flex w-full cursor-pointer items-center justify-start gap-2 rounded-lg border-t border-gray-300 bg-transparent px-3 py-1.5 pt-6 text-sm text-gray-500 hover:bg-gray-100"
+                    onClick={() => setIsReportModalOpen?.(true)}
+                  >
+                    <Flag size={16} />
+                    신고하기
+                  </button>
+                )}
+
+                {!data?.isBlocked && (
+                  <button
+                    type="button"
+                    className="flex w-full cursor-pointer items-center justify-center gap-2 rounded-lg bg-transparent px-3 py-1.5 text-sm text-gray-500 hover:bg-gray-100"
+                    onClick={() => setIsBlockModalOpen?.(true)}
+                  >
+                    <Ban size={16} />
+                    차단하기
+                  </button>
+                )}
+              </div>
+            </>
           )}
         </div>
-
-        {isMyProfile ? (
-          <button
-            type="button"
-            className="w-full cursor-pointer rounded-lg pt-6 text-left text-sm text-gray-500 hover:underline"
-            onClick={() => setIsWithdrawModalOpen?.(true)}
-          >
-            회원탈퇴
-          </button>
-        ) : (
-          <div className="flex items-center justify-between pt-6">
-            {data?.isReported ? (
-              <div className="flex w-full items-center justify-start gap-2 px-3 py-1.5 text-sm text-gray-500">
-                <Flag size={16} className="text-gray-500" />
-                <span>신고완료</span>
-              </div>
-            ) : (
-              <button
-                type="button"
-                className="flex w-full cursor-pointer items-center justify-start gap-2 rounded-lg bg-transparent px-3 py-1.5 text-sm text-gray-500 hover:bg-gray-100"
-                onClick={() => setIsReportModalOpen?.(true)}
-              >
-                <Flag size={16} />
-                신고하기
-              </button>
-            )}
-
-            {!data?.isBlocked && (
-              <button
-                type="button"
-                className="flex w-full cursor-pointer items-center justify-center gap-2 rounded-lg bg-transparent px-3 py-1.5 text-sm text-gray-500 hover:bg-gray-100"
-                onClick={() => setIsBlockModalOpen?.(true)}
-              >
-                <Ban size={16} />
-                차단하기
-              </button>
-            )}
-          </div>
-        )}
       </div>
     </section>
   )

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -175,7 +175,6 @@ export type CategoryName = (typeof PRODUCT_CATEGORIES)[number]['name']
 export const STATUS_EN_TO_KO: Array<{ value: string | null; name: string; bgColor: string }> = [
   { value: 'SELLING', name: '판매중', bgColor: 'bg-onsale' },
   { value: 'RESERVED', name: '예약중', bgColor: 'bg-reserved' },
-  { value: null, name: '요청중', bgColor: 'bg-requesting' },
   { value: 'COMPLETED', name: '판매완료', bgColor: 'bg-complete' },
 ]
 export type TransactionStatus = 'SELLING' | 'RESERVED' | 'COMPLETED'

--- a/src/hooks/useScrollDirection.ts
+++ b/src/hooks/useScrollDirection.ts
@@ -24,7 +24,7 @@ export function useScrollDirection({ threshold = 10, ignoreTime = 300 }: UseScro
       const prevScrollY = lastScrollY.current
       const diff = currentScrollY - prevScrollY
 
-      console.log('scrollY:', currentScrollY, 'diff:', diff, 'isCollapsed:', isCollapsedRef.current)
+      // console.log('scrollY:', currentScrollY, 'diff:', diff, 'isCollapsed:', isCollapsedRef.current)
 
       // threshold 이상 스크롤했을 때만 상태 변경
       if (Math.abs(diff) >= threshold) {

--- a/src/pages/UserPage.tsx
+++ b/src/pages/UserPage.tsx
@@ -51,8 +51,8 @@ function UserPage() {
 
   return (
     <>
-      <div className="bg-bg pb-4xl pt-8">
-        <div className="px-lg mx-auto flex max-w-7xl gap-8">
+      <div className="bg-bg pb-4xl pt-0 md:pt-8">
+        <div className="mx-auto flex max-w-7xl flex-col gap-8 md:flex-row">
           <ProfileData
             setIsWithdrawModalOpen={setIsWithdrawModalOpen}
             setIsReportModalOpen={setIsReportModalOpen}
@@ -82,12 +82,7 @@ function UserPage() {
           </section>
         </div>
       </div>
-      <UserReportModal
-        isOpen={isReportModalOpen}
-        onCancel={() => setIsReportModalOpen(false)}
-        userNickname={userData.nickname}
-        userId={Number(id)}
-      />
+      <UserReportModal isOpen={isReportModalOpen} onCancel={() => setIsReportModalOpen(false)} userNickname={userData.nickname} userId={Number(id)} />
       <BlockModal isOpen={isBlockModalOpen} onCancel={() => setIsBlockModalOpen(false)} userNickname={userData.nickname} userId={Number(id)} />
     </>
   )

--- a/src/pages/my-page/MyPage.tsx
+++ b/src/pages/my-page/MyPage.tsx
@@ -183,10 +183,10 @@ function MyPage() {
 
   return (
     <>
-      <div className="bg-bg pb-4xl pt-8">
-        <div className="px-lg mx-auto flex max-w-7xl gap-8">
+      <div className="bg-bg pb-4xl pt-0 md:pt-8">
+        <div className="mx-auto flex max-w-7xl flex-col gap-3.5 md:flex-row md:gap-8">
           <ProfileData setIsWithdrawModalOpen={setIsWithdrawModalOpen} data={myData!} />
-          <section className="flex flex-1 flex-col gap-7">
+          <section className="flex flex-1 flex-col gap-3.5 md:gap-7">
             <Tabs
               tabs={MY_PAGE_TABS}
               activeTab={activeMyPageTab}

--- a/src/pages/my-page/components/MyPagePanel.tsx
+++ b/src/pages/my-page/components/MyPagePanel.tsx
@@ -100,7 +100,7 @@ export default function MyPagePanel({
       role="tabpanel"
       id={`panel-${activeTabCode}`}
       aria-labelledby={activeMyPageTab}
-      className="border-border flex flex-col gap-6 rounded-xl border p-5"
+      className="flex flex-col gap-6 rounded-xl border-gray-200 px-5 py-7 md:border md:p-5"
     >
       {config ? (
         <MyPageTitle
@@ -109,16 +109,17 @@ export default function MyPagePanel({
           description={config.description}
           buttonLabel={config.buttonLabel}
           navigateTo={config.navigateTo}
+          buttonClassname="text-base"
         />
       ) : (
         <MyPageTitle heading="차단 유저" description={`차단한 유저 ${myBlockedTotal ?? 0}명`} />
       )}
 
-      <div className="gap-lg flex max-h-[60vh] flex-col overflow-y-auto">
+      <div className="gap-lg scrollbar-hide flex max-h-[60vh] flex-col overflow-y-auto">
         {activeMyPageTab !== 'tab-blocked' ? (
           productData?.content?.length ? (
             <>
-              <ul className="flex flex-col items-center justify-start gap-2.5">
+              <ul className="flex flex-col items-center justify-start divide-y divide-gray-200 md:gap-2.5 md:divide-y-0">
                 {productData.content.map((product) => (
                   <MyList key={product.id} {...product} activeTab={activeMyPageTab} handleConfirmModal={handleConfirmModal} />
                 ))}

--- a/src/pages/my-page/components/MyPageTitle.tsx
+++ b/src/pages/my-page/components/MyPageTitle.tsx
@@ -1,16 +1,18 @@
 import { Button } from '@src/components/commons/button/Button'
 import { Plus } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
+import { cn } from '@src/utils/cn'
 
 interface MyPageTitleProps {
   heading: string
   count?: number
   description: string
   buttonLabel?: string
+  buttonClassname?: string
   navigateTo?: string
 }
 
-export default function MyPageTitle({ heading, count, description, buttonLabel, navigateTo }: MyPageTitleProps) {
+export default function MyPageTitle({ heading, count, description, buttonLabel, navigateTo, buttonClassname }: MyPageTitleProps) {
   const navigate = useNavigate()
   const goToProductPost = () => {
     if (navigateTo) {
@@ -20,11 +22,17 @@ export default function MyPageTitle({ heading, count, description, buttonLabel, 
   return (
     <div className="flex justify-between">
       <div>
-        <h4 className="flex items-center gap-2">{heading}</h4>
+        <h4 className="flex items-center gap-2 text-lg font-bold">{heading}</h4>
         {description && <p>{count !== undefined ? `총 ${count}${description}` : description}</p>}
       </div>
       {buttonLabel && (
-        <Button size="sm" icon={Plus} className="bg-primary-200 h-fit cursor-pointer font-bold text-white" onClick={goToProductPost} type="button">
+        <Button
+          size="sm"
+          icon={Plus}
+          className={cn('bg-primary-200 h-fit cursor-pointer font-bold text-white', buttonClassname)}
+          onClick={goToProductPost}
+          type="button"
+        >
           {buttonLabel}
         </Button>
       )}


### PR DESCRIPTION
## 📌 개요

- 마이페이지 및 관련 컴포넌트의 모바일 반응형 UI를 구현합니다.

## 🔧 작업 내용

- [x] MyPage, UserPage 레이아웃 반응형 적용
- [x] ProfileData 컴포넌트 모바일 UI 구현
- [x] MyList 컴포넌트 모바일 UI 구현 (더보기 메뉴, 상태 변경 등)
- [x] MyPagePanel, MyPageTitle 컴포넌트 모바일 스타일 적용
- [x] Tabs 컴포넌트 모바일 UI 개선
- [x] 미사용 상태값(요청중) 제거
- [x] 디버깅용 console.log 주석 처리

## 📎 관련 이슈

- Close #284

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| -       | -       |

## 💬 리뷰어 참고 사항

- 모바일 화면(768px 미만)에서 UI 확인 부탁드립니다.
- MyList 컴포넌트에 더보기 메뉴(EllipsisVertical) 추가되었습니다.