### PR TITLE
feat: 채팅방 목록 실시간 정렬 및 레이아웃 개선(#391)

### DIFF
--- a/src/pages/chatting-page/components/ChatRooms.tsx
+++ b/src/pages/chatting-page/components/ChatRooms.tsx
@@ -38,9 +38,9 @@ export function ChatRooms({ rooms, handleSelectRoom, selectedRoomId, hasNextPage
   }
 
   return (
-    <section className="flex h-full flex-col rounded-none border-t border-l border-gray-300 md:max-w-96 md:min-w-96 md:border-b">
+    <section className="flex flex-col rounded-none border-t border-l border-gray-300 md:max-w-96 md:min-w-96 md:border-b">
       <h2 className="border-b border-gray-300 p-5">채팅목록</h2>
-      <div className="scrollbar-hide overflow-y-scroll px-3 py-3 md:h-[70vh]">
+      <div className="scrollbar-hide flex-1 overflow-y-scroll px-3 py-3">
         <ul className="flex flex-col gap-2">
           {rooms &&
             rooms.map((room) => {


### PR DESCRIPTION
## 📌 개요

- 채팅방 목록을 최신 메시지 시간 순으로 실시간 정렬하고 레이아웃 개선

## 🔧 작업 내용

- [x] chatRoomUpdates를 활용한 실시간 메시지 시간 기준 정렬
- [x] 채팅 페이지 레이아웃 및 높이 개선
- [x] 채팅 입력 영역 상단 보더 추가

## 📎 관련 이슈

Closes #391

## 💬 리뷰어 참고 사항

- useMemo 내에서 chatRoomUpdates의 lastMessageTime을 활용하여 실시간 정렬 구현