### PR TITLE
feat: 헤더 사용자 메뉴 모바일 UI 개선(#293)

### DIFF
--- a/src/components/header/components/user-section/UserMenu.tsx
+++ b/src/components/header/components/user-section/UserMenu.tsx
@@ -1,13 +1,14 @@
 // import Icon from '@components/commons/Icon'
 import { Z_INDEX } from '@constants/ui'
 import { cn } from '@utils/cn'
-import { UserRound as UserRoundIcon, LogOut as LogOutIcon } from 'lucide-react'
+import { UserRound as UserRoundIcon, LogOut as LogOutIcon, MessageSquare } from 'lucide-react'
 import { ROUTES } from '@src/constants/routes'
 import { useUserStore } from '@src/store/userStore'
 import { logout } from '@src/api/auth'
 import { useLoginModalStore } from '@src/store/modalStore'
 import { ProfileAvatar } from '@src/components/commons/ProfileAvatar'
 import { Link } from 'react-router-dom'
+import { useMediaQuery } from '@src/hooks/useMediaQuery'
 
 interface UserMenuProps {
   isNotificationOpen: boolean
@@ -20,7 +21,7 @@ interface UserMenuProps {
 export default function UserMenu({ isNotificationOpen, setIsNotificationOpen, isUserMenuOpen, setIsUserMenuOpen }: UserMenuProps) {
   const { user, clearAll } = useUserStore()
   const { openLogoutModal } = useLoginModalStore()
-
+  const isMd = useMediaQuery('(min-width: 768px)')
   const handleAvatarToggle = () => {
     if (isNotificationOpen) {
       setIsNotificationOpen(false)
@@ -54,21 +55,43 @@ export default function UserMenu({ isNotificationOpen, setIsNotificationOpen, is
       {isUserMenuOpen && (
         <div
           className={cn(
-            'absolute top-12 right-0 flex w-48 flex-col divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white shadow-lg',
+            'absolute top-12 right-0 flex w-32 flex-col divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white shadow-lg md:w-48',
             `${Z_INDEX.DROPDOWN}`
           )}
         >
-          <Link to={ROUTES.MYPAGE} className="hover:bg-primary-50 flex w-full items-center gap-3 px-4 py-2.5 text-sm text-gray-700">
-            <UserRoundIcon className="h-5 w-5" />
-            마이페이지
-          </Link>
-          <button
-            onClick={handleLogoutClick}
-            className="hover:bg-primary-50 text-danger-500 flex w-full cursor-pointer items-center gap-3 px-4 py-2.5 text-sm"
-          >
-            <LogOutIcon className="h-5 w-5 rotate-180" />
-            로그아웃
-          </button>
+          {isMd ? (
+            <>
+              <Link to={ROUTES.MYPAGE} className="hover:bg-primary-50 flex w-full items-center gap-3 px-4 py-2.5 text-sm text-gray-700">
+                <UserRoundIcon className="h-5 w-5" />
+                마이페이지
+              </Link>
+              <button
+                onClick={handleLogoutClick}
+                className="hover:bg-primary-50 text-danger-500 flex w-full cursor-pointer items-center gap-3 px-4 py-2.5 text-sm"
+              >
+                <LogOutIcon className="h-5 w-5 rotate-180" />
+                로그아웃
+              </button>
+            </>
+          ) : (
+            <>
+              <Link to={ROUTES.COMMUNITY} className="hover:bg-primary-50 flex w-full items-center gap-3 px-4 py-2.5 text-sm text-gray-700">
+                <MessageSquare className="h-5 w-5" />
+                커뮤니티
+              </Link>
+              <Link to={ROUTES.MYPAGE} className="hover:bg-primary-50 flex w-full items-center gap-3 px-4 py-2.5 text-sm text-gray-700">
+                <UserRoundIcon className="h-5 w-5" />
+                마이페이지
+              </Link>
+              <button
+                onClick={handleLogoutClick}
+                className="hover:bg-primary-50 text-danger-500 flex w-full cursor-pointer items-center gap-3 px-4 py-2.5 text-sm"
+              >
+                <LogOutIcon className="h-5 w-5 rotate-180" />
+                로그아웃
+              </button>
+            </>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## 📌 개요

- 헤더 사용자 메뉴(UserMenu)의 모바일 반응형 UI를 개선합니다.

## 🔧 작업 내용

- [x] 모바일에서 메뉴 너비 축소 (w-48 → w-32)
- [x] 모바일에서 커뮤니티 메뉴 항목 추가
- [x] 데스크톱/모바일 메뉴 항목 분리

## 📎 관련 이슈

Closes #293

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| -       | -       |

## 💬 리뷰어 참고 사항

- 모바일 화면(768px 미만)에서 사용자 메뉴 확인 부탁드립니다.
- 모바일에서는 커뮤니티 링크가 추가되었습니다.