### PR TITLE
fix: 데스크탑 레이아웃 상단 패딩 누락 수정(#399)

### DIFF
--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -40,7 +40,7 @@ export default function MainLayout() {
     <div className="flex min-h-screen flex-col">
       {showHeader && <Header hideSearchBar={hideSearchBar} hideMenuButton={hideMenuButton} />}
       {/* <ChatFloatButton /> */}
-      <main className="w-full flex-1 pt-16 md:pt-0">
+      <main className="w-full flex-1 pt-16 md:pt-24">
         <Outlet />
       </main>
     </div>


### PR DESCRIPTION
## 📌 개요

- 데스크탑(md 이상) 환경에서 메인 컨텐츠가 헤더에 가려지는 문제 수정

## 🔧 작업 내용

- [x] `MainLayout.tsx`에서 `md:pt-0` → `md:pt-24`로 변경하여 헤더 높이만큼 패딩 확보

## 📎 관련 이슈

Closes #399

## 💬 리뷰어 참고 사항

- #397에서 모바일 패딩은 처리되었으나, 데스크탑 패딩이 누락되어 추가 수정