### PR TITLE
fix: 유저 신고 후 페이지 뒤로가기 대신 쿼리 갱신(#406)

### DIFF
--- a/src/components/modal/UserReportModal.tsx
+++ b/src/components/modal/UserReportModal.tsx
@@ -1,7 +1,7 @@
-import { useNavigate } from 'react-router-dom'
 import { userReported } from '@src/api/profile'
 import { USER_REPORT_REASON } from '@src/constants/constants'
 import ReportModalBase, { type ReportFormValues } from './ReportModalBase'
+import { useQueryClient } from '@tanstack/react-query'
 
 interface UserReportModalProps {
   isOpen: boolean
@@ -11,13 +11,13 @@ interface UserReportModalProps {
 }
 
 export default function UserReportModal({ isOpen, userNickname, userId, onCancel }: UserReportModalProps) {
-  const navigate = useNavigate()
+  const queryClient = useQueryClient()
 
   const handleSubmit = async (data: ReportFormValues) => {
     try {
       await userReported(userId, { ...data })
+      queryClient.invalidateQueries({ queryKey: ['userPage'] })
       onCancel()
-      navigate(-1)
     } catch (error) {
       console.error('회원신고 실패:', error)
     }


### PR DESCRIPTION
## 📌 개요

- 유저 신고 완료 후 navigate(-1)로 뒤로가기 하던 것을 쿼리 갱신으로 변경

## 🔧 작업 내용

- [x] UserReportModal.tsx - navigate(-1) 제거
- [x] queryClient.invalidateQueries로 userPage 쿼리 갱신

## 📎 관련 이슈

Closes #406

## 💬 리뷰어 참고 사항

- 신고 후 현재 페이지에 머물면서 데이터만 새로고침