### PR TITLE
feat: 로그아웃 시 WebSocket 연결 해제(#329)

### DIFF
--- a/src/components/header/components/user-section/UserMenu.tsx
+++ b/src/components/header/components/user-section/UserMenu.tsx
@@ -6,6 +6,7 @@ import { ROUTES } from '@src/constants/routes'
 import { useUserStore } from '@src/store/userStore'
 import { logout } from '@src/api/auth'
 import { useLoginModalStore } from '@src/store/modalStore'
+import { chatSocketStore } from '@src/store/chatSocketStore'
 import { ProfileAvatar } from '@src/components/commons/ProfileAvatar'
 import { Link } from 'react-router-dom'
 import { useMediaQuery } from '@src/hooks/useMediaQuery'
@@ -23,6 +24,7 @@ interface UserMenuProps {
 export default function UserMenu({ isNotificationOpen, setIsNotificationOpen, isUserMenuOpen, setIsUserMenuOpen }: UserMenuProps) {
   const { user, clearAll } = useUserStore()
   const { openLogoutModal } = useLoginModalStore()
+  const { disconnect } = chatSocketStore()
   const modalRef = useRef<HTMLDivElement>(null)
   useOutsideClick(isUserMenuOpen, [modalRef], () => setIsUserMenuOpen(false))
 
@@ -42,6 +44,7 @@ export default function UserMenu({ isNotificationOpen, setIsNotificationOpen, is
       console.error('로그아웃 API 실패:', error)
     } finally {
       setIsUserMenuOpen(false)
+      disconnect() // WebSocket 연결 해제
       clearAll()
     }
   }


### PR DESCRIPTION
## 📌 개요

- 로그아웃 시 WebSocket 연결을 정상적으로 해제하여 리소스 정리

## 🔧 작업 내용

- [x] 로그아웃 시 chatSocketStore의 disconnect 호출하여 WebSocket 연결 정리

## 📎 관련 이슈

Closes #329

## 💬 리뷰어 참고 사항

- 로그아웃 시 clearAll() 호출 전에 disconnect()를 호출하여 WebSocket 연결을 먼저 해제합니다