### PR TITLE
design: 헤더 max-width 및 padding 조정(#303)

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -17,7 +17,7 @@ function Header({ hideSearchBar = false }: HeaderProps) {
         `${Z_INDEX.HEADER}`
       )}
     >
-      <div className="flex w-full flex-col gap-3 px-4 md:block md:px-2.5">
+      <div className="flex w-full flex-col gap-3 px-4 md:block md:max-w-7xl md:px-3.5">
         <div className="gap-lg flex items-center justify-between">
           <Logo />
           {!hideSearchBar && <SearchBar className="hidden md:block" />}


### PR DESCRIPTION
## 📌 개요

- 헤더 컴포넌트의 max-width 및 padding 값 조정

## 🔧 작업 내용

- [x] 헤더 데스크탑 max-width 7xl로 설정
- [x] 헤더 데스크탑 padding 값 조정 (px-2.5 → px-3.5)

## 📎 관련 이슈

Closes #303

## 📸 스크린샷 (선택)

(필요시 추가)

## 💬 리뷰어 참고 사항

- 헤더 너비 및 패딩 변경 확인 부탁드립니다