### PR TITLE
feat: 프로필 수정 페이지 모바일 UI 구현(#287)

### DIFF
--- a/src/components/profile/ProfileData.tsx
+++ b/src/components/profile/ProfileData.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import { MapPin, Calendar, Settings, MessageCircle, Flag, Ban, LockOpen, ShieldAlert } from 'lucide-react'
 import { ProductMetaItem } from '@src/components/product/ProductMetaItem'
 import { type Dispatch, type SetStateAction } from 'react'
@@ -38,6 +38,9 @@ export default function ProfileData({ setIsWithdrawModalOpen, setIsReportModalOp
   const isMyProfile = user?.id === data?.id
   const queryClient = useQueryClient()
   const isMd = useMediaQuery('(min-width: 768px)')
+  const { pathname } = useLocation()
+  const isProfileEditPage = /^\/profile-update$/.test(pathname)
+
   const { mutate: unblockUser } = useMutation({
     mutationFn: () => userUnBlocked(Number(data?.id)),
     onSuccess: () => {
@@ -88,21 +91,25 @@ export default function ProfileData({ setIsWithdrawModalOpen, setIsReportModalOp
                     <ProductMetaItem icon={Calendar} iconSize={17} label={`가입일: ${formattedJoinDate}`} className="gap-2" />
                   </div>
                 )}
-                <Link
-                  to={ROUTES.PROFILE_UPDATE}
-                  className="bg-primary-200 flex items-center justify-center gap-2.5 rounded-lg px-3 py-2 text-white transition-all"
-                >
-                  <Settings size={19} />
-                  <span>내 정보 수정</span>
-                </Link>
+                {!isProfileEditPage && (
+                  <Link
+                    to={ROUTES.PROFILE_UPDATE}
+                    className="bg-primary-200 flex items-center justify-center gap-2.5 rounded-lg px-3 py-2 text-white transition-all"
+                  >
+                    <Settings size={19} />
+                    <span>내 정보 수정</span>
+                  </Link>
+                )}
               </div>
-              <button
-                type="button"
-                className="w-full cursor-pointer rounded-lg border-gray-300 pb-5 text-right text-sm text-gray-500 hover:underline md:border-t md:pt-6 md:pb-0 md:text-left"
-                onClick={() => setIsWithdrawModalOpen?.(true)}
-              >
-                회원탈퇴
-              </button>
+              {!isProfileEditPage && (
+                <button
+                  type="button"
+                  className="w-full cursor-pointer rounded-lg border-gray-300 pb-5 text-right text-sm text-gray-500 hover:underline md:border-t md:pt-6 md:pb-0 md:text-left"
+                  onClick={() => setIsWithdrawModalOpen?.(true)}
+                >
+                  회원탈퇴
+                </button>
+              )}
             </>
           )}
 

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -11,11 +11,11 @@ export default function MainLayout() {
   const isCommunityDetailPage = /^\/community\/\d+$/.test(pathname)
   const isCommunityFormPage = /^\/community-post$/.test(pathname) || /^\/community\/\d+\/edit$/.test(pathname)
   const isCommunityListPage = /^\/community$/.test(pathname)
+  const isProfileEditPage = /^\/profile-update$/.test(pathname)
 
   // CommunityDetail: Header 전체 숨김, CommunityPage: SearchBar만 숨김
   const showHeader = !isCommunityDetailPage && !isCommunityFormPage
-  const hideSearchBar = !isMd && isCommunityListPage
-
+  const hideSearchBar = !isMd && (isCommunityListPage || isProfileEditPage)
   return (
     <div className="flex min-h-screen flex-col">
       {showHeader && <Header hideSearchBar={hideSearchBar} />}

--- a/src/pages/my-page/MyPage.tsx
+++ b/src/pages/my-page/MyPage.tsx
@@ -183,7 +183,7 @@ function MyPage() {
 
   return (
     <>
-      <div className="bg-bg pb-4xl pt-0 md:pt-8">
+      <div className="pb-4xl bg-white pt-0 md:pt-8">
         <div className="mx-auto flex max-w-7xl flex-col gap-3.5 md:flex-row md:gap-8">
           <ProfileData setIsWithdrawModalOpen={setIsWithdrawModalOpen} data={myData!} />
           <section className="flex flex-1 flex-col gap-3.5 md:gap-7">

--- a/src/pages/profile-update/ProfileUpdate.tsx
+++ b/src/pages/profile-update/ProfileUpdate.tsx
@@ -5,11 +5,12 @@ import { useQuery } from '@tanstack/react-query'
 import { fetchMyPageData } from '@src/api/products'
 import { useUserStore } from '@src/store/userStore'
 import ProfileUpdatePasswordForm from './components/ProfileUpdatePasswordForm'
+import { useMediaQuery } from '@src/hooks/useMediaQuery'
 
 function ProfileUpdate() {
   const [, setIsWithdrawModalOpen] = useState(false)
   const { user, updateUserProfile } = useUserStore()
-
+  const isMd = useMediaQuery('(min-width: 768px)')
   const { data: myData, isLoading: isLoadingMyData } = useQuery({
     queryKey: ['mypage', user?.id],
     queryFn: () => fetchMyPageData(),
@@ -41,10 +42,16 @@ function ProfileUpdate() {
   }
 
   return (
-    <div className="bg-bg pb-4xl pt-8">
-      <div className="px-lg mx-auto flex max-w-7xl gap-8">
-        <ProfileData setIsWithdrawModalOpen={setIsWithdrawModalOpen} data={myData!} />
-        <div className="flex w-full flex-col gap-8">
+    <div className="pb-4xl bg-[#F3F4F6] pt-0 md:bg-white md:pt-8">
+      <div className="mx-auto flex max-w-7xl flex-col gap-0 md:flex-row md:gap-8 md:p-0">
+        {isMd && <ProfileData setIsWithdrawModalOpen={setIsWithdrawModalOpen} data={myData!} />}
+        {!isMd && (
+          <div className="flex flex-col gap-2 border-b border-gray-200 bg-white p-5">
+            <h2 className="heading-h3">기본 정보</h2>
+            <p className="text-gray-500">프로필 이미지, 닉네임, 거주지를 수정할 수 있습니다</p>
+          </div>
+        )}
+        <div className="flex w-full flex-col gap-8 p-5 md:p-0">
           <ProfileUpdateBaseForm myData={myData!} />
           <ProfileUpdatePasswordForm />
         </div>

--- a/src/pages/profile-update/components/ProfileUpdateBaseForm.tsx
+++ b/src/pages/profile-update/components/ProfileUpdateBaseForm.tsx
@@ -15,6 +15,7 @@ import { useUserStore } from '@src/store/userStore'
 import { useDropzone } from 'react-dropzone'
 import { uploadImage } from '@src/api/products'
 import { useQueryClient } from '@tanstack/react-query'
+import { useMediaQuery } from '@src/hooks/useMediaQuery'
 
 export interface ProfileUpdateBaseFormValues {
   nickname: string
@@ -57,7 +58,9 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
 
   const titleLength = watch('introduction')?.length ?? 0
   const queryClient = useQueryClient()
+  const isMd = useMediaQuery('(min-width: 768px)')
   const [, setIsNicknameVerified] = useState(false)
+
   const [previewUrl, setPreviewUrl] = useState<string>(myData?.profileImageUrl || '')
   const [checkResult, setCheckResult] = useState<{
     status: 'idle' | 'success' | 'error'
@@ -151,18 +154,20 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
   }, [myData, reset])
 
   return (
-    <form className="border-border flex w-full flex-col gap-6 rounded-xl border p-7" onSubmit={handleSubmit(onSubmit)}>
+    <form className="flex w-full flex-col gap-6 rounded-xl border border-gray-200 bg-white p-5 md:p-7" onSubmit={handleSubmit(onSubmit)}>
       <fieldset className="flex flex-col gap-8">
         <legend className="sr-only">프로필 정보 수정 폼</legend>
-        <div className="flex flex-col gap-2">
-          <h2 className="heading-h3">기본 정보</h2>
-          <p className="text-gray-500">프로필 이미지, 닉네임, 거주지를 수정할 수 있습니다</p>
-        </div>
+        {isMd && (
+          <div className="flex flex-col gap-2">
+            <h2 className="heading-h3">기본 정보</h2>
+            <p className="text-gray-500">프로필 이미지, 닉네임, 거주지를 수정할 수 있습니다</p>
+          </div>
+        )}
 
         <div className="flex flex-col gap-6">
           <div className="flex flex-col gap-10">
             {/* 프로필 이미지 */}
-            <div className="flex flex-col items-center gap-2.5">
+            <div className="flex flex-col items-center gap-4">
               <div
                 {...getRootProps()}
                 className="flex h-28 w-28 cursor-pointer items-center justify-center overflow-hidden rounded-full bg-[#FACC15]"
@@ -183,8 +188,8 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
               <div className="flex flex-col gap-3.5">
                 <h3 className="heading-h5">본인 인증 정보</h3>
 
-                <div className="flex items-center justify-between gap-6">
-                  <div className="flex flex-1 flex-col gap-1">
+                <div className="flex flex-col items-center justify-between gap-6 md:flex-row">
+                  <div className="flex w-full flex-1 flex-col gap-1">
                     <div className="flex flex-col gap-2">
                       <span className="font-medium text-gray-600">이름</span>
                       <div className="bg-primary-50/50 rounded-lg p-3 font-medium text-gray-400">{myData?.nickname}</div>
@@ -192,7 +197,7 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
                     <p className="text-sm font-bold text-gray-400">본인 인증 정보로 변경할 수 없습니다.</p>
                   </div>
 
-                  <div className="flex flex-1 flex-col gap-1">
+                  <div className="flex w-full flex-1 flex-col gap-1">
                     <div className="flex flex-col gap-2">
                       <span className="font-medium text-gray-600">생년월일</span>
                       <div className="bg-primary-50/50 rounded-lg p-3 font-medium text-gray-400">{formatBirthDate(myData?.birthDate)}</div>

--- a/src/pages/profile-update/components/ProfileUpdatePasswordForm.tsx
+++ b/src/pages/profile-update/components/ProfileUpdatePasswordForm.tsx
@@ -75,7 +75,7 @@ export default function ProfileUpdatePasswordForm() {
   }, [password, passwordConfirm, setError, clearErrors])
 
   return (
-    <form className="border-border flex w-full flex-col gap-6 rounded-xl border p-7" onSubmit={handleSubmit(onSubmit)}>
+    <form className="flex w-full flex-col gap-6 rounded-xl border border-gray-200 bg-white p-7" onSubmit={handleSubmit(onSubmit)}>
       <fieldset className="flex flex-col gap-8">
         <legend className="sr-only">비밀번호 변경 폼</legend>
         <div className="flex flex-col gap-2">


### PR DESCRIPTION
## 📌 개요

- 프로필 수정 페이지(ProfileUpdate)의 모바일 반응형 UI를 구현합니다.

## 🔧 작업 내용

- [x] ProfileUpdate 페이지 레이아웃 반응형 적용
- [x] ProfileUpdateBaseForm 컴포넌트 모바일 UI 개선
- [x] ProfileUpdatePasswordForm 컴포넌트 스타일 수정
- [x] 프로필 수정 페이지에서 "내 정보 수정", "회원탈퇴" 버튼 숨김 처리
- [x] 모바일에서 Header SearchBar 숨김 처리
- [x] MyPage 배경색 수정

## 📎 관련 이슈

Closes #287

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| -       | -       |

## 💬 리뷰어 참고 사항

- 모바일 화면(768px 미만)에서 UI 확인 부탁드립니다.