### PR TITLE
fix: 상품 등록 후 상세 페이지 이동 버그 수정(#307)

### DIFF
--- a/src/api/products.ts
+++ b/src/api/products.ts
@@ -100,8 +100,9 @@ export const addFavorite = async (productId: number): Promise<void> => {
 }
 
 // 판매 상품 등록
-export const postProduct = async (requestData: ProductPostRequestData): Promise<void> => {
-  await api.post(`/products`, requestData)
+export const postProduct = async (requestData: ProductPostRequestData): Promise<ProductPostResponse> => {
+  const response = await api.post<{ data: ProductPostResponse }>(`/products`, requestData)
+  return response.data.data
 }
 
 // 판매요청 상품 등록

--- a/src/pages/product-detail/ProductDetail.tsx
+++ b/src/pages/product-detail/ProductDetail.tsx
@@ -10,6 +10,7 @@ import ProductSummary from './components/ProductSummary'
 import ProductDescription from './components/ProductDescription'
 import ProductActions from './components/ProductActions'
 import SellerOtherProducts from './components/SellerOtherProducts'
+import { useEffect } from 'react'
 
 function ProductDetail() {
   const navigate = useNavigate()
@@ -20,6 +21,9 @@ function ProductDetail() {
     queryFn: () => fetchProductById(id!),
     enabled: !!id,
   })
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [])
 
   if (isLoading) {
     return (

--- a/src/pages/product-post/ProductPost.tsx
+++ b/src/pages/product-post/ProductPost.tsx
@@ -16,6 +16,7 @@ function ProductPost() {
   const [activeProductTypeTab, setActiveProductTypeTab] = useState<ProductTypeTabId>(initialTab)
   const [productData, setProductData] = useState<ProductDetailItem | null>(null)
   const { id } = useParams()
+
   const isEditMode = !!id
 
   const handleTabChange = (tabId: string) => {
@@ -24,12 +25,14 @@ function ProductPost() {
   }
 
   const isSalesTab = activeProductTypeTab === 'tab-sales'
-  const headerTitle = isSalesTab
-    ? isEditMode ? '판매 상품 수정' : '판매 상품 등록'
-    : isEditMode ? '판매 요청 수정' : '판매 요청 등록'
+  const headerTitle = isSalesTab ? (isEditMode ? '판매 상품 수정' : '판매 상품 등록') : isEditMode ? '판매 요청 수정' : '판매 요청 등록'
   const headerDescription = isSalesTab
-    ? isEditMode ? '등록된 상품 정보를 수정할 수 있습니다.' : '상품을 등록하여 다른 사용자들에게 판매할 수 있습니다.'
-    : isEditMode ? '등록된 판매 요청 정보를 수정할 수 있습니다.' : '원하는 상품이 없을 때 판매를 요청할 수 있습니다.'
+    ? isEditMode
+      ? '등록된 상품 정보를 수정할 수 있습니다.'
+      : '상품을 등록하여 다른 사용자들에게 판매할 수 있습니다.'
+    : isEditMode
+      ? '등록된 판매 요청 정보를 수정할 수 있습니다.'
+      : '원하는 상품이 없을 때 판매를 요청할 수 있습니다.'
 
   useEffect(() => {
     const loadProduct = async () => {

--- a/src/pages/product-post/components/ProductPostForm.tsx
+++ b/src/pages/product-post/components/ProductPostForm.tsx
@@ -89,8 +89,15 @@ export function ProductPostForm({ isEditMode, productId: id, initialData }: Prod
     }
 
     try {
-      await postProduct(requestData)
-      navigate(`/products/${id}`)
+      if (isEditMode && id) {
+        // 편집 모드: 기존 상품 ID로 이동
+        await postProduct(requestData)
+        navigate(`/products/${id}`)
+      } else {
+        // 새 등록: 서버에서 생성된 ID로 이동
+        const createdProduct = await postProduct(requestData)
+        navigate(`/products/${createdProduct.id}`)
+      }
     } catch {
       alert('상품 등록에 실패했습니다.')
     }


### PR DESCRIPTION
## 📌 개요

- 상품 등록 후 생성된 상품의 상세 페이지로 올바르게 이동하도록 수정
- 기존에는 undefined로 이동하던 버그 수정

## 🔧 작업 내용

- [x] postProduct API에서 생성된 상품 정보 반환하도록 수정
- [x] 상품 등록 후 서버에서 반환된 ID로 상세 페이지 이동
- [x] 상품 상세 페이지 진입 시 스크롤 위치 초기화 추가
- [x] ProductPost 코드 포맷팅 정리

## 📎 관련 이슈

Closes #307

## 📸 스크린샷 (선택)

(필요시 추가)

## 💬 리뷰어 참고 사항

- 상품 등록 후 생성된 상품 ID로 올바르게 이동하는지 확인 부탁드립니다