### PR TITLE
fix: 로그아웃 후 좋아요 상태 초기화 안되는 현상 해결(#378)

### DIFF
--- a/src/components/header/components/MobileNavigation.tsx
+++ b/src/components/header/components/MobileNavigation.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { X, ChevronDown } from 'lucide-react'
 import { cn } from '@src/utils/cn'
 import { ROUTES } from '@src/constants/routes'
@@ -11,6 +11,7 @@ import { useUserStore } from '@src/store/userStore'
 import { useLoginModalStore } from '@src/store/modalStore'
 import { chatSocketStore } from '@src/store/chatSocketStore'
 import { logout } from '@src/api/auth'
+import { useQueryClient } from '@tanstack/react-query'
 
 interface MobileNavigationProps {
   isOpen: boolean
@@ -18,6 +19,8 @@ interface MobileNavigationProps {
 }
 
 export default function MobileNavigation({ isOpen, onClose }: MobileNavigationProps) {
+  const queryClient = useQueryClient()
+  const navigator = useNavigate()
   const [isCommunityOpen, setIsCommunityOpen] = useState(false)
   const [communityHeight, setCommunityHeight] = useState(0)
   const communityRef = useRef<HTMLDivElement>(null)
@@ -42,6 +45,8 @@ export default function MobileNavigation({ isOpen, onClose }: MobileNavigationPr
       onClose()
       disconnect()
       clearAll()
+      queryClient.clear()
+      navigator(ROUTES.HOME)
     }
   }
 

--- a/src/components/header/components/user-section/UserMenu.tsx
+++ b/src/components/header/components/user-section/UserMenu.tsx
@@ -8,12 +8,13 @@ import { logout } from '@src/api/auth'
 import { useLoginModalStore } from '@src/store/modalStore'
 import { chatSocketStore } from '@src/store/chatSocketStore'
 import { ProfileAvatar } from '@src/components/commons/ProfileAvatar'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { useRef } from 'react'
 import { useOutsideClick } from '@src/hooks/useOutsideClick'
 import { useMediaQuery } from '@src/hooks/useMediaQuery'
 import { IconButton } from '@src/components/commons/button/IconButton'
 import { Menu } from 'lucide-react'
+import { useQueryClient } from '@tanstack/react-query'
 
 interface UserMenuProps {
   isNotificationOpen: boolean
@@ -25,7 +26,16 @@ interface UserMenuProps {
   userNickname?: string
 }
 
-export default function UserMenu({ isNotificationOpen, setIsNotificationOpen, isUserMenuOpen, setIsUserMenuOpen, isSideOpen, setIsSideOpen }: UserMenuProps) {
+export default function UserMenu({
+  isNotificationOpen,
+  setIsNotificationOpen,
+  isUserMenuOpen,
+  setIsUserMenuOpen,
+  isSideOpen,
+  setIsSideOpen,
+}: UserMenuProps) {
+  const queryClient = useQueryClient()
+  const navigator = useNavigate()
   const { user, clearAll } = useUserStore()
   const { openLogoutModal } = useLoginModalStore()
   const { disconnect } = chatSocketStore()
@@ -49,6 +59,8 @@ export default function UserMenu({ isNotificationOpen, setIsNotificationOpen, is
       setIsUserMenuOpen(false)
       disconnect() // WebSocket 연결 해제
       clearAll()
+      queryClient.clear()
+      navigator(ROUTES.HOME)
     }
   }
 


### PR DESCRIPTION
## 📌 개요

- 로그아웃 후에도 좋아요 상태가 초기화되지 않는 버그 수정

## 🔧 작업 내용

- [x] 로그아웃 시 `queryClient.clear()` 호출하여 React Query 캐시 초기화
- [x] 로그아웃 후 홈으로 리다이렉트

## 📎 관련 이슈

Closes #378

## 💬 리뷰어 참고 사항

- `UserMenu`, `MobileNavigation` 두 곳에서 로그아웃 처리
- 캐시 초기화로 이전 사용자 데이터가 남아있는 현상 해결