### PR TITLE
feat: 홈 페이지 및 공통 컴포넌트 모바일 UI 개선(#291)

### DIFF
--- a/src/components/commons/select/CascadingSelectField.tsx
+++ b/src/components/commons/select/CascadingSelectField.tsx
@@ -64,7 +64,7 @@ export function CascadingSelectField<T extends FieldValues>({
         {label}
       </RequiredLabel>
 
-      <div className="flex gap-2.5">
+      <div className="flex flex-col gap-2.5 md:flex-row">
         <Controller
           name={primaryName}
           control={control}

--- a/src/components/header/SimpleHeader.tsx
+++ b/src/components/header/SimpleHeader.tsx
@@ -9,7 +9,6 @@ interface SimpleHeaderProps {
 }
 
 export function SimpleHeader({ title, description, to, layoutClassname }: SimpleHeaderProps) {
-
   return (
     <div className={cn('mx-auto flex max-w-7xl flex-col gap-2 bg-white px-3.5 py-2.5', layoutClassname)}>
       {to ? (

--- a/src/components/modal/BlockModal.tsx
+++ b/src/components/modal/BlockModal.tsx
@@ -29,7 +29,7 @@ export default function BlockModal({ isOpen, onCancel, userNickname, userId }: B
   if (!isOpen) return null
   return (
     <div className="fixed inset-0 z-100 flex items-center justify-center bg-gray-900/70">
-      <div className="flex w-[16vw] flex-col gap-4 rounded-lg bg-white p-5">
+      <div className="flex w-11/12 flex-col gap-4 rounded-lg bg-white p-5 md:w-[16vw]">
         <ModalTitle heading="사용자 차단하기" description={`정말로 ${userNickname}를 신고하시겠습니까?`} />
         <AlertBox alertList={USER_BLOCK_ALERT_LIST} />
 

--- a/src/components/modal/WithdrawModal.tsx
+++ b/src/components/modal/WithdrawModal.tsx
@@ -52,7 +52,7 @@ export default function WithdrawModal({ isOpen, onConfirm, onCancel }: WithdrawM
 
   return (
     <div className="fixed inset-0 z-100 flex items-center justify-center bg-gray-900/70">
-      <div className="flex w-[16vw] flex-col gap-4 rounded-lg bg-white p-5">
+      <div className="flex w-11/12 flex-col gap-4 rounded-lg bg-white p-5 md:w-[16vw]">
         <ModalTitle heading="회원탈퇴" description="정말로 탈퇴하시겠습니까?" />
         <AlertBox alertList={WITH_DRAW_ALERT_LIST} />
 

--- a/src/components/product/ProductStateFilter.tsx
+++ b/src/components/product/ProductStateFilter.tsx
@@ -64,7 +64,7 @@ export function ProductStateFilter({
           상품 상태
         </RequiredLabel>
       )}
-      <div className={cn('flex flex-wrap gap-2.5')} role="radiogroup" aria-labelledby="condition-filter-heading">
+      <div className={cn('grid grid-cols-2 flex-wrap gap-2.5 md:flex')} role="radiogroup" aria-labelledby="condition-filter-heading">
         {CONDITION_ITEMS.map((item) => (
           <div key={item.value} className={inputClassname}>
             <input

--- a/src/components/product/components/ProductBadge.tsx
+++ b/src/components/product/components/ProductBadge.tsx
@@ -7,7 +7,7 @@ interface ProductBadgeProps {
 
 export function ProductBadge({ petTypeName, productStatusName }: ProductBadgeProps) {
   return (
-    <div className="gap-xs z-1 flex">
+    <div className="gap-xs z-1 flex flex-wrap">
       <Badge className="bg-primary-700 text-white">{petTypeName}</Badge>
       <Badge className="bg-primary-200 text-gray-900">{productStatusName}</Badge>
     </div>

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -2,20 +2,23 @@ import Header from '@components/header/Header'
 // import ChatFloatButton from '@src/components/commons/chat/ChatFloatButton';
 import { Outlet, useLocation } from 'react-router-dom'
 import { useMediaQuery } from '@src/hooks/useMediaQuery'
+import { ROUTES } from '@src/constants/routes'
+
+// Header 숨김 패턴 (정규표현식 필요)
+const HIDE_HEADER_PATTERNS = [/^\/community\/\d+$/, /^\/community\/\d+\/edit$/, new RegExp(`^${ROUTES.COMMUNITY_POST}$`)]
+
+// SearchBar 숨김 경로 (정적 경로)
+const HIDE_SEARCHBAR_PATHS: string[] = [ROUTES.COMMUNITY, ROUTES.PROFILE_UPDATE, ROUTES.PRODUCT_POST, ROUTES.LOGIN, ROUTES.SIGNUP, ROUTES.FIND_PASSWORD, ROUTES.MYPAGE]
+
+// SearchBar 숨김 패턴 (동적 경로)
+const HIDE_SEARCHBAR_PATTERNS = [/^\/products\/\d+\/edit$/, /^\/user-profile\/\d+$/]
 
 export default function MainLayout() {
   const isMd = useMediaQuery('(min-width: 768px)')
   const { pathname } = useLocation()
 
-  // /community 관련 페이지인지 확인
-  const isCommunityDetailPage = /^\/community\/\d+$/.test(pathname)
-  const isCommunityFormPage = /^\/community-post$/.test(pathname) || /^\/community\/\d+\/edit$/.test(pathname)
-  const isCommunityListPage = /^\/community$/.test(pathname)
-  const isProfileEditPage = /^\/profile-update$/.test(pathname)
-
-  // CommunityDetail: Header 전체 숨김, CommunityPage: SearchBar만 숨김
-  const showHeader = !isCommunityDetailPage && !isCommunityFormPage
-  const hideSearchBar = !isMd && (isCommunityListPage || isProfileEditPage)
+  const showHeader = !HIDE_HEADER_PATTERNS.some((pattern) => pattern.test(pathname))
+  const hideSearchBar = !isMd && (HIDE_SEARCHBAR_PATHS.includes(pathname) || HIDE_SEARCHBAR_PATTERNS.some((pattern) => pattern.test(pathname)))
   return (
     <div className="flex min-h-screen flex-col">
       {showHeader && <Header hideSearchBar={hideSearchBar} />}

--- a/src/pages/UserPage.tsx
+++ b/src/pages/UserPage.tsx
@@ -51,7 +51,7 @@ function UserPage() {
 
   return (
     <>
-      <div className="bg-bg pb-4xl pt-0 md:pt-8">
+      <div className="pb-4xl bg-white pt-0 md:pt-8">
         <div className="mx-auto flex max-w-7xl flex-col gap-0 md:flex-row md:gap-8">
           <ProfileData
             setIsWithdrawModalOpen={setIsWithdrawModalOpen}

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -22,10 +22,12 @@ import { useNavigate, useSearchParams } from 'react-router-dom'
 import { Plus } from 'lucide-react'
 import { Button } from '@src/components/commons/button/Button'
 import { useUserStore } from '@src/store/userStore'
+import { useMediaQuery } from '@src/hooks/useMediaQuery'
 
 function Home() {
   const { isLogin } = useUserStore()
   const isLoggedIn = isLogin()
+  const isMd = useMediaQuery('(min-width: 768px)')
   const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
   const keyword = searchParams.get('keyword') || ''
@@ -285,7 +287,7 @@ function Home() {
       {/* <ChatButton /> */}
       {isLoggedIn && (
         <div className="fixed right-10 bottom-5 z-50">
-          <Button size="lg" className="bg-primary-300 cursor-pointer text-white" icon={Plus} onClick={toGoProductPostPage}>
+          <Button size={isMd ? 'lg' : 'md'} className="bg-primary-300 cursor-pointer text-white" icon={Plus} onClick={toGoProductPostPage}>
             상품등록
           </Button>
         </div>

--- a/src/pages/home/components/filter/DetailFilterButton.tsx
+++ b/src/pages/home/components/filter/DetailFilterButton.tsx
@@ -1,6 +1,7 @@
 import { Funnel as FilterIcon, ChevronDown as DownArrow } from 'lucide-react'
 import { cn } from '@src/utils/cn'
 import { Button } from '@src/components/commons/button/Button'
+import { useMediaQuery } from '@src/hooks/useMediaQuery'
 
 interface DetailFilterToggleProps {
   isOpen: boolean
@@ -10,6 +11,7 @@ interface DetailFilterToggleProps {
 }
 
 export function DetailFilterButton({ isOpen, onClick, ariaControls, filterReset }: DetailFilterToggleProps) {
+  const isMd = useMediaQuery('(min-width: 768px)')
   return (
     <div
       role="button"
@@ -24,10 +26,13 @@ export function DetailFilterButton({ isOpen, onClick, ariaControls, filterReset 
       <div className={cn('flex items-center gap-2')}>
         <FilterIcon className={cn('h-4 w-4')} aria-hidden="true" />
         <span className={cn('heading-h4')}>세부 필터</span>
-        <p className={cn('bg-primary-50 items-center justify-center overflow-hidden rounded-md px-3 py-1 text-sm')} aria-hidden="true">
-          상품상태 · 가격대 · 지역
-        </p>
+        {isMd && (
+          <p className={cn('bg-primary-50 items-center justify-center overflow-hidden rounded-md px-3 py-1 text-sm')} aria-hidden="true">
+            상품상태 · 가격대 · 지역
+          </p>
+        )}
       </div>
+
       <div className="flex items-center gap-4">
         <Button size="xs" type="button" className="bg-primary-50 cursor-pointer" onClick={filterReset}>
           필터 초기화

--- a/src/pages/home/components/filter/LocationFilter.tsx
+++ b/src/pages/home/components/filter/LocationFilter.tsx
@@ -75,7 +75,7 @@ export function LocationFilter({ headingClassName, onLocationChange }: LocationF
       <span id="location-filter-heading" className={cn('heading-h5', headingClassName)}>
         지역
       </span>
-      <div className="flex gap-2.5" role="group" aria-labelledby="location-filter-heading">
+      <div className="flex flex-col gap-2.5 md:flex-row" role="group" aria-labelledby="location-filter-heading">
         {/* 시/도 선택 */}
         <div className="flex-1">
           <SelectDropdown

--- a/src/pages/home/components/filter/PriceFilter.tsx
+++ b/src/pages/home/components/filter/PriceFilter.tsx
@@ -40,7 +40,7 @@ export function PriceFilter({ headingClassName, selectedPriceRange, onMinPriceCh
       <span id="price-filter-heading" className={cn('heading-h5', headingClassName)}>
         가격대
       </span>
-      <div className="gap-sm flex flex-wrap" role="group" aria-labelledby="price-filter-heading">
+      <div className="gap-sm grid grid-cols-2 flex-wrap md:flex" role="group" aria-labelledby="price-filter-heading">
         {PRICE_TYPE.map((item) => (
           <Button
             key={`${item.value.min}-${item.value.max}`}


### PR DESCRIPTION
## 📌 개요

- 홈 페이지 및 공통 컴포넌트의 모바일 반응형 UI를 개선합니다.

## 🔧 작업 내용

- [x] MainLayout Header/SearchBar 숨김 로직 리팩토링 (패턴 기반)
- [x] BlockModal, WithdrawModal 너비 모바일 반응형 적용
- [x] ProductStateFilter, PriceFilter 그리드 레이아웃 반응형 적용
- [x] LocationFilter, CascadingSelectField 레이아웃 반응형 적용
- [x] DetailFilterButton 모바일 텍스트 숨김 처리
- [x] Home 상품등록 버튼 크기 반응형 적용
- [x] ProductBadge flex-wrap 추가
- [x] UserPage 배경색 수정

## 📎 관련 이슈

Closes #291

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| -       | -       |

## 💬 리뷰어 참고 사항

- 모바일 화면(768px 미만)에서 UI 확인 부탁드립니다.
- MainLayout의 Header/SearchBar 숨김 로직이 패턴 기반으로 리팩토링되었습니다.