### PR TITLE
refactor: 채팅 UI 개선 및 알림 연동(#346)

### DIFF
--- a/src/components/commons/card/ChatProductCard.tsx
+++ b/src/components/commons/card/ChatProductCard.tsx
@@ -6,7 +6,6 @@ interface ChatProductCardProps {
   productTitle?: string
   productPrice?: number
   size?: 'sm' | 'md'
-  titleWidth?: string
 }
 
 const sizeClasses = {
@@ -14,7 +13,7 @@ const sizeClasses = {
   md: 'w-16',
 }
 
-export function ChatProductCard({ productImageUrl, productTitle, productPrice, size = 'sm', titleWidth }: ChatProductCardProps) {
+export function ChatProductCard({ productImageUrl, productTitle, productPrice, size = 'sm' }: ChatProductCardProps) {
   return (
     <>
       <div className={`relative aspect-square shrink-0 overflow-hidden rounded-lg ${sizeClasses[size]}`}>
@@ -24,8 +23,8 @@ export function ChatProductCard({ productImageUrl, productTitle, productPrice, s
           className="h-full w-full object-cover transition-all duration-300 ease-in-out group-hover:scale-105"
         />
       </div>
-      <div className="flex-1">
-        <p className={`line-clamp-1 truncate ${titleWidth ?? ''}`}>{productTitle}</p>
+      <div className="min-w-0 flex-1">
+        <p className="truncate">{productTitle}</p>
         <p className="font-bold">{formatPrice(Number(productPrice))}원</p>
       </div>
     </>

--- a/src/pages/chatting-page/components/ChatRooms.tsx
+++ b/src/pages/chatting-page/components/ChatRooms.tsx
@@ -42,8 +42,10 @@ export function ChatRooms({ rooms, handleSelectRoom, selectedRoomId }: ChatRooms
                   )}
                   onClick={() => handleSelectRoom(room)}
                 >
-                  <SellerAvatar profileImageUrl={roomData?.opponentProfileImageUrl} nickname={roomData?.opponentNickname} />
-                  <div className="flex w-full flex-1 flex-col gap-2 md:flex-none">
+                  <div className="shrink-0">
+                    <SellerAvatar profileImageUrl={roomData?.opponentProfileImageUrl} nickname={roomData?.opponentNickname} />
+                  </div>
+                  <div className="flex min-w-0 flex-1 flex-col gap-2">
                     <div className="flex w-full items-start justify-between">
                       <div className="flex flex-col gap-1">
                         <p className="leading-none font-semibold">{roomData?.opponentNickname}</p>
@@ -56,17 +58,18 @@ export function ChatRooms({ rooms, handleSelectRoom, selectedRoomId }: ChatRooms
                           <span className="text-sm leading-none font-medium text-gray-500">{getTimeAgo(roomData.lastMessageTime)}</span>
                         )}
                         {roomData.unreadCount >= 1 && (
-                          <p className="bg-danger-500 flex size-5 items-center justify-center rounded-full text-white">{roomData.unreadCount}</p>
+                          <p className="bg-danger-500 tex-sm flex size-5 items-center justify-center rounded-full text-white">
+                            {roomData.unreadCount}
+                          </p>
                         )}
                       </div>
                     </div>
-                    <div className="border-primary-100 bg-primary-50 flex items-center justify-between gap-2 rounded-lg border px-2.5 py-3">
+                    <div className="border-primary-100 bg-primary-50 flex items-center gap-2 rounded-lg border px-2.5 py-3 overflow-hidden">
                       <ChatProductCard
                         productImageUrl={roomData?.productImageUrl}
                         productTitle={roomData?.productTitle}
                         productPrice={roomData?.productPrice}
                         size="sm"
-                        titleWidth="w-52"
                       />
                     </div>
                   </div>

--- a/src/store/chatSocketStore.ts
+++ b/src/store/chatSocketStore.ts
@@ -110,12 +110,13 @@ export const chatSocketStore = create<ChatSocketState>((set, get) => ({
     }))
   },
   clearUnreadCount: (chatRoomId: number) => {
-    const current = get().chatRoomUpdates[chatRoomId]
-    if (!current) return
     set((state) => ({
       chatRoomUpdates: {
         ...state.chatRoomUpdates,
-        [chatRoomId]: { ...current, unreadCount: 0 },
+        [chatRoomId]: {
+          ...(state.chatRoomUpdates[chatRoomId] || {}),
+          unreadCount: 0,
+        },
       },
     }))
   },


### PR DESCRIPTION
## 📌 개요

- 채팅 UI overflow 문제 수정 및 알림 카운트 연동

## 🔧 작업 내용

- [x] 채팅방 입장 시 알림 카운트 감소 로직 추가
- [x] ChatRooms UI overflow 수정 및 레이아웃 개선
- [x] clearUnreadCount 로직 개선
- [x] ChatProductCard titleWidth prop 제거 및 스타일 개선

## 📎 관련 이슈

Closes #346

## 💬 리뷰어 참고 사항

- 채팅방 입장 시 알림 카운트가 자동으로 감소됩니다