### PR TITLE
fix: 로그인 후 redirectUrl 복귀 처리(#379)

### DIFF
--- a/src/hooks/useFavorite.ts
+++ b/src/hooks/useFavorite.ts
@@ -10,7 +10,7 @@ interface UseFavoriteOptions {
 }
 
 export function useFavorite({ productId, initialIsFavorite }: UseFavoriteOptions) {
-  const { isLogin } = useUserStore()
+  const { isLogin, setRedirectUrl } = useUserStore()
   const { openLoginModal } = useLoginModalStore()
   const queryClient = useQueryClient()
   const [isFavorite, setIsFavorite] = useState(initialIsFavorite)
@@ -44,6 +44,7 @@ export function useFavorite({ productId, initialIsFavorite }: UseFavoriteOptions
 
     // 미로그인 시 로그인 모달 열기
     if (!isLogin()) {
+      setRedirectUrl(window.location.pathname)
       openLoginModal()
       return
     }

--- a/src/pages/login/components/LoginForm.tsx
+++ b/src/pages/login/components/LoginForm.tsx
@@ -32,7 +32,9 @@ export function LoginForm() {
       const response = await login(data)
       handleLogin(response.data.user, response.data.accessToken, response.data.refreshToken)
       console.log('로그인 성공:', response)
-      navigate('/')
+      const redirectUrl = useUserStore.getState().redirectUrl
+      navigate(redirectUrl || '/')
+      useUserStore.getState().setRedirectUrl(null) // 사용 후 초기화
     } catch (error) {
       // console.error('로그인 실패:', error)
       if (axios.isAxiosError(error)) {

--- a/src/pages/my-page/MyPage.tsx
+++ b/src/pages/my-page/MyPage.tsx
@@ -12,7 +12,7 @@ import { withDraw } from '@src/api/profile'
 import ProfileData from '@src/components/profile/ProfileData'
 
 function MyPage() {
-  const { user, clearAll, updateUserProfile } = useUserStore()
+  const { user, clearAll, updateUserProfile, setRedirectUrl } = useUserStore()
   const [searchParams, setSearchParams] = useSearchParams()
   const queryClient = useQueryClient()
   const navigate = useNavigate()
@@ -178,6 +178,7 @@ function MyPage() {
     )
   }
   if (!user?.id) {
+    setRedirectUrl(window.location.pathname)
     navigate('/auth/login')
   }
 

--- a/src/pages/product-detail/components/SellerProfileCard.tsx
+++ b/src/pages/product-detail/components/SellerProfileCard.tsx
@@ -12,11 +12,12 @@ interface SellerProfileCardProps {
 }
 
 export default function SellerProfileCard({ sellerInfo }: SellerProfileCardProps) {
-  const { user, isLogin } = useUserStore()
+  const { user, isLogin, setRedirectUrl } = useUserStore()
   const { openLoginModal } = useLoginModalStore()
   const navigate = useNavigate()
   const goToUserPage = (sellerId: number) => {
     if (!isLogin()) {
+      setRedirectUrl(window.location.pathname)
       openLoginModal()
       return
     }


### PR DESCRIPTION
## 📌 개요

- 로그인 후 이전 페이지로 돌아가지 않고 항상 홈으로 이동하는 버그 수정

## 🔧 작업 내용

- [x] 미로그인 시 현재 URL을 `redirectUrl`에 저장
- [x] 로그인 성공 후 `redirectUrl`로 이동 후 초기화

## 📎 관련 이슈

Closes #379

## 💬 리뷰어 참고 사항

- `useFavorite`, `MyPage`, `SellerProfileCard`에서 로그인 필요 시 현재 URL 저장
- `LoginForm`에서 로그인 성공 후 저장된 URL로 이동