### PR TITLE
refactor: OAuth 로그인 URL 운영 환경 적용(#336)

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,12 +1,4 @@
-import type {
-  NicknameCheckResponse,
-  EmailCheckResponse,
-  SignUpRequestData,
-  SignUpResponse,
-  LoginRequestData,
-  LoginResponse,
-} from '../types'
-// import { apiFetch } from './apiFetch'
+import type { NicknameCheckResponse, EmailCheckResponse, SignUpRequestData, SignUpResponse, LoginRequestData, LoginResponse } from '../types'
 import axios from 'axios'
 import { api } from './api'
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'

--- a/src/pages/login/components/SocialLoginButtons.tsx
+++ b/src/pages/login/components/SocialLoginButtons.tsx
@@ -4,7 +4,7 @@ import google from '@assets/images/google.svg'
 
 export function SocialLoginButtons() {
   const handleGoogleLogin = () => {
-    window.location.href = 'http://localhost:8080/oauth2/authorization/google'
+    window.location.href = 'https://cmarket-api.duckdns.org/oauth2/authorization/google'
   }
 
   return (


### PR DESCRIPTION
## 📌 개요

- Google OAuth 로그인 URL을 localhost에서 운영 서버 URL로 변경

## 🔧 작업 내용

- [x] `SocialLoginButtons.tsx`의 Google 로그인 URL을 운영 서버로 변경
- [x] `auth.ts` import 정리

## 📎 관련 이슈

Closes #336

## 💬 리뷰어 참고 사항

- 운영 환경에서 소셜 로그인이 정상 동작하도록 URL 변경