### PR TITLE
feat: 채팅 목록 실시간 업데이트 기능 구현(#317)

### DIFF
--- a/src/api/chatting.ts
+++ b/src/api/chatting.ts
@@ -35,6 +35,8 @@ export const outChatRoom = async (chatRoomId: number) => {
   await api.delete(`/chat/rooms/${chatRoomId}`)
 }
 
+// 채팅방 목록 실시간 업데이트 이벤트
+export const updateChatRoomInList = () => {}
 // 이미지 업로드
 export const uploadImage = async (files: File[]): Promise<ImageUploadResponse['data']> => {
   const formData = new FormData()

--- a/src/pages/chatting-page/ChattingPage.tsx
+++ b/src/pages/chatting-page/ChattingPage.tsx
@@ -17,7 +17,7 @@ export default function ChattingPage() {
   const navigate = useNavigate()
   const { user, accessToken } = useUserStore()
   const { id: chatRoomId } = useParams()
-  const { connect, disconnect, subscribeToRoom, isConnected, sendMessage, messages: realtimeMessages } = chatSocketStore()
+  const { connect, disconnect, subscribeToRoom, isConnected, sendMessage, messages: realtimeMessages, clearUnreadCount } = chatSocketStore()
 
   const { data: roomMessages } = useQuery({
     queryKey: ['messages', chatRoomId],
@@ -35,6 +35,7 @@ export default function ChattingPage() {
 
   const handleSelectRoom = (room: fetchChatRoom) => {
     subscribeToRoom(room.chatRoomId)
+    clearUnreadCount(room.chatRoomId)
     setSelectedRoom(room)
     navigate(`/chat/${room.chatRoomId}`, { replace: true })
   }
@@ -68,6 +69,12 @@ export default function ChattingPage() {
       }
     }
   }, [rooms, chatRoomId, selectedRoom])
+
+  useEffect(() => {
+    if (!user) {
+      navigate('/auth/login')
+    }
+  }, [])
 
   // export default function Chatting({ isOpen, setIsOpen }: ChatProps) {
   //   const [searchParams] = useSearchParams()

--- a/src/pages/chatting-page/components/ChatLog.tsx
+++ b/src/pages/chatting-page/components/ChatLog.tsx
@@ -81,7 +81,7 @@ export function ChatLog({ roomMessages }: ChatLogProps) {
                   {!isMine && <p className="text-sm text-gray-600">{message.senderNickname}</p>}
                   <span
                     className={cn(
-                      'rounded-t-lg px-3 py-2',
+                      'whitespace-pre-wrap rounded-t-lg px-3 py-2',
                       isMine ? 'rounded-bl-lg bg-gray-900 text-white' : 'rounded-br-lg border border-gray-300 bg-white'
                     )}
                   >

--- a/src/pages/chatting-page/components/ChatRooms.tsx
+++ b/src/pages/chatting-page/components/ChatRooms.tsx
@@ -4,6 +4,7 @@ import { ChatProductCard } from '@src/components/commons/card/ChatProductCard'
 
 import { getTimeAgo } from '@src/utils/getTimeAgo'
 import { cn } from '@src/utils/cn'
+import { chatSocketStore } from '@src/store/chatSocketStore'
 interface ChatRoomsProps {
   rooms: fetchChatRoom[]
   handleSelectRoom: (room: fetchChatRoom) => void
@@ -11,49 +12,65 @@ interface ChatRoomsProps {
 }
 
 export function ChatRooms({ rooms, handleSelectRoom, selectedRoomId }: ChatRoomsProps) {
+  const { chatRoomUpdates } = chatSocketStore()
+  const getRoomData = (room: fetchChatRoom) => {
+    const update = chatRoomUpdates[room.chatRoomId]
+    if (update) {
+      return {
+        ...room,
+        lastMessage: update.lastMessage,
+        lastMessageTime: update.lastMessageTime,
+        unreadCount: update.unreadCount,
+      }
+    }
+    return room
+  }
   return (
     <section className="flex flex-col rounded-none border-t border-b border-l border-gray-300 md:max-w-96 md:min-w-96">
       <h2 className="border-b border-gray-300 p-5">채팅목록</h2>
       <div className="px-3 py-3">
         <ul className="flex flex-col gap-2">
           {rooms &&
-            rooms.map((room) => (
-              <li
-                key={room.chatRoomId}
-                className={cn(
-                  'flex cursor-pointer items-start gap-2 rounded-lg p-3',
-                  room.chatRoomId === selectedRoomId ? 'border border-gray-300 bg-[#E5E7EB]/50' : 'border border-transparent'
-                )}
-                onClick={() => handleSelectRoom(room)}
-              >
-                <SellerAvatar profileImageUrl={room?.opponentProfileImageUrl} nickname={room?.opponentNickname} />
-                <div className="flex w-full flex-col gap-2">
-                  <div className="flex w-full items-start justify-between">
-                    <div className="flex flex-col gap-1">
-                      <p className="leading-none">{room?.opponentNickname}</p>
-                      <p className="text-sm">{room.lastMessage}</p>
+            rooms.map((room) => {
+              const roomData = getRoomData(room)
+              return (
+                <li
+                  key={roomData.chatRoomId}
+                  className={cn(
+                    'flex cursor-pointer items-start gap-2 rounded-lg p-3',
+                    roomData.chatRoomId === selectedRoomId ? 'border border-gray-300 bg-[#E5E7EB]/50' : 'border border-transparent'
+                  )}
+                  onClick={() => handleSelectRoom(room)}
+                >
+                  <SellerAvatar profileImageUrl={roomData?.opponentProfileImageUrl} nickname={roomData?.opponentNickname} />
+                  <div className="flex w-full flex-col gap-2">
+                    <div className="flex w-full items-start justify-between">
+                      <div className="flex flex-col gap-1">
+                        <p className="leading-none">{roomData?.opponentNickname}</p>
+                        <p className="text-sm">{roomData.lastMessage}</p>
+                      </div>
+                      <div className="flex items-center gap-1">
+                        {roomData.lastMessageTime && (
+                          <span className="text-sm leading-none font-medium text-gray-500">{getTimeAgo(roomData.lastMessageTime)}</span>
+                        )}
+                        {roomData.unreadCount >= 1 && (
+                          <p className="bg-danger-500 flex size-5 items-center justify-center rounded-full text-white">{roomData.unreadCount}</p>
+                        )}
+                      </div>
                     </div>
-                    <div className="flex items-center gap-1">
-                      {room.lastMessageTime && (
-                        <span className="text-sm leading-none font-medium text-gray-500">{getTimeAgo(room.lastMessageTime)}</span>
-                      )}
-                      {room.unreadCount >= 1 && (
-                        <p className="bg-danger-500 flex size-5 items-center justify-center rounded-full text-white">{room.unreadCount}</p>
-                      )}
+                    <div className="border-primary-100 bg-primary-50 flex items-center justify-between gap-2 rounded-lg border px-2.5 py-3">
+                      <ChatProductCard
+                        productImageUrl={roomData?.productImageUrl}
+                        productTitle={roomData?.productTitle}
+                        productPrice={roomData?.productPrice}
+                        size="sm"
+                        titleWidth="w-52"
+                      />
                     </div>
                   </div>
-                  <div className="border-primary-100 bg-primary-50 flex items-center justify-between gap-2 rounded-lg border px-2.5 py-3">
-                    <ChatProductCard
-                      productImageUrl={room?.productImageUrl}
-                      productTitle={room?.productTitle}
-                      productPrice={room?.productPrice}
-                      size="sm"
-                      titleWidth="w-52"
-                    />
-                  </div>
-                </div>
-              </li>
-            ))}
+                </li>
+              )
+            })}
         </ul>
       </div>
     </section>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -578,6 +578,11 @@ export interface ChatRoomMessagesResponse {
   data: {
     messages: Message[]
   }
+  currentPage: number
+  totalPages: number
+  totalElements: number
+  hasNext: boolean
+  hasPrevious: boolean
 }
 
 export interface Message {
@@ -614,6 +619,20 @@ export interface fetchChatRoom {
   unreadCount: number
 }
 
+export interface ChatRoomUpdateResponse {
+  chatRoomId: number
+  productId: number
+  productTitle: string
+  productPrice: number
+  productImageUrl: string
+  opponentId: number
+  opponentNickname: string
+  opponentProfileImageUrl: string
+  lastMessage: string
+  lastMessageTime: string
+  hasUnread: boolean
+  unreadCount: number
+}
 // export interface ProductDetailItemResponse {
 //   code: string
 //   message: string


### PR DESCRIPTION
## 📌 개요

- 채팅방 목록에서 새 메시지 수신 시 실시간으로 목록 업데이트 및 읽지 않은 메시지 카운트 표시 기능 구현

## 🔧 작업 내용

- [x] WebSocket으로 채팅방 목록 실시간 업데이트 구독 추가
- [x] 읽지 않은 메시지 카운트 관리 기능 구현
- [x] 채팅방 선택 시 unread count 초기화
- [x] 비로그인 사용자 채팅 페이지 접근 시 로그인 페이지로 리다이렉트
- [x] 채팅 메시지 줄바꿈(whitespace-pre-wrap) 스타일 적용
- [x] ChatRoomUpdateResponse 타입 및 페이지네이션 필드 추가

## 📎 관련 이슈

Closes #317

## 💬 리뷰어 참고 사항

- chatSocketStore.ts에서 `/user/queue/chat-room-list` 구독을 통해 실시간 업데이트를 받습니다
- ChatRooms 컴포넌트에서 chatRoomUpdates 상태를 활용하여 UI를 업데이트합니다