### PR TITLE
chore: 소셜 로그인 OAuth URL 도메인 변경(#355)

### DIFF
--- a/src/pages/login/components/SocialLoginButtons.tsx
+++ b/src/pages/login/components/SocialLoginButtons.tsx
@@ -4,10 +4,10 @@ import google from '@assets/images/google.svg'
 
 export function SocialLoginButtons() {
   const handleGoogleLogin = () => {
-    window.location.href = 'https://cmarket-api.duckdns.org/oauth2/authorization/google'
+    window.location.href = 'https://cuddle-market.duckdns.org/oauth2/authorization/google'
   }
   const handleKakaoLogin = () => {
-    window.location.href = 'https://cmarket-api.duckdns.org/oauth2/authorization/kakao'
+    window.location.href = 'https://cuddle-market.duckdns.org/oauth2/authorization/kakao'
   }
 
   return (


### PR DESCRIPTION
## 📌 개요

- 소셜 로그인 OAuth 인증 URL 도메인을 새 도메인으로 변경

## 🔧 작업 내용

- [x] Google 로그인 URL 도메인 변경 (`cmarket-api.duckdns.org` → `cuddle-market.duckdns.org`)
- [x] Kakao 로그인 URL 도메인 변경 (`cmarket-api.duckdns.org` → `cuddle-market.duckdns.org`)

## 📎 관련 이슈

Closes #355

## 💬 리뷰어 참고 사항

- 단순 도메인 URL 변경 작업입니다