### PR TITLE
feat: 유저 페이지 모바일 UI 개선(#289)

### DIFF
--- a/src/components/product/ProductListItem.tsx
+++ b/src/components/product/ProductListItem.tsx
@@ -9,6 +9,7 @@ import { getTradeStatusColor } from '@src/utils/getTradeStatusColor'
 import { cn } from '@src/utils/cn'
 import { Eye } from 'lucide-react'
 import type { Product } from '@src/types'
+import { useMediaQuery } from '@src/hooks/useMediaQuery'
 
 interface ProductListItemProps {
   product: Product
@@ -19,22 +20,26 @@ export function ProductListItem({ product, children }: ProductListItemProps) {
   const { id, title, price, mainImageUrl, tradeStatus, viewCount } = product
   const tradeStatusText = getTradeStatus(tradeStatus)
   const tradeStatusColor = getTradeStatusColor(tradeStatus)
-
+  const isMd = useMediaQuery('(min-width: 768px)')
   return (
     <li id={id.toString()} className="w-full">
       <Link to={ROUTES.DETAIL_ID(id)} className="flex w-full items-center justify-center gap-6 rounded-lg border border-gray-300 p-3.5">
-        <div className="aspect-square w-[10%] shrink-0 overflow-hidden rounded-lg">
+        <div className="relative aspect-square w-32 shrink-0 overflow-hidden rounded-lg md:static md:w-[10%]">
           <img
             src={mainImageUrl || PlaceholderImage}
             alt={title}
             className="h-full w-full object-cover transition-all duration-300 ease-in-out group-hover:scale-105"
           />
+          {!isMd &&
+            (children
+              ? children
+              : tradeStatus && <Badge className={cn('absolute top-2 left-2 bg-[#48BB78] text-white', tradeStatusColor)}>{tradeStatusText}</Badge>)}
         </div>
         <div className="flex flex-1 items-start">
           <div className="flex h-fit flex-1 flex-col items-start gap-2">
             <div className="flex w-full items-start justify-between">
               <div className="flex flex-col gap-1">
-                <h3 className="heading-h5 w-96 truncate">{title}</h3>
+                <h3 className="md:heading-h5 line-clamp-2 w-full text-[17px] font-bold md:line-clamp-none md:w-96 md:truncate">{title}</h3>
                 <span className="font-medium text-gray-500">{formatPrice(price)} 원</span>
               </div>
             </div>
@@ -42,7 +47,8 @@ export function ProductListItem({ product, children }: ProductListItemProps) {
               <ProductMetaItem icon={Eye} label={`조회 ${viewCount}`} className="text-sm text-gray-400" />
             </div>
           </div>
-          {children ? children : tradeStatus && <Badge className={cn('bg-[#48BB78] text-white', tradeStatusColor)}>{tradeStatusText}</Badge>}
+          {isMd &&
+            (children ? children : tradeStatus && <Badge className={cn('bg-[#48BB78] text-white', tradeStatusColor)}>{tradeStatusText}</Badge>)}
         </div>
       </Link>
     </li>

--- a/src/components/profile/ProfileData.tsx
+++ b/src/components/profile/ProfileData.tsx
@@ -147,7 +147,7 @@ export default function ProfileData({ setIsWithdrawModalOpen, setIsReportModalOp
                 ) : (
                   <button
                     type="button"
-                    className="flex w-full cursor-pointer items-center justify-start gap-2 rounded-lg border-t border-gray-300 bg-transparent px-3 py-1.5 pt-6 text-sm text-gray-500 hover:bg-gray-100"
+                    className="flex w-full cursor-pointer items-center justify-start gap-2 border-t border-gray-300 bg-transparent px-3 pt-6 pb-6 text-sm text-gray-500 hover:bg-gray-100 md:rounded-lg md:py-1.5"
                     onClick={() => setIsReportModalOpen?.(true)}
                   >
                     <Flag size={16} />

--- a/src/pages/UserPage.tsx
+++ b/src/pages/UserPage.tsx
@@ -52,17 +52,18 @@ function UserPage() {
   return (
     <>
       <div className="bg-bg pb-4xl pt-0 md:pt-8">
-        <div className="mx-auto flex max-w-7xl flex-col gap-8 md:flex-row">
+        <div className="mx-auto flex max-w-7xl flex-col gap-0 md:flex-row md:gap-8">
           <ProfileData
             setIsWithdrawModalOpen={setIsWithdrawModalOpen}
             setIsReportModalOpen={setIsReportModalOpen}
             setIsBlockModalOpen={setIsBlockModalOpen}
             data={userData!}
           />
-          <section className="border-border flex w-full flex-col gap-6 rounded-xl border p-5">
+          <section className="flex w-full flex-col gap-6 rounded-xl border-gray-200 p-5 md:border">
             <div className="flex justify-between">
-              <h4 className="flex items-center gap-2">
-                {userData?.nickname}님의 판매상품 {totalProducts}
+              <h4 className="flex flex-col items-start">
+                <span className="font-bold">{userData?.nickname}님의 판매상품</span>
+                <span>총 {totalProducts}개의 상품이 있습니다</span>
               </h4>
             </div>
             <div className="gap-lg flex max-h-[60vh] flex-col overflow-y-auto">


### PR DESCRIPTION
## 📌 개요

- 유저 페이지(UserPage) 및 관련 컴포넌트의 모바일 반응형 UI를 개선합니다.

## 🔧 작업 내용

- [x] ProductListItem 컴포넌트 모바일 UI 개선 (이미지 크기, Badge 위치, 제목 스타일)
- [x] ProfileData 컴포넌트 신고하기 버튼 스타일 반응형 적용
- [x] UserPage 레이아웃 및 판매상품 섹션 모바일 UI 개선

## 📎 관련 이슈

Closes #289

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| -       | -       |

## 💬 리뷰어 참고 사항

- 모바일 화면(768px 미만)에서 UI 확인 부탁드립니다.