### PR TITLE
fix: 상품/요청 폼 수정 모드 시 버튼 텍스트 및 에러 메시지 개선(#407)

### DIFF
--- a/src/pages/product-post/components/ProductPostForm.tsx
+++ b/src/pages/product-post/components/ProductPostForm.tsx
@@ -99,7 +99,7 @@ export function ProductPostForm({ isEditMode, productId: id, initialData }: Prod
         navigate(`/products/${createdProduct.id}`)
       }
     } catch {
-      alert('상품 등록에 실패했습니다.')
+      alert(isEditMode ? '상품 수정에 실패했습니다.' : '상품 등록에 실패했습니다.')
     }
   }
   useEffect(() => {
@@ -144,7 +144,7 @@ export function ProductPostForm({ isEditMode, productId: id, initialData }: Prod
           </div>
           <div className="flex items-center gap-4">
             <Button size="md" className={cn('w-[80%] flex-1 cursor-pointer text-white', !isValid ? 'bg-gray-300' : 'bg-primary-200')} type="submit">
-              등록
+              {isEditMode ? '수정' : '등록'}
             </Button>
             <Button size="md" className="w-[20%] cursor-pointer bg-gray-100 text-gray-900" type="button">
               취소

--- a/src/pages/product-post/components/ProductRequestForm.tsx
+++ b/src/pages/product-post/components/ProductRequestForm.tsx
@@ -87,7 +87,7 @@ export function ProductRequestForm({ isEditMode, productId: id, initialData }: P
       await requestPostProduct(requestData)
       navigate(`/products/${id}`)
     } catch {
-      alert('상품 등록에 실패했습니다.')
+      alert(isEditMode ? '상품 수정에 실패했습니다.' : '상품 등록에 실패했습니다.')
     }
   }
 
@@ -147,7 +147,7 @@ export function ProductRequestForm({ isEditMode, productId: id, initialData }: P
           </div>
           <div className="flex items-center gap-4">
             <Button size="md" className={cn('w-[80%] flex-1 cursor-pointer text-white', !isValid ? 'bg-gray-300' : 'bg-primary-200')} type="submit">
-              등록
+              {isEditMode ? '수정' : '등록'}
             </Button>
             <Button size="md" className="w-[20%] cursor-pointer bg-gray-100 text-gray-900" type="button">
               취소


### PR DESCRIPTION
## 📌 개요

- 상품/요청 폼에서 수정 모드일 때 버튼 텍스트와 에러 메시지가 올바르게 표시되도록 수정

## 🔧 작업 내용

- [x] ProductPostForm.tsx - 수정 모드 시 버튼 '수정', 에러 메시지 개선
- [x] ProductRequestForm.tsx - 수정 모드 시 버튼 '수정', 에러 메시지 개선

## 📎 관련 이슈

Closes #407

## 💬 리뷰어 참고 사항

- isEditMode에 따라 버튼 텍스트와 에러 메시지 분기 처리