### PR TITLE
fix: 채팅 알림 읽음 처리 시 채팅방 목록 동기화(#349)

### DIFF
--- a/src/components/header/components/notification-section/NotificationsDropdown.tsx
+++ b/src/components/header/components/notification-section/NotificationsDropdown.tsx
@@ -11,6 +11,7 @@ import { useNavigate } from 'react-router-dom'
 import { getNavigationPath } from '@src/utils/getNavigationPath'
 import { useOutsideClick } from '@src/hooks/useOutsideClick'
 import NotificationsSkeleton from './NotificationsSkeleton'
+import { chatSocketStore } from '@src/store/chatSocketStore'
 // import type { NotificationItem } from '@src/types/notifications'
 
 interface NotificationsDropdownProps {
@@ -63,10 +64,13 @@ export default function NotificationsDropdown({ isNotificationOpen, setIsNotific
         unreadCount: Math.max((prev?.unreadCount ?? 0) - 1, 0),
       }))
     }
+    // 채팅 알림인 경우 ChatRooms의 unreadCount도 감소
+    if (notification.relatedEntityType === 'CHAT_ROOM') {
+      chatSocketStore.getState().clearUnreadCount(notification.relatedEntityId)
+    }
     const path = getNavigationPath(notification)
     console.log('이동할 경로:', path)
     setIsNotificationOpen(false)
-    // navigate(getNavigationPath(notification))
     navigate(path)
     await readNotification(notification.notificationId)
     refetch()


### PR DESCRIPTION
## 📌 개요

- 채팅 알림 읽음 처리 시 채팅방 목록의 unreadCount가 동기화되지 않는 버그 수정

## 🔧 작업 내용

- [x] 채팅 알림 클릭 시 chatSocketStore의 clearUnreadCount 호출
- [x] 알림과 채팅방 목록 간 읽음 상태 동기화

## 📎 관련 이슈

Closes #349

## 💬 리뷰어 참고 사항

- 채팅 알림(CHAT_ROOM 타입) 클릭 시 해당 채팅방의 unreadCount도 함께 0으로 초기화됩니다