### PR TITLE
fix: 로그아웃 시 인증 필요 페이지에서만 홈으로 리다이렉트(#405)

### DIFF
--- a/src/components/header/components/MobileNavigation.tsx
+++ b/src/components/header/components/MobileNavigation.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { X, ChevronDown } from 'lucide-react'
 import { cn } from '@src/utils/cn'
 import { ROUTES } from '@src/constants/routes'
@@ -21,6 +21,7 @@ interface MobileNavigationProps {
 export default function MobileNavigation({ isOpen, onClose }: MobileNavigationProps) {
   const queryClient = useQueryClient()
   const navigator = useNavigate()
+  const location = useLocation()
   const [isCommunityOpen, setIsCommunityOpen] = useState(false)
   const [communityHeight, setCommunityHeight] = useState(0)
   const communityRef = useRef<HTMLDivElement>(null)
@@ -36,6 +37,12 @@ export default function MobileNavigation({ isOpen, onClose }: MobileNavigationPr
   const { openLogoutModal } = useLoginModalStore()
   const { disconnect } = chatSocketStore()
 
+  // 로그인 필수 페이지 목록
+  const authRequiredPaths = [ROUTES.MYPAGE, ROUTES.PROFILE_UPDATE, ROUTES.CHAT]
+
+  // 현재 페이지가 로그인 필수 페이지인지 확인
+  const isAuthRequiredPage = authRequiredPaths.some((path) => location.pathname.startsWith(path))
+
   const handleLogout = async () => {
     try {
       await logout()
@@ -46,7 +53,9 @@ export default function MobileNavigation({ isOpen, onClose }: MobileNavigationPr
       disconnect()
       clearAll()
       queryClient.clear()
-      navigator(ROUTES.HOME)
+      if (isAuthRequiredPage) {
+        navigator(ROUTES.HOME)
+      }
     }
   }
 

--- a/src/components/header/components/user-section/UserMenu.tsx
+++ b/src/components/header/components/user-section/UserMenu.tsx
@@ -8,7 +8,7 @@ import { logout } from '@src/api/auth'
 import { useLoginModalStore } from '@src/store/modalStore'
 import { chatSocketStore } from '@src/store/chatSocketStore'
 import { ProfileAvatar } from '@src/components/commons/ProfileAvatar'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useRef } from 'react'
 import { useOutsideClick } from '@src/hooks/useOutsideClick'
 import { useMediaQuery } from '@src/hooks/useMediaQuery'
@@ -36,6 +36,7 @@ export default function UserMenu({
 }: UserMenuProps) {
   const queryClient = useQueryClient()
   const navigator = useNavigate()
+  const location = useLocation()
   const { user, clearAll } = useUserStore()
   const { openLogoutModal } = useLoginModalStore()
   const { disconnect } = chatSocketStore()
@@ -49,6 +50,12 @@ export default function UserMenu({
     setIsUserMenuOpen(!isUserMenuOpen)
   }
 
+  // 로그인 필수 페이지 목록
+  const authRequiredPaths = [ROUTES.MYPAGE, ROUTES.PROFILE_UPDATE, ROUTES.CHAT]
+
+  // 현재 페이지가 로그인 필수 페이지인지 확인
+  const isAuthRequiredPage = authRequiredPaths.some((path) => location.pathname.startsWith(path))
+
   // 로그아웃 실행 함수
   const onLogout = async () => {
     try {
@@ -60,7 +67,9 @@ export default function UserMenu({
       disconnect() // WebSocket 연결 해제
       clearAll()
       queryClient.clear()
-      navigator(ROUTES.HOME)
+      if (isAuthRequiredPage) {
+        navigator(ROUTES.HOME)
+      }
     }
   }
 

--- a/src/components/modal/LoginModal.tsx
+++ b/src/components/modal/LoginModal.tsx
@@ -1,13 +1,16 @@
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import { Button } from '@src/components/commons/button/Button'
 import { ROUTES } from '@src/constants/routes'
 import { useLoginModalStore } from '@src/store/modalStore'
+import { useUserStore } from '@src/store/userStore'
 import { useRef } from 'react'
 import { useOutsideClick } from '@src/hooks/useOutsideClick'
 import { Z_INDEX } from '@src/constants/ui'
 
 export default function ConfirmModal() {
   const { isOpen, modalType, onConfirm, closeModal } = useLoginModalStore()
+  const setRedirectUrl = useUserStore((state) => state.setRedirectUrl)
+  const location = useLocation()
   const modalRef = useRef<HTMLDivElement>(null)
   // 바깥 클릭 시 onCancel 호출
   useOutsideClick(isOpen, [modalRef], closeModal)
@@ -42,7 +45,10 @@ export default function ConfirmModal() {
             <Link
               to={ROUTES.LOGIN}
               className="bg-primary-300 flex flex-1 items-center justify-center rounded-lg px-4 py-2.5 text-white"
-              onClick={closeModal}
+              onClick={() => {
+                setRedirectUrl(location.pathname + location.search)
+                closeModal()
+              }}
             >
               {confirmText}
             </Link>


### PR DESCRIPTION
## 📌 개요

- 로그아웃 시 항상 홈으로 리다이렉트되던 문제를 수정하여, 인증이 필요한 페이지에서만 홈으로 이동하도록 변경

## 🔧 작업 내용

- [x] MobileNavigation.tsx - 인증 필요 페이지일 때만 홈으로 이동
- [x] UserMenu.tsx - 인증 필요 페이지일 때만 홈으로 이동
- [x] LoginModal.tsx - 로그인 클릭 시 현재 경로를 redirectUrl로 저장

## 📎 관련 이슈

Closes #405

## 💬 리뷰어 참고 사항

- authRequiredPaths 배열로 인증 필요 페이지 목록 관리