### PR TITLE
feat: 상품 수정 API 연동(#318)

### DIFF
--- a/src/api/products.ts
+++ b/src/api/products.ts
@@ -110,6 +110,12 @@ export const requestPostProduct = async (requestData: RequestProductPostRequestD
   await api.post(`/products/requests`, requestData)
 }
 
+// 판매요청 상품 수정
+export const patchProduct = async (requestData: ProductPostRequestData, id: number): Promise<ProductPostResponse> => {
+  const response = await api.patch<{ data: ProductPostResponse }>(`/products/${id}`, requestData)
+  return response.data.data
+}
+
 // 이미지 업로드
 export const uploadImage = async (files: File[]): Promise<ImageUploadResponse['data']> => {
   const formData = new FormData()

--- a/src/pages/product-post/components/ProductPostForm.tsx
+++ b/src/pages/product-post/components/ProductPostForm.tsx
@@ -7,7 +7,7 @@ import BasicInfoSection from './basicInfoSection/BasicInfoSection'
 import PriceAndStatusSection from './priceAndStatusSection/PriceAndStatusSection'
 import TradeInfoSection from './tradeInfoSection/TradeInfoSection'
 import type { ProductDetailItem, ProductPostRequestData } from '@src/types'
-import { postProduct } from '@src/api/products'
+import { patchProduct, postProduct } from '@src/api/products'
 import { cn } from '@src/utils/cn'
 import { useEffect, useMemo } from 'react'
 
@@ -91,7 +91,7 @@ export function ProductPostForm({ isEditMode, productId: id, initialData }: Prod
     try {
       if (isEditMode && id) {
         // 편집 모드: 기존 상품 ID로 이동
-        await postProduct(requestData)
+        await patchProduct(requestData, Number(id))
         navigate(`/products/${id}`)
       } else {
         // 새 등록: 서버에서 생성된 ID로 이동


### PR DESCRIPTION
## 📌 개요

- 상품 등록 후 수정 기능을 위한 PATCH API 연동 및 폼 수정

## 🔧 작업 내용

- [x] 상품 수정 API (PATCH /products/:id) 함수 추가
- [x] ProductPostForm에서 수정 모드 시 patchProduct API 호출

## 📎 관련 이슈

Closes #318

## 💬 리뷰어 참고 사항

- 기존 postProduct 대신 patchProduct를 사용하여 수정 모드에서 올바른 API를 호출합니다