### PR TITLE
feat: 커뮤니티 기능 개선(#403)

### DIFF
--- a/src/api/community.ts
+++ b/src/api/community.ts
@@ -5,6 +5,7 @@ import type {
   CommentResponse,
   CommunityDetailItemResponse,
   CommunityPostRequestData,
+  CommunityPostResponse,
   CommunityResponse,
   ReportedRequestData,
   ReportedResponse,
@@ -89,8 +90,9 @@ export const fetchInfoCommunity = async (
 }
 
 // 커뮤니티 글 등록
-export const postCommunity = async (requestData: CommunityPostRequestData): Promise<void> => {
-  await api.post(`/community/posts`, requestData)
+export const postCommunity = async (requestData: CommunityPostRequestData) => {
+  const response = await api.post<CommunityPostResponse>(`/community/posts`, requestData)
+  return response.data.data
 }
 
 // 커뮤니티 글 상세 조회

--- a/src/pages/signup/validationRules.ts
+++ b/src/pages/signup/validationRules.ts
@@ -10,11 +10,11 @@ export const signupValidationRules = {
     required: '이름을 입력해주세요',
     minLength: {
       value: 2,
-      message: '이름은 2~ 10자 이상이어야 합니다.',
+      message: '이름은 2~ 10자 이하이어야 합니다.',
     },
     maxLength: {
       value: 10,
-      message: '이름은 2~ 10자 이상이어야 합니다.',
+      message: '이름은 2~ 10자 이하이어야 합니다.',
     },
   } satisfies RegisterOptions<SignUpFormValues, 'name'>,
 
@@ -22,11 +22,11 @@ export const signupValidationRules = {
     required: '닉네임을 입력해주세요',
     minLength: {
       value: 2,
-      message: '닉네임은 2~ 10자 이상이어야 합니다.',
+      message: '닉네임은 2~ 10자 이하이어야 합니다.',
     },
     maxLength: {
       value: 10,
-      message: '닉네임은 2~ 10자 이상이어야 합니다.',
+      message: '닉네임은 2~ 10자 이하이어야 합니다.',
     },
   } satisfies RegisterOptions<SignUpFormValues, 'nickname'>,
 
@@ -58,16 +58,29 @@ export const commonTitleValidationRules = {
   },
 }
 
+// 커뮤니티 내용 필드 validation 규칙
+export const communityContentValidationRules = {
+  required: '내용을 입력하세요',
+  minLength: {
+    value: 2,
+    message: '내용은 2~1000자여야 합니다.',
+  },
+  maxLength: {
+    value: 1000,
+    message: '내용은 2~1000자여야 합니다.',
+  },
+}
+
 export const productPostValidationRules = {
   name: {
     required: '상품명을 입력해주세요',
     minLength: {
       value: 2,
-      message: '상품명은 2~ 50자 이상이어야 합니다.',
+      message: '상품명은 2~ 50자 이하이어야 합니다.',
     },
     maxLength: {
       value: 50,
-      message: '상품명은 2~ 50자 이상이어야 합니다.',
+      message: '상품명은 2~ 50자 이하이어야 합니다.',
     },
   } satisfies RegisterOptions<ProductPostFormValues, 'title'>,
 
@@ -75,11 +88,11 @@ export const productPostValidationRules = {
     required: '상품설명을 입력해주세요',
     minLength: {
       value: 2,
-      message: '상품설명은 2~ 1000자 이상이어야 합니다.',
+      message: '상품설명은 2 ~ 1000자 이하이어야 합니다.',
     },
     maxLength: {
       value: 1000,
-      message: '상품설명은 2~ 1000자 이하이어야 합니다.',
+      message: '상품설명은 2 ~ 1000자 이하이어야 합니다.',
     },
   } satisfies RegisterOptions<ProductPostFormValues, 'description'>,
 
@@ -109,11 +122,11 @@ export const WithDrawApiErrors = {
     required: '상세 사유를 입력해주세요',
     minLength: {
       value: 2,
-      message: '상세사유는 2~ 500자 이상이어야 합니다.',
+      message: '상세사유는 2 ~ 500자 이하이어야 합니다.',
     },
     maxLength: {
       value: 500,
-      message: '상세사유는 2~ 500자 이상이어야 합니다.',
+      message: '상세사유는 2 ~ 500자 이하이어야 합니다.',
     },
   },
 } as const
@@ -122,7 +135,7 @@ export const ReportApiErrors = {
   detailReason: {
     maxLength: {
       value: 300,
-      message: '상세사유는 2~ 300자 이상이어야 합니다.',
+      message: '상세사유는 2 ~ 300자 이하이어야 합니다.',
     },
   },
 } as const

--- a/src/types/community.ts
+++ b/src/types/community.ts
@@ -39,6 +39,14 @@ export interface CommunityPostRequestData {
   imageUrls: string[]
 }
 
+export interface CommunityPostResponse {
+  code: string
+  message: string
+  data: {
+    id: number
+  }
+}
+
 export interface CommunityDetailItem extends CommunityItem {
   authorId: number
   authorProfileImageUrl: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,6 +51,7 @@ export type {
   CommunityItem,
   CommunityResponse,
   CommunityPostRequestData,
+  CommunityPostResponse,
   CommunityDetailItem,
   CommunityDetailItemResponse,
   Comment,


### PR DESCRIPTION
## 📌 개요

- 커뮤니티 상세 페이지 UI 개선 및 글 작성 폼 기능 강화

## 🔧 작업 내용

- [x] 더보기 메뉴 UI 개선 (수정/삭제/신고 버튼 통합)
- [x] 비로그인 시 댓글/대댓글 작성 시 로그인 모달 표시
- [x] 글 작성 시 임시 저장 기능 (sessionStorage)
- [x] 글 작성/수정 완료 후 해당 게시글로 이동
- [x] 커뮤니티 내용 validation 규칙 추가 (2~1000자)
- [x] postCommunity API 응답 타입 추가

## 📎 관련 이슈

Closes #403

## 💬 리뷰어 참고 사항

- 임시 저장은 sessionStorage 사용 (브라우저 탭 닫으면 삭제됨)
- 글 작성 완료 시 임시 저장 데이터 자동 삭제