### PR TITLE
feat: 채팅 이미지 메시지 및 차단 메시지 처리(#325)

### DIFF
--- a/src/pages/chatting-page/components/ChatLog.tsx
+++ b/src/pages/chatting-page/components/ChatLog.tsx
@@ -2,6 +2,7 @@ import type { Message } from '@src/types'
 import { cn } from '@src/utils/cn'
 import { useUserStore } from '@src/store/userStore'
 import { useEffect, useRef } from 'react'
+import PlaceholderImage from '@assets/images/placeholder.png'
 
 interface ChatLogProps {
   roomMessages: Message[]
@@ -84,20 +85,40 @@ export function ChatLog({ roomMessages, onLoadPrevious, hasMorePrevious, isLoadi
           <ul>
             {messages.map((message) => {
               const isMine = getIsMine(message, user?.id)
-              return (
+              return message.messageType === 'SYSTEM' ? (
+                <li className="bg-primary-100 m-6 mx-auto w-fit rounded-full px-3 py-1 text-center">{message.content}</li>
+              ) : message.isBlocked ? (
+                <li className="ml-auto flex w-fit max-w-64 min-w-60 flex-col rounded-full px-3 py-1">
+                  <span className="rounded-t-lg rounded-bl-lg bg-gray-900 px-3 py-2 text-white">{message.content}</span>
+                  <span className="text-sm">개인정보 포함으로 상대방에게 전송되지 않았습니다.</span>
+                </li>
+              ) : (
                 <li
                   key={message.messageId}
                   className={cn('flex max-w-64 min-w-60 flex-col gap-1 rounded-lg px-3 py-2', isMine ? 'ml-auto' : 'mr-auto')}
                 >
                   {!isMine && <p className="text-sm text-gray-600">{message.senderNickname}</p>}
-                  <span
-                    className={cn(
-                      'rounded-t-lg px-3 py-2 whitespace-pre-wrap',
-                      isMine ? 'rounded-bl-lg bg-gray-900 text-white' : 'rounded-br-lg border border-gray-300 bg-white'
-                    )}
-                  >
-                    {message.content}
-                  </span>
+                  {message.messageType === 'IMAGE' ? (
+                    <div className="relative aspect-square w-32 shrink-0 overflow-hidden rounded-lg md:static">
+                      <img
+                        src={message.imageUrl || PlaceholderImage}
+                        alt={message.senderNickname}
+                        onError={(e) => {
+                          e.currentTarget.src = PlaceholderImage
+                        }}
+                        className="h-full w-full object-cover transition-all duration-300 ease-in-out group-hover:scale-105"
+                      />
+                    </div>
+                  ) : (
+                    <span
+                      className={cn(
+                        'rounded-t-lg px-3 py-2 whitespace-pre-wrap',
+                        isMine ? 'rounded-bl-lg bg-gray-900 text-white' : 'rounded-br-lg border border-gray-300 bg-white'
+                      )}
+                    >
+                      {message.content}
+                    </span>
+                  )}
                   <span className={cn('text-xs text-gray-500', isMine ? 'text-right' : 'text-left')}>{chatFormatTime(message.createdAt)}</span>
                 </li>
               )


### PR DESCRIPTION
## 📌 개요

- 채팅 이미지 메시지 전송/표시 및 차단 메시지 처리 기능 구현

## 🔧 작업 내용

- [x] 이미지 업로드 및 이미지 메시지 전송 기능
- [x] 이미지 메시지 표시 UI 구현
- [x] 차단된 메시지 알림 표시 (개인정보 포함 메시지)
- [x] 시스템 메시지 UI 구현 (중앙 정렬, 배경색 적용)
- [x] 개인정보 차단 알림 WebSocket 구독 (/user/queue/chat)

## 📎 관련 이슈

Closes #325

## 💬 리뷰어 참고 사항

- 이미지 업로드는 기존 products API의 uploadImage 함수를 재사용합니다
- messageType에 따라 TEXT, IMAGE, SYSTEM 메시지를 다르게 렌더링합니다
- isBlocked가 true인 메시지는 "개인정보 포함으로 상대방에게 전송되지 않았습니다" 안내를 표시합니다