### PR TITLE
refactor: WebSocket 전용 transport 방식으로 변경(#357)

### DIFF
--- a/src/store/chatSocketStore.ts
+++ b/src/store/chatSocketStore.ts
@@ -58,7 +58,7 @@ export const chatSocketStore = create<ChatSocketState>((set, get) => ({
 
     // STOMP Client 생성
     const socket = new Client({
-      webSocketFactory: () => new SockJS(url), // ← 추가
+      webSocketFactory: () => new SockJS(url, null, { transports: ['websocket'] }),
       connectHeaders: {
         Authorization: `Bearer ${accessToken}`,
       },


### PR DESCRIPTION
## 📌 개요

- SockJS WebSocket 연결 시 transport 방식을 명시적으로 지정하여 연결 안정성 개선

## 🔧 작업 내용

- [x] SockJS에 `transports: ['websocket']` 옵션 추가
- [x] WebSocket 전용 연결 방식으로 변경

## 📎 관련 이슈

Closes #357

## 💬 리뷰어 참고 사항

- 채팅 소켓 연결 방식 변경으로 fallback 없이 WebSocket만 사용합니다