### PR TITLE
fix: Validation 문구 오타 수정 - 이상 → 이하(#408)

### DIFF
--- a/src/utils/validation/authValidationRules.ts
+++ b/src/utils/validation/authValidationRules.ts
@@ -48,11 +48,11 @@ export const profileValidationRules = {
   introduction: {
     minLength: {
       value: 2,
-      message: '자기소개는 2~ 100자 이상이어야 합니다.',
+      message: '자기소개는 2~ 100자 이하이어야 합니다.',
     },
     maxLength: {
       value: 1000,
-      message: '자기소개는 2~ 1000자 이상이어야 합니다.',
+      message: '자기소개는 2~ 1000자 이하이어야 합니다.',
     },
   } satisfies RegisterOptions<ProfileUpdateBaseFormValues, 'introduction'>,
 


### PR DESCRIPTION
## 📌 개요

- validation 에러 메시지에서 "이상"이 "이하"로 표시되어야 하는 오타 수정

## 🔧 작업 내용

- [x] authValidationRules.ts - "2~ 10자 이상" → "2~ 10자 이하" 수정

## 📎 관련 이슈

Closes #408

## 💬 리뷰어 참고 사항

- 단순 문구 오타 수정