### PR TITLE
fix: 상품 등록 버튼 활성화 색상 개선(#415)

### DIFF
--- a/src/pages/product-post/components/ProductPostForm.tsx
+++ b/src/pages/product-post/components/ProductPostForm.tsx
@@ -143,7 +143,7 @@ export function ProductPostForm({ isEditMode, productId: id, initialData }: Prod
             <TradeInfoSection control={control} setValue={setValue} register={register} />
           </div>
           <div className="flex items-center gap-4">
-            <Button size="md" className={cn('w-[80%] flex-1 cursor-pointer text-white', !isValid ? 'bg-gray-300' : 'bg-primary-200')} type="submit">
+            <Button size="md" className={cn('w-[80%] flex-1 cursor-pointer text-white', !isValid ? 'bg-gray-300' : 'bg-primary-300')} type="submit">
               {isEditMode ? '수정' : '등록'}
             </Button>
             <Button size="md" className="w-[20%] cursor-pointer bg-gray-100 text-gray-900" type="button">


### PR DESCRIPTION
## 📌 개요

- 상품 등록/수정 폼의 제출 버튼 활성화 색상이 연해서 가시성이 부족한 문제 개선

## 🔧 작업 내용

- [x] 버튼 활성화 배경색 `bg-primary-200` → `bg-primary-300`으로 변경

## 📎 관련 이슈

Closes #415

## 💬 리뷰어 참고 사항

- 버튼 색상만 변경된 단순 수정입니다