### PR TITLE
refactor: ChattingPage 불필요한 useEffect 제거(#315)

### DIFF
--- a/src/pages/chatting-page/ChattingPage.tsx
+++ b/src/pages/chatting-page/ChattingPage.tsx
@@ -69,14 +69,6 @@ export default function ChattingPage() {
     }
   }, [rooms, chatRoomId, selectedRoom])
 
-  useEffect(() => {
-    if (roomMessages && chatRoomId) {
-      // 이미 초기화되지 않은 경우에만
-      if (!realtimeMessages[Number(chatRoomId)]?.length) {
-        // chatSocketStore에 초기 메시지 설정 함수가 필요
-      }
-    }
-  }, [roomMessages, chatRoomId])
   // export default function Chatting({ isOpen, setIsOpen }: ChatProps) {
   //   const [searchParams] = useSearchParams()
   //   const [currentView, setCurrentView] = useState<'list' | 'chat'>('list')


### PR DESCRIPTION
## 📌 개요

- ChattingPage 컴포넌트에서 내부에 실제 동작 코드가 없는 불필요한 useEffect 훅 제거

## 🔧 작업 내용

- [x] 빈 useEffect 훅 제거
- [x] 컴포넌트 로직 간소화

## 📎 관련 이슈

Closes #315

## 📸 스크린샷 (선택)

(필요시 추가)

## 💬 리뷰어 참고 사항

- 내부에 실제 동작 코드가 없는 빈 useEffect 훅이 제거되었습니다.
- 기능 변경은 없습니다.