### PR TITLE
fix: 채팅방 메시지 중복 표시 수정(#366)

### DIFF
--- a/src/pages/chatting-page/ChattingPage.tsx
+++ b/src/pages/chatting-page/ChattingPage.tsx
@@ -23,7 +23,7 @@ export default function ChattingPage() {
   const navigate = useNavigate()
   const { user, accessToken } = useUserStore()
   const { id: chatRoomId } = useParams()
-  const { connect, disconnect, subscribeToRoom, isConnected, sendMessage, messages: realtimeMessages, clearUnreadCount } = chatSocketStore()
+  const { connect, disconnect, subscribeToRoom, isConnected, sendMessage, messages: realtimeMessages, clearUnreadCount, clearRoomMessages } = chatSocketStore()
   const fileInputRef = useRef<HTMLInputElement>(null)
   const {
     data: roomMessages,
@@ -115,9 +115,11 @@ export default function ChattingPage() {
   // 연결 완료 후 구독 (중복 구독은 subscribeToRoom 내부에서 방지)
   useEffect(() => {
     if (isConnected && chatRoomId) {
+      // 채팅방 진입 시 실시간 메시지 초기화 (httpMessages와 중복 방지)
+      clearRoomMessages(Number(chatRoomId))
       subscribeToRoom(Number(chatRoomId))
     }
-  }, [isConnected, chatRoomId, subscribeToRoom])
+  }, [isConnected, chatRoomId, subscribeToRoom, clearRoomMessages])
 
   useEffect(() => {
     if (rooms && chatRoomId && !selectedRoom) {

--- a/src/store/chatSocketStore.ts
+++ b/src/store/chatSocketStore.ts
@@ -37,6 +37,7 @@ interface ChatSocketState {
   //---
   subscriptions: Record<number, StompSubscription> // 구독한 채팅방들의 구독 객체를 저장합니다. 나중에 unsubscribeFromRoom에서 특정 채팅방 구독을 해제할 때 사용합니다.
   unsubscribeFromRoom: (chatRoomId: number) => void // 채팅방을 나갈 때 해당 채팅방의 구독을 해제해야 합니다. subscriptions[chatRoomId].unsubscribe()를 호출합니다.
+  clearRoomMessages: (chatRoomId: number) => void // 채팅방의 실시간 메시지를 초기화합니다. (중복 방지)
   isConnected: boolean // STOMP 연결 상태를 UI에서 확인할 수 있도록 합니다. onConnect 시 true, onDisconnect 시 false로 설정됩니다.
   // 채팅방별 업데이트 정보
   chatRoomUpdates: Record<number, ChatRoomUpdateResponse>
@@ -232,5 +233,11 @@ export const chatSocketStore = create<ChatSocketState>((set, get) => ({
         return { subscriptions: rest }
       })
     }
+  },
+  clearRoomMessages: (chatRoomId: number) => {
+    set((state) => {
+      const { [chatRoomId]: _, ...rest } = state.messages
+      return { messages: rest }
+    })
   },
 }))


### PR DESCRIPTION
## 📌 개요

- 채팅방 진입 시 httpMessages와 실시간 메시지가 중복 표시되는 문제 수정

## 🔧 작업 내용

- [x] chatSocketStore에 clearRoomMessages 함수 추가
- [x] ChattingPage에서 채팅방 진입 시 실시간 메시지 초기화

## 📎 관련 이슈

Closes #366

## 💬 리뷰어 참고 사항

- 채팅방 구독 전에 해당 채팅방의 실시간 메시지를 초기화하여 중복 표시 방지