### PR TITLE
refactor: 채팅 WebSocket URL 환경변수화(#331)

### DIFF
--- a/src/pages/chatting-page/ChattingPage.tsx
+++ b/src/pages/chatting-page/ChattingPage.tsx
@@ -13,8 +13,8 @@ import { ChatLog } from '@src/pages/chatting-page/components/ChatLog'
 import ChatInput from './components/ChatInput'
 import { uploadImage } from '@src/api/products'
 import { cn } from '@src/utils/cn'
-const WS_URL = 'http://192.168.45.25:8080/ws-stomp'
-
+// const WS_URL = 'http://192.168.45.25:8080/ws-stomp'
+const VITE_WS_URL = import.meta.env.VITE_WS_URL || 'http://localhost:8080/ws-stomp'
 export default function ChattingPage() {
   const [isChatOpen, setIsChatOpen] = useState(false)
   const [selectedRoom, setSelectedRoom] = useState<fetchChatRoom | null>(null)
@@ -103,7 +103,7 @@ export default function ChattingPage() {
   }
   useEffect(() => {
     if (accessToken) {
-      connect(WS_URL, accessToken)
+      connect(VITE_WS_URL, accessToken)
     }
   }, [connect, disconnect, accessToken])
 


### PR DESCRIPTION
## 📌 개요

- 채팅 페이지의 WebSocket URL을 하드코딩에서 환경변수로 변경하여 환경별 유연한 설정 가능하도록 개선

## 🔧 작업 내용

- [x] `ChattingPage.tsx`에서 하드코딩된 WebSocket URL을 `VITE_WS_URL` 환경변수로 변경
- [x] 환경변수가 없을 경우 기본값(`http://localhost:8080/ws-stomp`) 사용하도록 설정

## 📎 관련 이슈

Closes #331

## 💬 리뷰어 참고 사항

- 환경변수 `VITE_WS_URL`이 `.env` 파일에 설정되어 있는지 확인 필요