### PR TITLE
fix: 요청 폼 버튼 색상 일관성 수정(#423)

### DIFF
--- a/src/pages/product-post/components/ProductRequestForm.tsx
+++ b/src/pages/product-post/components/ProductRequestForm.tsx
@@ -146,7 +146,7 @@ export function ProductRequestForm({ isEditMode, productId: id, initialData }: P
             <TradeInfoSection control={control} setValue={setValue} showProductTradeFilter={false} register={register} />
           </div>
           <div className="flex items-center gap-4">
-            <Button size="md" className={cn('w-[80%] flex-1 cursor-pointer text-white', !isValid ? 'bg-gray-300' : 'bg-primary-200')} type="submit">
+            <Button size="md" className={cn('w-[80%] flex-1 cursor-pointer text-white', !isValid ? 'bg-gray-300' : 'bg-primary-300')} type="submit">
               {isEditMode ? '수정' : '등록'}
             </Button>
             <Button size="md" className="w-[20%] cursor-pointer bg-gray-100 text-gray-900" type="button">


### PR DESCRIPTION
## 📌 개요

- 요청 등록/수정 폼의 제출 버튼 색상이 다른 폼들과 일관되지 않은 문제 수정

## 🔧 작업 내용

- [x] ProductRequestForm.tsx 버튼 색상 `bg-primary-200` → `bg-primary-300` 변경

## 📎 관련 이슈

Closes #423

## 💬 리뷰어 참고 사항

- ProductPostForm.tsx와 동일한 버튼 색상으로 통일