### PR TITLE
refactor: 채팅 입력 상태 관리 개선(#363)

### DIFF
--- a/src/pages/chatting-page/ChattingPage.tsx
+++ b/src/pages/chatting-page/ChattingPage.tsx
@@ -19,6 +19,7 @@ export default function ChattingPage() {
   const queryClient = useQueryClient()
   const [isChatOpen, setIsChatOpen] = useState(false)
   const [selectedRoom, setSelectedRoom] = useState<fetchChatRoom | null>(null)
+  const [inputMessage, setInputMessage] = useState('')
   const navigate = useNavigate()
   const { user, accessToken } = useUserStore()
   const { id: chatRoomId } = useParams()
@@ -61,9 +62,10 @@ export default function ChattingPage() {
     navigate(`/chat/${room.chatRoomId}`)
   }
 
-  const handleSend = (message: string) => {
-    if (selectedRoom) {
-      sendMessage(selectedRoom.chatRoomId, message, 'TEXT')
+  const handleSend = () => {
+    if (selectedRoom && inputMessage.length > 0) {
+      sendMessage(selectedRoom.chatRoomId, inputMessage, 'TEXT')
+      setInputMessage('')
     }
   }
   const handleImageSend = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -162,8 +164,8 @@ export default function ChattingPage() {
                 <label htmlFor="chat-file-input" className="cursor-pointer rounded p-1">
                   <Paperclip size={20} />
                 </label>
-                <ChatInput onSend={handleSend} />
-                <IconButton size="lg" className="bg-primary-100 aspect-square h-full">
+                <ChatInput value={inputMessage} onChange={setInputMessage} onSubmit={handleSend} />
+                <IconButton size="lg" className="bg-primary-100 aspect-square h-full" onClick={handleSend}>
                   <Send className="text-white" />
                 </IconButton>
               </div>

--- a/src/pages/chatting-page/components/ChatInput.tsx
+++ b/src/pages/chatting-page/components/ChatInput.tsx
@@ -1,30 +1,26 @@
-import { useState } from 'react'
-
 interface ChatInputProps {
-  onSend: (message: string) => void
+  value: string
+  onChange: (value: string) => void
+  onSubmit: () => void
 }
 
-export default function ChatInput({ onSend }: ChatInputProps) {
-  const [inputMessage, setInputMessage] = useState('')
+export default function ChatInput({ value, onChange, onSubmit }: ChatInputProps) {
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (inputMessage.length === 0) return
+    if (value.length === 0) return
     // IME 조합 중일 때는 무시 (한글 입력 시 중복 전송 방지)
     if (e.nativeEvent.isComposing) return
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
-      onSend(inputMessage)
-      setInputMessage('')
+      onSubmit()
     }
   }
 
   return (
     <textarea
-      name=""
-      id=""
       rows={1}
-      onChange={(e) => setInputMessage(e.target.value)}
+      onChange={(e) => onChange(e.target.value)}
       onKeyDown={handleKeyDown}
-      value={inputMessage}
+      value={value}
       placeholder="채팅을 입력하세요."
       className="h-fit w-full resize-none rounded bg-[#E5E7EB]/50 p-2.5 focus:outline-none"
     />


### PR DESCRIPTION
## 📌 개요

- ChatInput 컴포넌트를 제어 컴포넌트로 변경하여 상태 관리 개선

## 🔧 작업 내용

- [x] 입력 상태를 부모 컴포넌트(ChattingPage)로 끌어올림
- [x] ChatInput을 제어 컴포넌트로 변경
- [x] 전송 버튼 클릭 시에도 메시지 전송 가능하도록 수정

## 📎 관련 이슈

Closes #363

## 💬 리뷰어 참고 사항

- ChatInput의 내부 상태를 props로 전달받도록 변경했습니다