### PR TITLE
fix: 모바일 레이아웃 상단 패딩 전역 처리(#397)

### DIFF
--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -11,7 +11,15 @@ const HIDE_HEADER_PATTERNS = [/^\/community\/\d+\/edit$/, new RegExp(`^${ROUTES.
 const HIDE_HEADER_MOBILE_PATTERNS = [/^\/community\/\d+$/]
 
 // SearchBar 숨김 경로 (정적 경로)
-const HIDE_SEARCHBAR_PATHS: string[] = [ROUTES.COMMUNITY, ROUTES.PROFILE_UPDATE, ROUTES.PRODUCT_POST, ROUTES.LOGIN, ROUTES.SIGNUP, ROUTES.FIND_PASSWORD, ROUTES.MYPAGE]
+const HIDE_SEARCHBAR_PATHS: string[] = [
+  ROUTES.COMMUNITY,
+  ROUTES.PROFILE_UPDATE,
+  ROUTES.PRODUCT_POST,
+  ROUTES.LOGIN,
+  ROUTES.SIGNUP,
+  ROUTES.FIND_PASSWORD,
+  ROUTES.MYPAGE,
+]
 
 // 메뉴 버튼 숨김 경로
 const HIDE_MENU_BUTTON_PATHS: string[] = [ROUTES.LOGIN, ROUTES.SIGNUP]
@@ -32,7 +40,7 @@ export default function MainLayout() {
     <div className="flex min-h-screen flex-col">
       {showHeader && <Header hideSearchBar={hideSearchBar} hideMenuButton={hideMenuButton} />}
       {/* <ChatFloatButton /> */}
-      <main className="w-full flex-1">
+      <main className="w-full flex-1 pt-16 md:pt-0">
         <Outlet />
       </main>
     </div>

--- a/src/pages/chatting-page/ChattingPage.tsx
+++ b/src/pages/chatting-page/ChattingPage.tsx
@@ -174,7 +174,7 @@ export default function ChattingPage() {
   }, [])
 
   return (
-    <div className="md:pb-4xl bg-white pt-16 md:h-auto md:pt-8">
+    <div className="md:pb-4xl bg-white md:h-auto md:pt-8">
       <div className="mx-auto flex h-full max-w-7xl flex-col md:h-[80vh] md:flex-row">
         <div className={cn('md:flex', isChatOpen ? 'hidden' : 'block')}>
           <ChatRooms


### PR DESCRIPTION
## 📌 개요

- 모바일에서 헤더로 인해 콘텐츠가 가려지는 문제를 MainLayout에서 전역으로 처리하도록 개선

## 🔧 작업 내용

- [x] MainLayout에서 모바일 상단 패딩(`pt-16 md:pt-0`) 전역 처리
- [x] ChattingPage에서 중복된 `pt-16` 제거

## 📎 관련 이슈

Close #397

## 📸 스크린샷 (선택)

(해당 없음)

## 💬 리뷰어 참고 사항

- 모바일에서 헤더 높이만큼 상단 패딩이 전역으로 적용되었는지 확인 부탁드립니다