### PR TITLE
design: 프로필 이미지 변경 버튼 UX 개선(#425)

### DIFF
--- a/src/pages/profile-update/components/ProfileUpdateBaseForm.tsx
+++ b/src/pages/profile-update/components/ProfileUpdateBaseForm.tsx
@@ -15,6 +15,7 @@ import { useUserStore } from '@src/store/userStore'
 import { uploadImage } from '@src/api/products'
 import { useQueryClient } from '@tanstack/react-query'
 import { useMediaQuery } from '@src/hooks/useMediaQuery'
+import { Camera } from 'lucide-react'
 
 export interface ProfileUpdateBaseFormValues {
   nickname: string
@@ -170,25 +171,22 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
           <div className="flex flex-col gap-10">
             {/* 프로필 이미지 */}
             <div className="flex flex-col items-center gap-4">
-              <div
-                onClick={() => fileInputRef.current?.click()}
-                className="bg-primary-50 flex h-28 w-28 cursor-pointer items-center justify-center overflow-hidden rounded-full"
-              >
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept=".jpg,.jpeg,.png,.webp"
-                  onChange={handleImageChange}
-                  className="hidden"
-                />
+              <div className="bg-primary-50 relative flex h-28 w-28 cursor-pointer items-center justify-center rounded-full">
+                <input ref={fileInputRef} type="file" accept=".jpg,.jpeg,.png,.webp" onChange={handleImageChange} className="hidden" />
                 {previewUrl ? (
                   <img src={previewUrl ?? ''} alt={myData?.nickname} className="h-full w-full object-cover" />
                 ) : (
                   <div className="heading-h1 font-normal!">{myData?.nickname.charAt(0).toUpperCase()}</div>
                 )}
+                <div
+                  className="bg-primary-100 absolute right-0 bottom-2 flex size-8 items-center justify-center rounded-full"
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  <Camera className="" size={20} />
+                </div>
               </div>
               {errors.profileImageUrl && <p className="text-danger-500 text-xs font-semibold">{errors.profileImageUrl.message}</p>}
-              <p className="text-sm">프로필 사진을 변경하려면 이미지를 클릭하세요</p>
+              <p className="text-sm">프로필 사진을 변경하려면 카메라 아이콘을 클릭하세요</p>
             </div>
 
             {/* 정보 영역 */}


### PR DESCRIPTION
## 📌 개요

- 프로필 이미지 변경 시 카메라 아이콘 버튼을 추가하여 인터랙션 힌트 제공

## 🔧 작업 내용

- [x] 프로필 이미지 우측 하단에 카메라 아이콘 버튼 추가
- [x] 클릭 대상을 전체 이미지 → 카메라 아이콘으로 변경
- [x] 안내 텍스트 수정: "이미지를 클릭하세요" → "카메라 아이콘을 클릭하세요"

## 📎 관련 이슈

Closes #425

## 💬 리뷰어 참고 사항

- lucide-react의 Camera 아이콘 사용
- 기존 기능 유지하면서 UX만 개선