### PR TITLE
fix: 커뮤니티 탭 URL 동기화 버그 수정(#373)

### DIFF
--- a/src/pages/community/CommunityPage.tsx
+++ b/src/pages/community/CommunityPage.tsx
@@ -1,5 +1,5 @@
 import { SimpleHeader } from '@src/components/header/SimpleHeader'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { COMMUNITY_SEARCH_TYPE, COMMUNITY_SORT_TYPE, COMMUNITY_TABS, type CommunityTabId } from '@src/constants/constants'
 import { CommunityTabs } from './components/CommunityTabs'
@@ -25,6 +25,14 @@ export default function CommunityPage() {
   const { isCollapsed: isFilterCollapsed } = useScrollDirection()
 
   const [activeCommunityTypeTab, setActiveCommunityTypeTab] = useState<CommunityTabId>(initialTab)
+
+  // URL의 tab 파라미터가 변경되면 탭 상태 동기화
+  useEffect(() => {
+    if (tabParam) {
+      setActiveCommunityTypeTab(tabParam)
+    }
+  }, [tabParam])
+
   const sortBy = searchParams.get('sortBy')
   const [selectedSort, setSelectedSort] = useState<string>(() => {
     const sortItem = COMMUNITY_SEARCH_TYPE.find((sort) => {


### PR DESCRIPTION
## 📌 개요

- 커뮤니티 페이지에서 URL의 tab 파라미터가 변경되어도 탭 상태가 동기화되지 않는 버그를 수정합니다.

## 🔧 작업 내용

- [x] useEffect를 통해 URL의 tab 파라미터 변경 시 탭 상태 동기화

## 📎 관련 이슈

Closes #373

## 💬 리뷰어 참고 사항

- 브라우저 뒤로가기/앞으로가기 시 탭 상태가 URL과 동기화되는지 확인