### PR TITLE
fix: 채팅목록 헤더 스타일 수정(#395)

### DIFF
--- a/src/pages/chatting-page/components/ChatRooms.tsx
+++ b/src/pages/chatting-page/components/ChatRooms.tsx
@@ -6,6 +6,7 @@ import { getTimeAgo } from '@src/utils/getTimeAgo'
 import { cn } from '@src/utils/cn'
 import { chatSocketStore } from '@src/store/chatSocketStore'
 import { useIntersectionObserver } from '@src/hooks/useIntersectionObserver'
+import { Z_INDEX } from '@src/constants/ui'
 interface ChatRoomsProps {
   rooms: fetchChatRoom[]
   handleSelectRoom: (room: fetchChatRoom) => void
@@ -39,7 +40,7 @@ export function ChatRooms({ rooms, handleSelectRoom, selectedRoomId, hasNextPage
 
   return (
     <section className="relative flex flex-col rounded-none border-t border-l border-gray-300 md:max-w-96 md:min-w-96 md:border-b">
-      <h2 className="sticky top-16 border-b border-gray-300 p-5 md:static">채팅목록</h2>
+      <h2 className={cn('sticky top-16 border-b border-gray-300 bg-white p-5 md:static', Z_INDEX.HEADER)}>채팅목록</h2>
       <div className="scrollbar-hide flex-1 overflow-y-scroll px-3 py-3">
         <ul className="flex flex-col gap-2">
           {rooms &&


### PR DESCRIPTION
## 📌 개요

- 채팅목록 헤더가 sticky로 고정되어 있지만, 배경색이 없어 스크롤 시 콘텐츠와 겹쳐 보이는 문제 수정

## 🔧 작업 내용

- [x] 채팅목록 헤더에 `bg-white` 배경색 추가
- [x] `Z_INDEX.HEADER` z-index 적용으로 레이어 순서 정리

## 📎 관련 이슈

Close #395

## 📸 스크린샷 (선택)

(해당 없음)

## 💬 리뷰어 참고 사항

- sticky 헤더의 배경색 및 z-index 적용 여부 확인 부탁드립니다