### PR TITLE
fix: 가격 입력 필드 "원" 텍스트 움직임 버그 수정(#417)

### DIFF
--- a/src/components/commons/Input.tsx
+++ b/src/components/commons/Input.tsx
@@ -12,6 +12,7 @@ interface InputProps {
   size?: string
   id?: string
   inputClass?: string
+  suffix?: string
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
   [key: string]: any // register에서 전달하는 다른 props들을 받기 위해
 }
@@ -28,6 +29,7 @@ export function Input({
   onChange,
   id,
   inputClass,
+  suffix,
   ...rest // 나머지 모든 props (register가 전달하는 ref, name 등)
 }: InputProps) {
   return (
@@ -61,6 +63,7 @@ export function Input({
         )}
         {...rest}
       />
+      {suffix && <span className="absolute top-1/2 right-3 -translate-y-1/2 text-sm text-gray-500">{suffix}</span>}
     </div>
   )
 }

--- a/src/components/commons/InputField.tsx
+++ b/src/components/commons/InputField.tsx
@@ -17,12 +17,13 @@ interface InputFieldProps {
   inputClass?: string
   registration: UseFormRegisterReturn
   id?: string
+  suffix?: string
 }
 
-export function InputField({ error, checkResult, registration, classname, inputClass, id, ...inputProps }: InputFieldProps) {
+export function InputField({ error, checkResult, registration, classname, inputClass, id, suffix, ...inputProps }: InputFieldProps) {
   return (
     <div className={cn('flex flex-col gap-1', classname)}>
-      <Input {...inputProps} {...registration} inputClass={inputClass} id={id} />
+      <Input {...inputProps} {...registration} inputClass={inputClass} id={id} suffix={suffix} />
       {error && <p className="text-danger-500 text-xs font-semibold">{error.message}</p>}
       {checkResult?.message && (
         <p className={cn('text-xs font-semibold', checkResult.status === 'error' ? 'text-danger-500' : 'text-success-500')}>{checkResult.message}</p>

--- a/src/pages/product-post/components/priceAndStatusSection/PriceAndStatusSection.tsx
+++ b/src/pages/product-post/components/priceAndStatusSection/PriceAndStatusSection.tsx
@@ -24,7 +24,7 @@ export default function PriceAndStatusSection({
   return (
     <section className="flex flex-col gap-5 rounded-xl border border-gray-100 bg-white px-6 py-5">
       <FormSectionHeader heading={heading} />
-      <PriceField register={register} errors={errors} label={priceLabel} />
+      <PriceField register={register} errors={errors} label={priceLabel} suffix="원" />
       {showProductStateFilter && (
         <Controller
           name="productStatus"

--- a/src/pages/product-post/components/priceAndStatusSection/components/PriceField.tsx
+++ b/src/pages/product-post/components/priceAndStatusSection/components/PriceField.tsx
@@ -9,9 +9,10 @@ interface PriceFieldProps {
   register: UseFormRegister<ProductPostFormValues>
   errors: FieldErrors<ProductPostFormValues>
   label?: string
+  suffix?: string
 }
 
-export function PriceField({ register, errors, label = '판매 가격' }: PriceFieldProps) {
+export function PriceField({ register, errors, suffix, label = '판매 가격' }: PriceFieldProps) {
   return (
     <div className="flex flex-col gap-1">
       <RequiredLabel htmlFor="price" labelClass="heading-h5">
@@ -28,8 +29,9 @@ export function PriceField({ register, errors, label = '판매 가격' }: PriceF
           inputClass="pr-10"
           error={errors.price}
           registration={register('price', productPostValidationRules.price)}
+          suffix={suffix}
         />
-        <span className="absolute top-1/2 right-3 -translate-y-1/2 text-sm text-gray-500">원</span>
+        {/* <span className="absolute top-1/2 right-3 -translate-y-1/2 text-sm text-gray-500">원</span> */}
       </div>
     </div>
   )


### PR DESCRIPTION
## 📌 개요

- 상품 등록/수정 시 가격 입력 필드의 "원" 텍스트가 입력값에 따라 움직이는 버그 수정

## 🔧 작업 내용

- [x] Input 컴포넌트에 `suffix` prop 추가
- [x] InputField 컴포넌트에 `suffix` prop 전달
- [x] PriceField에서 하드코딩된 "원" span을 `suffix` prop으로 대체

## 📎 관련 이슈

Closes #417

## 💬 리뷰어 참고 사항

- Input 컴포넌트에 suffix 기능을 추가하여 재사용 가능하도록 구현