### PR TITLE
feat: 헤더 네비게이션 활성 상태 표시 기능 추가(#387)

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -4,13 +4,12 @@ import Logo from '../Logo'
 import { SearchBar } from './components/SearchBar'
 import UserControls from './components/UserControls'
 import MobileNavigation from './components/MobileNavigation'
-import { Link } from 'react-router-dom'
+import { NavLink } from 'react-router-dom'
 import { ROUTES } from '@src/constants/routes'
 import { useMediaQuery } from '@src/hooks/useMediaQuery'
 import { useEffect, useRef, useState } from 'react'
 import { IconButton } from '@src/components/commons/button/IconButton'
 import { Search } from 'lucide-react'
-import { NavLink } from 'react-router-dom'
 
 interface HeaderProps {
   hideSearchBar?: boolean


### PR DESCRIPTION
## 📌 개요

- 헤더의 네비게이션 링크에 현재 활성화된 페이지를 시각적으로 표시하는 기능 추가

## 🔧 작업 내용

- [x] Link 컴포넌트를 NavLink로 변경
- [x] 활성 상태일 때 하단 보더 및 강조 스타일 적용
- [x] 비활성 상태일 때 회색 텍스트로 구분

## 📎 관련 이슈

Closes #387

## 💬 리뷰어 참고 사항

- NavLink의 isActive 콜백을 활용하여 현재 페이지 상태에 따른 스타일 분기 처리