### PR TITLE
refactor: z-index 체계 정리 및 모바일 네비게이션 개선(#376)

### DIFF
--- a/src/components/commons/select/SelectDropdown.tsx
+++ b/src/components/commons/select/SelectDropdown.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { cn } from '@src/utils/cn'
 import { ChevronDown as DownArrow } from 'lucide-react'
+import { Z_INDEX } from '@src/constants/ui'
 
 // 메인 토글 버튼 컴포넌트
 interface SelectProps {
@@ -99,7 +100,7 @@ function SelectOptions({ options, selectedValue, onSelect, placeholder, optionCl
       ref={listboxRef}
       role="listbox"
       aria-label={placeholder}
-      className="absolute top-full left-0 z-20 mt-0.5 flex max-h-56 w-full flex-col gap-1 overflow-scroll rounded-md border border-gray-400 bg-white p-1 shadow-md"
+      className={cn('absolute top-full left-0 mt-0.5 flex max-h-56 w-full flex-col gap-1 overflow-scroll rounded-md border border-gray-400 bg-white p-1 shadow-md', Z_INDEX.DROPDOWN)}
     >
       {options.map((option) => {
         const isSelected = selectedValue === option.value

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -10,6 +10,7 @@ import { useMediaQuery } from '@src/hooks/useMediaQuery'
 import { useEffect, useRef, useState } from 'react'
 import { IconButton } from '@src/components/commons/button/IconButton'
 import { Search } from 'lucide-react'
+
 interface HeaderProps {
   hideSearchBar?: boolean
   hideMenuButton?: boolean
@@ -29,6 +30,7 @@ function Header({ hideSearchBar = false, hideMenuButton = false }: HeaderProps) 
   }, [])
 
   return (
+    <>
     <header
       className={cn(
         'bg-primary-200 sticky top-0 flex w-full items-center justify-center py-3',
@@ -76,8 +78,9 @@ function Header({ hideSearchBar = false, hideMenuButton = false }: HeaderProps) 
           </div>
         )}
       </div>
-      <MobileNavigation isOpen={isSideOpen} onClose={() => setIsSideOpen(false)} />
     </header>
+    <MobileNavigation isOpen={isSideOpen} onClose={() => setIsSideOpen(false)} />
+  </>
   )
 }
 

--- a/src/components/header/components/UserControls.tsx
+++ b/src/components/header/components/UserControls.tsx
@@ -35,13 +35,13 @@ export default function UserControls({ isSideOpen, setIsSideOpen, hideMenuButton
   return (
     <div className="flex items-center gap-2 md:gap-4">
       {isLogin() ? (
-        <div className="flex items-center gap-3">
-          <Link to={ROUTES.CHAT} className="">
-            <MessageCircleMore />
+        <div className="flex items-center gap-1">
+          <Link to={ROUTES.CHAT} className="ml-1">
+            <MessageCircleMore className="text-white" strokeWidth={1.5} />
           </Link>
           <div className="relative mr-2.5" onClick={handleBellToggle}>
             <IconButton aria-label="알림" size="lg" className="hover:bg-transparent">
-              <Bell size={24} className="stroke-gray-600" />
+              <Bell size={24} className="stroke-white" />
             </IconButton>
             {(unreadCountData?.unreadCount ?? 0) > 0 && (
               <span className="bg-danger-500 absolute top-0 -right-2 flex size-5 items-center justify-center rounded-full p-2 text-sm text-white">
@@ -50,12 +50,13 @@ export default function UserControls({ isSideOpen, setIsSideOpen, hideMenuButton
             )}
             {isNotificationOpen && <NotificationsDropdown isNotificationOpen={isNotificationOpen} setIsNotificationOpen={setIsNotificationOpen} />}
           </div>
-
           <UserMenu
             isNotificationOpen={false}
             setIsNotificationOpen={setIsNotificationOpen}
             isUserMenuOpen={isUserMenuOpen}
             setIsUserMenuOpen={setIsUserMenuOpen}
+            isSideOpen={isSideOpen}
+            setIsSideOpen={setIsSideOpen}
           />
         </div>
       ) : (

--- a/src/components/header/components/user-section/UserMenu.tsx
+++ b/src/components/header/components/user-section/UserMenu.tsx
@@ -1,7 +1,7 @@
 // import Icon from '@components/commons/Icon'
 import { Z_INDEX } from '@constants/ui'
 import { cn } from '@utils/cn'
-import { UserRound as UserRoundIcon, LogOut as LogOutIcon, MessageSquare } from 'lucide-react'
+import { UserRound as UserRoundIcon, LogOut as LogOutIcon } from 'lucide-react'
 import { ROUTES } from '@src/constants/routes'
 import { useUserStore } from '@src/store/userStore'
 import { logout } from '@src/api/auth'
@@ -11,22 +11,27 @@ import { ProfileAvatar } from '@src/components/commons/ProfileAvatar'
 import { Link } from 'react-router-dom'
 import { useRef } from 'react'
 import { useOutsideClick } from '@src/hooks/useOutsideClick'
+import { useMediaQuery } from '@src/hooks/useMediaQuery'
+import { IconButton } from '@src/components/commons/button/IconButton'
+import { Menu } from 'lucide-react'
 
 interface UserMenuProps {
   isNotificationOpen: boolean
   setIsNotificationOpen: (isNotificationOpen: boolean) => void
   isUserMenuOpen: boolean
   setIsUserMenuOpen: (isUserMenuOpen: boolean) => void
+  isSideOpen: boolean
+  setIsSideOpen: (isSideOpen: boolean) => void
   userNickname?: string
 }
 
-export default function UserMenu({ isNotificationOpen, setIsNotificationOpen, isUserMenuOpen, setIsUserMenuOpen }: UserMenuProps) {
+export default function UserMenu({ isNotificationOpen, setIsNotificationOpen, isUserMenuOpen, setIsUserMenuOpen, isSideOpen, setIsSideOpen }: UserMenuProps) {
   const { user, clearAll } = useUserStore()
   const { openLogoutModal } = useLoginModalStore()
   const { disconnect } = chatSocketStore()
   const modalRef = useRef<HTMLDivElement>(null)
   useOutsideClick(isUserMenuOpen, [modalRef], () => setIsUserMenuOpen(false))
-
+  const isMd = useMediaQuery('(min-width: 768px)')
   const handleAvatarToggle = () => {
     if (isNotificationOpen) {
       setIsNotificationOpen(false)
@@ -53,11 +58,9 @@ export default function UserMenu({ isNotificationOpen, setIsNotificationOpen, is
     openLogoutModal(onLogout)
   }
 
-  return (
+  return isMd ? (
     <div className="relative flex cursor-pointer items-center gap-2" onClick={handleAvatarToggle}>
       <ProfileAvatar imageUrl={user?.profileImageUrl} nickname={user?.nickname || ''} size="sm" />
-
-      <p className="hidden text-base text-gray-700 md:block">{user?.nickname}</p>
       {isUserMenuOpen && (
         <div
           className={cn(
@@ -66,10 +69,6 @@ export default function UserMenu({ isNotificationOpen, setIsNotificationOpen, is
           )}
           ref={modalRef}
         >
-          <Link to={ROUTES.COMMUNITY} className="hover:bg-primary-50 flex w-full items-center gap-3 px-4 py-2.5 text-sm text-gray-700">
-            <MessageSquare className="h-5 w-5" />
-            커뮤니티
-          </Link>
           <Link to={ROUTES.MYPAGE} className="hover:bg-primary-50 flex w-full items-center gap-3 px-4 py-2.5 text-sm text-gray-700">
             <UserRoundIcon className="h-5 w-5" />
             마이페이지
@@ -84,5 +83,9 @@ export default function UserMenu({ isNotificationOpen, setIsNotificationOpen, is
         </div>
       )}
     </div>
+  ) : (
+    <IconButton aria-label="메뉴" onClick={() => setIsSideOpen(!isSideOpen)}>
+      <Menu className="text-white" />
+    </IconButton>
   )
 }

--- a/src/components/modal/BlockModal.tsx
+++ b/src/components/modal/BlockModal.tsx
@@ -6,6 +6,7 @@ import { userBlocked } from '@src/api/profile'
 import { useQueryClient } from '@tanstack/react-query'
 import { useRef } from 'react'
 import { useOutsideClick } from '@src/hooks/useOutsideClick'
+import { Z_INDEX } from '@src/constants/ui'
 
 interface BlockModalProps {
   isOpen: boolean
@@ -33,7 +34,7 @@ export default function BlockModal({ isOpen, onCancel, userNickname, userId }: B
   }
   if (!isOpen) return null
   return (
-    <div className="fixed inset-0 z-100 flex items-center justify-center bg-gray-900/70">
+    <div className={`fixed inset-0 flex items-center justify-center bg-gray-900/70 ${Z_INDEX.MODAL}`}>
       <div ref={modalRef} className="flex w-11/12 flex-col gap-4 rounded-lg bg-white p-5 md:w-[16vw] md:min-w-max">
         <ModalTitle heading="사용자 차단하기" description={`정말로 ${userNickname}를 신고하시겠습니까?`} />
         <AlertBox alertList={USER_BLOCK_ALERT_LIST} />

--- a/src/components/modal/DeleteConfirmModal.tsx
+++ b/src/components/modal/DeleteConfirmModal.tsx
@@ -6,6 +6,7 @@ import { PRODUCT_DELETE_ALERT_LIST } from '@src/constants/constants'
 import ModalTitle from './ModalTitle'
 import { useRef } from 'react'
 import { useOutsideClick } from '@src/hooks/useOutsideClick'
+import { Z_INDEX } from '@src/constants/ui'
 
 interface DeleteConfirmModalProps {
   isOpen: boolean
@@ -21,7 +22,7 @@ function DeleteConfirmModal({ isOpen, product, onConfirm, onCancel }: DeleteConf
   if (!isOpen || !product) return null
 
   return (
-    <div className="fixed inset-0 z-100 flex items-center justify-center bg-gray-900/70">
+    <div className={`fixed inset-0 flex items-center justify-center bg-gray-900/70 ${Z_INDEX.MODAL}`}>
       <div className="flex w-11/12 flex-col gap-4 rounded-lg bg-white p-5 md:w-[16vw] md:min-w-96" ref={modalRef}>
         <ModalTitle heading="상품 삭제" description="정말로 이 상품을 삭제하시겠습니까?" />
         <AlertBox alertList={PRODUCT_DELETE_ALERT_LIST} />

--- a/src/components/modal/DeletePostConfirmModal.tsx
+++ b/src/components/modal/DeletePostConfirmModal.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react'
 import { Button } from '../commons/button/Button'
 import ModalTitle from './ModalTitle'
 import { useOutsideClick } from '@src/hooks/useOutsideClick'
+import { Z_INDEX } from '@src/constants/ui'
 
 interface DeletePostConfirmProps {
   isOpen: boolean
@@ -17,7 +18,7 @@ export default function DeletePostConfirmModal({ isOpen, postId, onConfirm, onCa
   if (!isOpen || !postId) return null
 
   return (
-    <div className="fixed inset-0 z-100 flex items-center justify-center bg-gray-900/70">
+    <div className={`fixed inset-0 flex items-center justify-center bg-gray-900/70 ${Z_INDEX.MODAL}`}>
       <div className="flex w-11/12 flex-col gap-4 rounded-lg bg-white p-5 md:w-[16vw] md:min-w-96" ref={modalRef}>
         <ModalTitle heading="게시글 삭제" description="정말로 이 게시글을 삭제하시겠습니까?" />
         <div className="flex justify-end gap-3">

--- a/src/components/modal/LoginModal.tsx
+++ b/src/components/modal/LoginModal.tsx
@@ -4,6 +4,7 @@ import { ROUTES } from '@src/constants/routes'
 import { useLoginModalStore } from '@src/store/modalStore'
 import { useRef } from 'react'
 import { useOutsideClick } from '@src/hooks/useOutsideClick'
+import { Z_INDEX } from '@src/constants/ui'
 
 export default function ConfirmModal() {
   const { isOpen, modalType, onConfirm, closeModal } = useLoginModalStore()
@@ -27,7 +28,7 @@ export default function ConfirmModal() {
   }
 
   return (
-    <div className="fixed inset-0 z-100 flex items-center justify-center bg-gray-900/70">
+    <div className={`fixed inset-0 flex items-center justify-center bg-gray-900/70 ${Z_INDEX.MODAL}`}>
       <div ref={modalRef} className="flex w-11/12 flex-col items-center gap-6 rounded-lg bg-white p-5 md:w-[16vw] md:min-w-80">
         <div className="flex w-full flex-col items-center gap-2">
           <h3 className="heading-h4">{heading}</h3>

--- a/src/components/modal/ReportModalBase.tsx
+++ b/src/components/modal/ReportModalBase.tsx
@@ -6,6 +6,7 @@ import { ReportApiErrors } from '@src/pages/signup/validationRules'
 import ImageUploadField from '@src/pages/product-post/components/imageUploadField/ImageUploadField'
 import { useRef, type ReactNode } from 'react'
 import { useOutsideClick } from '@src/hooks/useOutsideClick'
+import { Z_INDEX } from '@src/constants/ui'
 
 export interface ReportFormValues {
   reasonCode: string
@@ -64,7 +65,7 @@ export default function ReportModalBase({ isOpen, heading, description, reasons,
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 z-100 flex items-center justify-center bg-gray-900/70 p-4">
+    <div className={`fixed inset-0 flex items-center justify-center bg-gray-900/70 p-4 ${Z_INDEX.MODAL}`}>
       <div ref={modalRef} className="flex max-h-[90vh] w-11/12 flex-col gap-4 overflow-y-auto rounded-lg bg-white p-5 md:w-[16vw] md:min-w-96">
         <ModalTitle heading={heading} description={description} />
 

--- a/src/components/modal/WithdrawModal.tsx
+++ b/src/components/modal/WithdrawModal.tsx
@@ -8,6 +8,7 @@ import AlertBox from './AlertBox'
 import ModalTitle from './ModalTitle'
 import { useRef } from 'react'
 import { useOutsideClick } from '@src/hooks/useOutsideClick'
+import { Z_INDEX } from '@src/constants/ui'
 
 export interface WithDrawFormValues {
   reason: string
@@ -55,7 +56,7 @@ export default function WithdrawModal({ isOpen, onConfirm, onCancel }: WithdrawM
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 z-100 flex items-center justify-center bg-gray-900/70">
+    <div className={`fixed inset-0 flex items-center justify-center bg-gray-900/70 ${Z_INDEX.MODAL}`}>
       <div ref={modalRef} className="flex w-11/12 flex-col gap-4 rounded-lg bg-white p-5 md:w-[16vw] md:min-w-96">
         <ModalTitle heading="회원탈퇴" description="정말로 탈퇴하시겠습니까?" />
         <AlertBox alertList={WITH_DRAW_ALERT_LIST} />

--- a/src/constants/ui.ts
+++ b/src/constants/ui.ts
@@ -1,8 +1,10 @@
 export const Z_INDEX = {
-  HEADER: 'z-25',
   DROPDOWN: 'z-20',
-  BUTTON: 'z-25',
-  MODAL: 'z-30',
-  POPUP: 'z-40',
-  TOAST: 'z-50',
+  HEADER: 'z-30',
+  BUTTON: 'z-30',
+  FLOATING_BUTTON: 'z-30',
+  OVERLAY: 'z-40',
+  SIDEBAR: 'z-50',
+  TOAST: 'z-[60]',
+  MODAL: 'z-[100]',
 } as const

--- a/src/pages/chatting-page/ChattingPage.tsx
+++ b/src/pages/chatting-page/ChattingPage.tsx
@@ -13,6 +13,7 @@ import { ChatLog } from '@src/pages/chatting-page/components/ChatLog'
 import ChatInput from './components/ChatInput'
 import { uploadImage } from '@src/api/products'
 import { cn } from '@src/utils/cn'
+import { Z_INDEX } from '@src/constants/ui'
 // const WS_URL = 'http://192.168.45.25:8080/ws-stomp'
 const VITE_WS_URL = import.meta.env.VITE_WS_URL || 'http://localhost:8080/ws-stomp'
 export default function ChattingPage() {
@@ -161,7 +162,7 @@ export default function ChattingPage() {
                   isLoadingPrevious={isFetchingNextPage}
                 />
               </div>
-              <div className="fixed right-0 bottom-0 left-0 z-25 flex items-center gap-2.5 bg-white p-3.5 md:static">
+              <div className={cn('fixed right-0 bottom-0 left-0 flex items-center gap-2.5 bg-white p-3.5 md:static', Z_INDEX.HEADER)}>
                 <input type="file" id="chat-file-input" ref={fileInputRef} className="hidden" accept="image/*" onChange={handleImageSend} />
                 <label htmlFor="chat-file-input" className="cursor-pointer rounded p-1">
                   <Paperclip size={20} />

--- a/src/pages/community/CommunityPage.tsx
+++ b/src/pages/community/CommunityPage.tsx
@@ -16,6 +16,7 @@ import { useMediaQuery } from '@src/hooks/useMediaQuery'
 import { useScrollDirection } from '@src/hooks/useScrollDirection'
 import { Button } from '@src/components/commons/button/Button'
 import { cn } from '@src/utils/cn'
+import { Z_INDEX } from '@src/constants/ui'
 
 export default function CommunityPage() {
   const [searchParams, setSearchParams] = useSearchParams()
@@ -162,14 +163,14 @@ export default function CommunityPage() {
       <SimpleHeader
         title={headerTitle}
         description={isMd ? headerDescription : undefined}
-        layoutClassname="py-5 justify-between border-b border-gray-200 md:static sticky top-16 z-20"
+        layoutClassname={`py-5 justify-between border-b border-gray-200 md:static sticky top-16 ${Z_INDEX.DROPDOWN}`}
       />
       <div className="relative min-h-screen bg-[#F3F4F6] pt-0 md:pt-5">
         <div className="pb-4xl mx-auto max-w-7xl px-0 md:px-4">
           <div className="flex w-full flex-col">
             {/* 모바일: 필터 영역 */}
             {!isMd && (
-              <div className="sticky top-32 z-20 bg-white">
+              <div className={`sticky top-32 bg-white ${Z_INDEX.DROPDOWN}`}>
                 {/* 접히는 필터 영역 */}
                 <div
                   className={cn(
@@ -334,7 +335,7 @@ export default function CommunityPage() {
           </div>
         </div>
         {!isMd && isLogin() && (
-          <Link to={ROUTES.COMMUNITY_POST} type="button" className="bg-primary-200 fixed right-4 bottom-4 rounded-full px-3 py-3 text-white">
+          <Link to={ROUTES.COMMUNITY_POST} type="button" className={`bg-primary-200 fixed right-4 bottom-4 rounded-full px-3 py-3 text-white ${Z_INDEX.FLOATING_BUTTON}`}>
             <Plus />
           </Link>
         )}

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -20,6 +20,7 @@ import { Button } from '@src/components/commons/button/Button'
 import { useUserStore } from '@src/store/userStore'
 import { useMediaQuery } from '@src/hooks/useMediaQuery'
 import { useFilterStore } from '@src/store/filterStore'
+import { Z_INDEX } from '@src/constants/ui'
 
 function Home() {
   const { isLogin } = useUserStore()
@@ -283,7 +284,7 @@ function Home() {
       </div>
       {/* <ChatButton /> */}
       {isLoggedIn && (
-        <div className="fixed right-10 bottom-5 z-50">
+        <div className={`fixed right-10 bottom-5 ${Z_INDEX.FLOATING_BUTTON}`}>
           <Button size={isMd ? 'lg' : 'md'} className="bg-primary-300 cursor-pointer text-white" icon={Plus} onClick={toGoProductPostPage}>
             상품등록
           </Button>


### PR DESCRIPTION
## 📌 개요

- z-index 값을 상수로 통일하여 관리 용이성 향상
- 모바일 네비게이션에서 로그인 상태에 따른 버튼 대응

## 🔧 작업 내용

- [x] z-index 상수 체계 정리 (DROPDOWN: 20, HEADER: 30, OVERLAY: 40, SIDEBAR: 50, TOAST: 60, MODAL: 100)
- [x] 모달 컴포넌트 z-index 상수 적용 (6개 파일)
- [x] 모바일 네비게이션 로그인 상태 대응 (로그인↔로그아웃, 회원가입↔마이페이지)
- [x] UserMenu 모바일 반응형 개선 (햄버거 메뉴 버튼)
- [x] UserControls 아이콘 색상 흰색으로 변경
- [x] SelectDropdown, CommunityPage, ChattingPage, Home z-index 상수 적용

## 📎 관련 이슈

Closes #376

## 💬 리뷰어 참고 사항

- 모바일에서 로그인 상태에 따른 버튼 변경 확인 (로그인↔로그아웃)
- z-index 우선순위가 올바르게 적용되는지 확인 (모달이 최상위)