### PR TITLE
feat: 댓글 작성자 배지 표시 및 메뉴 외부 클릭 닫기 기능 추가(#301)

### DIFF
--- a/src/components/modal/WithdrawModal.tsx
+++ b/src/components/modal/WithdrawModal.tsx
@@ -56,7 +56,7 @@ export default function WithdrawModal({ isOpen, onConfirm, onCancel }: WithdrawM
 
   return (
     <div className="fixed inset-0 z-100 flex items-center justify-center bg-gray-900/70">
-      <div className="flex w-11/12 flex-col gap-4 rounded-lg bg-white p-5 md:w-[16vw] md:min-w-96" ref={modalRef}>
+      <div ref={modalRef} className="flex w-11/12 flex-col gap-4 rounded-lg bg-white p-5 md:w-[16vw] md:min-w-96">
         <ModalTitle heading="회원탈퇴" description="정말로 탈퇴하시겠습니까?" />
         <AlertBox alertList={WITH_DRAW_ALERT_LIST} />
 

--- a/src/pages/community/components/CommentItem.tsx
+++ b/src/pages/community/components/CommentItem.tsx
@@ -4,8 +4,9 @@ import type { Comment } from '@src/types'
 import { EllipsisVertical } from 'lucide-react'
 import { IconButton } from '@src/components/commons/button/IconButton'
 import { ProfileAvatar } from '@src/components/commons/ProfileAvatar'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useUserStore } from '@src/store/userStore'
+import { useOutsideClick } from '@src/hooks/useOutsideClick'
 
 interface CommentItemProps {
   comment: Comment
@@ -36,8 +37,10 @@ export function CommentItem({
   const handleMoreToggle = () => {
     setIsMoreMenuOpen(!isMoreMenuOpen)
   }
-  console.log(comment)
 
+  const modalRef = useRef<HTMLButtonElement>(null)
+  // 바깥 클릭 시 onCancel 호출
+  useOutsideClick(isMoreMenuOpen, [modalRef], () => setIsMoreMenuOpen(false))
   const handleDelete = () => {
     onDelete?.(comment.id)
     setIsMoreMenuOpen(false)
@@ -50,7 +53,12 @@ export function CommentItem({
       {/* 유저 정보 및 내용 */}
       <div className="flex flex-col justify-center gap-1">
         <div className="flex items-center gap-3.5">
-          <p>{comment.authorNickname}</p>
+          <div className="flex items-center gap-1.5">
+            <p>{comment.authorNickname}</p>
+            {Number(comment.authorId) === user?.id && (
+              <p className="bg-primary-200 rounded-full px-2.5 py-1 text-xs font-semibold text-white">작성자</p>
+            )}
+          </div>
           <p className="text-sm text-gray-400">{formatDate(comment.createdAt)}</p>
         </div>
         <p>{comment.content}</p>
@@ -78,6 +86,7 @@ export function CommentItem({
               className="absolute top-7 right-0 cursor-pointer rounded border border-gray-200 bg-white px-3 py-1.5 text-sm whitespace-nowrap shadow-md hover:bg-gray-50"
               type="button"
               onClick={() => handleDelete()}
+              ref={modalRef}
             >
               삭제
             </button>


### PR DESCRIPTION
## 📌 개요

- 댓글 컴포넌트에 작성자 배지 표시 기능 추가
- 댓글 삭제 메뉴 외부 클릭 시 닫기 기능 구현

## 🔧 작업 내용

- [x] 댓글 작성자에게 "작성자" 배지 표시 기능 추가
- [x] 댓글 삭제 메뉴 외부 클릭 시 닫기 기능 추가 (useOutsideClick 훅 적용)
- [x] WithdrawModal ref 속성 위치 정리

## 📎 관련 이슈

Closes #301

## 📸 스크린샷 (선택)

(필요시 추가)

## 💬 리뷰어 참고 사항

- 댓글 작성자 배지 스타일 확인 부탁드립니다
- 외부 클릭 감지 로직이 올바르게 동작하는지 확인 부탁드립니다