### PR TITLE
feat: 채팅 메시지 무한 스크롤 구현(#321)

### DIFF
--- a/src/api/chatting.ts
+++ b/src/api/chatting.ts
@@ -27,7 +27,7 @@ export const fetchRooms = async () => {
 // 채팅 내역 조회
 export const fetchRoomMessages = async (chatRoomId: number, page: number = 0, size: number = 50) => {
   const response = await api.get<ChatRoomMessagesResponse>(`/chat/rooms/${chatRoomId}/messages?page=${page}&size=${size}`)
-  return response.data.data.messages
+  return response.data
 }
 
 // 채팅방 나가기

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -602,6 +602,11 @@ export interface ChatRoomsResponse {
   code: string
   message: string
   data: { chatRooms: fetchChatRoom[] }
+  currentPage: number
+  totalPages: number
+  totalElements: number
+  hasNext: boolean
+  hasPrevious: boolean
 }
 
 export interface fetchChatRoom {


### PR DESCRIPTION
## 📌 개요

- 채팅 메시지 목록에 무한 스크롤 기능을 추가하여 이전 메시지를 페이지네이션으로 로드

## 🔧 작업 내용

- [x] fetchRoomMessages 응답 형식 변경 (페이지네이션 정보 포함)
- [x] useQuery → useInfiniteQuery로 변경하여 무한 스크롤 구현
- [x] ChatLog에 스크롤 이벤트 핸들러 추가
- [x] 스크롤이 맨 위에 도달하면 이전 메시지 로드
- [x] ChatRoomsResponse 타입에 페이지네이션 필드 추가

## 📎 관련 이슈

Closes #321

## 💬 리뷰어 참고 사항

- 스크롤이 맨 위(scrollTop === 0)에 도달하면 이전 페이지를 로드합니다
- hasNext 필드로 다음 페이지 존재 여부를 확인합니다