### PR TITLE
refactor: 채팅 페이지 레이아웃 및 스크롤 동작 개선(#393)

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -33,7 +33,7 @@ function Header({ hideSearchBar = false, hideMenuButton = false }: HeaderProps) 
     <>
       <header
         className={cn(
-          'bg-primary-200 sticky top-0 flex w-full items-center justify-center py-3',
+          'bg-primary-200 fixed top-0 flex w-full items-center justify-center py-3',
           hideSearchBar ? 'h-16 md:h-24' : 'h-auto pb-0 md:h-24',
           `${Z_INDEX.HEADER}`
         )}

--- a/src/pages/chatting-page/ChattingPage.tsx
+++ b/src/pages/chatting-page/ChattingPage.tsx
@@ -174,7 +174,7 @@ export default function ChattingPage() {
   }, [])
 
   return (
-    <div className="md:pb-4xl h-[calc(100dvh-112px)] bg-white pt-0 md:h-auto md:pt-8">
+    <div className="md:pb-4xl bg-white pt-16 md:h-auto md:pt-8">
       <div className="mx-auto flex h-full max-w-7xl flex-col md:h-[80vh] md:flex-row">
         <div className={cn('md:flex', isChatOpen ? 'hidden' : 'block')}>
           <ChatRooms
@@ -186,11 +186,13 @@ export default function ChattingPage() {
             fetchNextPage={fetchNextRooms}
           />
         </div>
-        <section className={cn('flex flex-1 flex-col border border-gray-300', 'md:flex', isChatOpen ? 'flex' : 'hidden')}>
+        <section className={cn('relative flex flex-1 flex-col border border-gray-300 md:flex', isChatOpen ? 'flex' : 'hidden')}>
           {selectedRoom ? (
             <>
-              <ChatRoomInfo data={selectedRoom} onLeaveRoom={handleLeaveRoom} onBack={handleBack} />
-              <div className="bg-primary-50 h-1/2 flex-1 p-3.5">
+              <div className="sticky top-16 shrink-0 md:static">
+                <ChatRoomInfo data={selectedRoom} onLeaveRoom={handleLeaveRoom} onBack={handleBack} />
+              </div>
+              <div className="bg-primary-50 min-h-0 flex-1 p-3.5 pb-20 md:pb-3.5">
                 <ChatLog
                   roomMessages={allMessages}
                   onLoadPrevious={() => fetchNextPage()}
@@ -200,7 +202,7 @@ export default function ChattingPage() {
               </div>
               <div
                 className={cn(
-                  'fixed right-0 bottom-0 left-0 flex items-center gap-2.5 border-t border-gray-300 bg-white p-3.5 md:static',
+                  'fixed right-0 bottom-0 left-0 flex items-center gap-2.5 border-t border-gray-300 bg-white p-3.5 md:relative',
                   Z_INDEX.HEADER
                 )}
               >

--- a/src/pages/chatting-page/components/ChatLog.tsx
+++ b/src/pages/chatting-page/components/ChatLog.tsx
@@ -76,7 +76,7 @@ export function ChatLog({ roomMessages, onLoadPrevious, hasMorePrevious, isLoadi
   }, [roomMessages])
 
   return (
-    <div ref={scrollRef} onScroll={handleScroll} className="scrollbar-hide flex h-full flex-col gap-4 overflow-y-auto">
+    <div ref={scrollRef} onScroll={handleScroll} className="flex h-full flex-col gap-4 overflow-y-auto">
       {Object.entries(groupedMessages).map(([dateKey, messages]) => (
         <div key={dateKey} className="flex flex-col gap-2">
           <div className="flex justify-center">

--- a/src/pages/chatting-page/components/ChatRoomInfo.tsx
+++ b/src/pages/chatting-page/components/ChatRoomInfo.tsx
@@ -30,7 +30,7 @@ export function ChatRoomInfo({ data, onLeaveRoom, onBack }: ChatRoomInfoProps) {
     }
   }
   return (
-    <div className="sticky top-28 flex flex-col gap-2.5 bg-white p-3.5 md:static">
+    <div className="flex flex-col gap-2.5 bg-white p-3.5">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           {onBack && (

--- a/src/pages/chatting-page/components/ChatRooms.tsx
+++ b/src/pages/chatting-page/components/ChatRooms.tsx
@@ -38,8 +38,8 @@ export function ChatRooms({ rooms, handleSelectRoom, selectedRoomId, hasNextPage
   }
 
   return (
-    <section className="flex flex-col rounded-none border-t border-l border-gray-300 md:max-w-96 md:min-w-96 md:border-b">
-      <h2 className="border-b border-gray-300 p-5">채팅목록</h2>
+    <section className="relative flex flex-col rounded-none border-t border-l border-gray-300 md:max-w-96 md:min-w-96 md:border-b">
+      <h2 className="sticky top-16 border-b border-gray-300 p-5 md:static">채팅목록</h2>
       <div className="scrollbar-hide flex-1 overflow-y-scroll px-3 py-3">
         <ul className="flex flex-col gap-2">
           {rooms &&


### PR DESCRIPTION
## 📌 개요

- Header를 fixed로 변경하고 채팅 페이지 컴포넌트들의 레이아웃 및 스크롤 동작을 개선합니다.

## 🔧 작업 내용

- [x] Header: sticky → fixed로 변경하여 스크롤 시에도 상단 고정
- [x] ChattingPage: 레이아웃 높이 계산 및 포지셔닝 수정
- [x] ChatRoomInfo: sticky 포지셔닝을 부모 컴포넌트로 이동
- [x] ChatRooms: 채팅목록 헤더에 sticky 적용
- [x] ChatLog: scrollbar-hide 클래스 제거

## 📎 관련 이슈

Closes #393

## 📸 스크린샷 (선택)

(필요시 추가)

## 💬 리뷰어 참고 사항

- 모바일 환경에서의 스크롤 동작 확인 부탁드립니다.