### PR TITLE
refactor: 홈 필터 상태 전역 store로 마이그레이션(#368)

### DIFF
--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,7 +1,8 @@
 import CuddleMarketLogo from '@assets/images/CuddleMarketLogoImage.png'
 import { ROUTES } from '@src/constants/routes'
-import { Link } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import { cn } from '@src/utils/cn'
+import { useFilterStore } from '@src/store/filterStore'
 
 interface LogoProps {
   logoClassname?: string
@@ -9,8 +10,16 @@ interface LogoProps {
 }
 
 export default function Logo({ logoClassname, textClassname }: LogoProps) {
+  const [, setSearchParams] = useSearchParams()
+  const resetFilters = useFilterStore((state) => state.resetFilters)
+
+  const handleLogoClick = () => {
+    setSearchParams({})
+    resetFilters()
+  }
+
   return (
-    <Link to={ROUTES.HOME} className="flex items-center gap-2">
+    <Link to={ROUTES.HOME} onClick={handleLogoClick} className="flex items-center gap-2">
       <div className={cn('h-11 w-auto object-contain md:h-16', logoClassname)}>
         <img src={CuddleMarketLogo} alt="CuddleMarket 로고" className="h-full w-full object-cover" />
       </div>

--- a/src/store/filterStore.ts
+++ b/src/store/filterStore.ts
@@ -1,0 +1,48 @@
+import { create } from 'zustand'
+import type { PetTypeTabId, PriceRange, LocationFilter, CategoryFilter, ProductTypeTabId } from '@src/constants/constants'
+
+interface FilterState {
+  activePetTypeTab: PetTypeTabId
+  selectedDetailPet: CategoryFilter | null
+  selectedCategory: CategoryFilter | null
+  selectedProductStatus: string | null
+  selectedProductPrice: PriceRange | null
+  selectedLocation: LocationFilter | null
+  selectedSort: string
+  activeProductTypeTab: ProductTypeTabId
+
+  setActivePetTypeTab: (tab: PetTypeTabId) => void
+  setSelectedDetailPet: (pet: CategoryFilter | null) => void
+  setSelectedCategory: (category: CategoryFilter | null) => void
+  setSelectedProductStatus: (status: string | null) => void
+  setSelectedProductPrice: (price: PriceRange | null) => void
+  setSelectedLocation: (location: LocationFilter | null) => void
+  setSelectedSort: (sort: string) => void
+  setActiveProductTypeTab: (tab: ProductTypeTabId) => void
+  resetFilters: () => void
+}
+
+const initialState = {
+  activePetTypeTab: 'tab-all' as PetTypeTabId,
+  selectedDetailPet: null,
+  selectedCategory: null,
+  selectedProductStatus: null,
+  selectedProductPrice: null,
+  selectedLocation: null,
+  selectedSort: '최신순',
+  activeProductTypeTab: 'tab-all' as ProductTypeTabId,
+}
+
+export const useFilterStore = create<FilterState>((set) => ({
+  ...initialState,
+
+  setActivePetTypeTab: (tab) => set({ activePetTypeTab: tab }),
+  setSelectedDetailPet: (pet) => set({ selectedDetailPet: pet }),
+  setSelectedCategory: (category) => set({ selectedCategory: category }),
+  setSelectedProductStatus: (status) => set({ selectedProductStatus: status }),
+  setSelectedProductPrice: (price) => set({ selectedProductPrice: price }),
+  setSelectedLocation: (location) => set({ selectedLocation: location }),
+  setSelectedSort: (sort) => set({ selectedSort: sort }),
+  setActiveProductTypeTab: (tab) => set({ activeProductTypeTab: tab }),
+  resetFilters: () => set(initialState),
+}))


### PR DESCRIPTION
## 📌 개요

- 홈 페이지 필터 상태를 전역 store로 마이그레이션하여 다른 컴포넌트에서도 접근 가능하도록 개선

## 🔧 작업 내용

- [x] filterStore 생성 (전역 상태 관리)
- [x] Home.tsx의 로컬 상태를 filterStore로 마이그레이션
- [x] 로고 클릭 시 필터 및 URL 파라미터 초기화

## 📎 관련 이슈

Closes #368

## 💬 리뷰어 참고 사항

- 로고 클릭 시 필터가 초기화되어 홈으로 이동합니다
- 기존 로컬 상태를 zustand store로 변경했습니다