### PR TITLE
refactor: 페이지별 에러 처리 및 로딩 상태 개선(#427)

### DIFF
--- a/src/pages/chatting-page/ChattingPage.tsx
+++ b/src/pages/chatting-page/ChattingPage.tsx
@@ -42,6 +42,9 @@ export default function ChattingPage() {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isLoading: isLoadingMessages,
+    error: errorMessages,
+    refetch: refetchMessages,
   } = useInfiniteQuery({
     queryKey: ['messages', chatRoomId],
     queryFn: ({ pageParam }) => fetchRoomMessages(Number(chatRoomId), pageParam),
@@ -58,6 +61,8 @@ export default function ChattingPage() {
     fetchNextPage: fetchNextRooms,
     hasNextPage: hasNextRooms,
     isFetchingNextPage: isFetchingNextRooms,
+    isLoading: isLoadingRooms,
+    error: errorRooms,
   } = useInfiniteQuery({
     queryKey: ['chatRooms'],
     queryFn: ({ pageParam }) => fetchRooms(pageParam),
@@ -173,6 +178,27 @@ export default function ChattingPage() {
     }
   }, [])
 
+  if (isLoadingRooms && !rooms) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600"></div>
+      </div>
+    )
+  }
+
+  if (errorRooms || !rooms) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="flex flex-col items-center gap-4">
+          <p>채팅 목록을 불러올 수 없습니다</p>
+          <button onClick={() => navigate('/')} className="text-blue-600 hover:text-blue-800">
+            홈으로 돌아가기
+          </button>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="md:pb-4xl bg-white md:h-auto md:pt-8">
       <div className="mx-auto flex h-full max-w-7xl flex-col md:h-[80vh] md:flex-row">
@@ -194,10 +220,13 @@ export default function ChattingPage() {
               </div>
               <div className="bg-primary-50 min-h-0 flex-1 p-3.5 pb-20 md:pb-3.5">
                 <ChatLog
+                  isLoadingMessages={isLoadingMessages}
+                  errorMessages={errorMessages}
                   roomMessages={allMessages}
                   onLoadPrevious={() => fetchNextPage()}
                   hasMorePrevious={hasNextPage}
                   isLoadingPrevious={isFetchingNextPage}
+                  onRetry={() => refetchMessages()}
                 />
               </div>
               <div

--- a/src/pages/chatting-page/components/ChatLog.tsx
+++ b/src/pages/chatting-page/components/ChatLog.tsx
@@ -5,10 +5,13 @@ import { useEffect, useRef } from 'react'
 import PlaceholderImage from '@assets/images/placeholder.png'
 
 interface ChatLogProps {
+  isLoadingMessages: boolean
+  errorMessages: Error | null
   roomMessages: Message[]
   onLoadPrevious?: () => void
   hasMorePrevious?: boolean
   isLoadingPrevious?: boolean
+  onRetry?: () => void
 }
 
 // isMine 계산: HTTP API 응답은 isMine 포함, STOMP는 senderId로 비교
@@ -55,7 +58,15 @@ const groupMessagesByDate = (messages: Message[]) => {
   return groups
 }
 
-export function ChatLog({ roomMessages, onLoadPrevious, hasMorePrevious, isLoadingPrevious }: ChatLogProps) {
+export function ChatLog({
+  isLoadingMessages,
+  errorMessages,
+  roomMessages,
+  onLoadPrevious,
+  hasMorePrevious,
+  isLoadingPrevious,
+  onRetry,
+}: ChatLogProps) {
   const { user } = useUserStore()
   const groupedMessages = groupMessagesByDate(roomMessages)
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -74,6 +85,29 @@ export function ChatLog({ roomMessages, onLoadPrevious, hasMorePrevious, isLoadi
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight
     }
   }, [roomMessages])
+
+  if (isLoadingMessages && !roomMessages) {
+    return (
+      <div className="px-lg py-md tablet:py-xl mx-auto max-w-7xl">
+        <div className="flex items-center justify-center py-20">
+          <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600" role="status" aria-label="상품 로딩 중"></div>
+        </div>
+      </div>
+    )
+  }
+
+  if (errorMessages) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="flex flex-col items-center gap-4">
+          <p>메세지를 불러올 수 없습니다</p>
+          <button onClick={onRetry} className="text-blue-600 hover:text-blue-800">
+            다시 시도
+          </button>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div ref={scrollRef} onScroll={handleScroll} className="flex h-full flex-col gap-4 overflow-y-auto">

--- a/src/pages/community/CommunityDetail.tsx
+++ b/src/pages/community/CommunityDetail.tsx
@@ -44,12 +44,16 @@ export default function CommunityDetail() {
   const queryClient = useQueryClient()
   const { id } = useParams<{ id: string }>()
 
-  const { data, error } = useQuery({
+  const {
+    data,
+    isLoading: isLoadingCommunityData,
+    error,
+  } = useQuery({
     queryKey: ['community', id],
     queryFn: () => fetchCommunityId(id!),
     enabled: !!id,
   })
-  const { data: commentData } = useQuery({
+  const { data: commentData, isLoading: isLoadingCommentData } = useQuery({
     queryKey: ['community', id, 'comments'],
     queryFn: () => fetchComments(id!),
     enabled: !!id,
@@ -108,11 +112,20 @@ export default function CommunityDetail() {
     window.scrollTo(0, 0)
   }, [])
 
-  if (error || !data) {
+  if (isLoadingCommunityData || isLoadingCommentData) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <div className="text-center">
-          <button onClick={() => navigate('/')} className="text-blue-600 hover:text-blue-800">
+        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600"></div>
+      </div>
+    )
+  }
+
+  if (error || !data || !commentData) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="flex flex-col items-center gap-4">
+          <p>게시글 정보를 불러올 수 없습니다</p>
+          <button onClick={() => navigate('/community')} className="text-blue-600 hover:text-blue-800">
             목록으로 돌아가기
           </button>
         </div>

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -5,13 +5,7 @@ import { DetailFilter } from '@src/pages/home/components/filter/DetailFilter'
 import { ProductsSection } from '@src/pages/home/components/product-section/ProductsSection'
 import { fetchAllProducts } from '../../api/products'
 import { useIntersectionObserver } from '../../hooks/useIntersectionObserver'
-import {
-  PRODUCT_TYPE_TABS,
-  PET_TYPE_TABS,
-  type ProductTypeTabId,
-  SORT_TYPE,
-  type SORT_LABELS,
-} from '@src/constants/constants'
+import { PRODUCT_TYPE_TABS, PET_TYPE_TABS, type ProductTypeTabId, SORT_TYPE, type SORT_LABELS } from '@src/constants/constants'
 import { PetTypeFilter } from './components/filter/PetTypeFilter'
 import { CategoryFilter } from './components/filter/CategoryFilter'
 import { useNavigate, useSearchParams } from 'react-router-dom'
@@ -220,12 +214,14 @@ function Home() {
       </div>
     )
   }
-
-  if (error) {
+  if (error || !data) {
     return (
-      <div className="px-lg py-md tablet:py-xl mx-auto max-w-7xl">
-        <div className="rounded-md border border-red-200 bg-red-50 p-4" role="alert">
-          <p className="text-red-600">{error.message}</p>
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="flex flex-col items-center gap-4">
+          <p>상품을 불러올 수 없습니다</p>
+          <button onClick={() => window.location.reload()} className="text-blue-600 hover:text-blue-800">
+            새로고침
+          </button>
         </div>
       </div>
     )

--- a/src/pages/my-page/MyPage.tsx
+++ b/src/pages/my-page/MyPage.tsx
@@ -59,7 +59,6 @@ function MyPage() {
     fetchNextPage: fetchNextRequests,
     hasNextPage: hasNextRequests,
     isFetchingNextPage: isFetchingNextRequests,
-    isLoading: isLoadingMyRequestData,
     error: errorMyRequestData,
   } = useInfiniteQuery({
     queryKey: ['myRequest', user?.id],
@@ -74,7 +73,6 @@ function MyPage() {
     fetchNextPage: fetchNextFavorites,
     hasNextPage: hasNextFavorites,
     isFetchingNextPage: isFetchingNextFavorites,
-    isLoading: isLoadingMyFavoriteData,
     error: errorMyFavoritetData,
   } = useInfiniteQuery({
     queryKey: ['myFavorite', user?.id],
@@ -89,7 +87,6 @@ function MyPage() {
     fetchNextPage: fetchNextBlocked,
     hasNextPage: hasNextBlocked,
     isFetchingNextPage: isFetchingNextBlocked,
-    isLoading: isLoadingMyFBlockedData,
     error: errorMyFBlockedData,
   } = useInfiniteQuery({
     queryKey: ['myBlocked', user?.id],
@@ -158,7 +155,8 @@ function MyPage() {
     }
   }, [myData, updateUserProfile])
 
-  if (isLoadingMyData || isLoadingMyProductData || isLoadingMyRequestData || isLoadingMyFavoriteData || isLoadingMyFBlockedData) {
+  // 초기 로딩 시에만 스피너 표시 (무한 스크롤 시 스피너 중복 방지)
+  if ((isLoadingMyData && !myData) || (isLoadingMyProductData && !myProductsData)) {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600"></div>
@@ -169,14 +167,16 @@ function MyPage() {
   if (errorMyData || errorMyProductData || errorMyRequestData || errorMyFavoritetData || errorMyFBlockedData) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <div className="text-center">
+        <div className="flex flex-col gap-4">
+          <p>내 정보를 불러올 수 없습니다</p>
           <button onClick={() => navigate('/')} className="text-blue-600 hover:text-blue-800">
-            목록으로 돌아가기
+            홈으로 돌아가기
           </button>
         </div>
       </div>
     )
   }
+
   if (!user?.id) {
     setRedirectUrl(window.location.pathname)
     navigate('/auth/login')

--- a/src/pages/product-detail/ProductDetail.tsx
+++ b/src/pages/product-detail/ProductDetail.tsx
@@ -36,8 +36,8 @@ function ProductDetail() {
   if (error || !data) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <div className="text-center">
-          {/* <p className="mb-4 text-red-600">{error || '상품을 찾을 수 없습니다.'}</p> */}
+        <div className="flex flex-col items-center gap-4">
+          <p>상품 정보를 불러올 수 없습니다</p>
           <button onClick={() => navigate('/')} className="text-blue-600 hover:text-blue-800">
             목록으로 돌아가기
           </button>

--- a/src/pages/profile-update/ProfileUpdate.tsx
+++ b/src/pages/profile-update/ProfileUpdate.tsx
@@ -6,12 +6,18 @@ import { fetchMyPageData } from '@src/api/products'
 import { useUserStore } from '@src/store/userStore'
 import ProfileUpdatePasswordForm from './components/ProfileUpdatePasswordForm'
 import { useMediaQuery } from '@src/hooks/useMediaQuery'
+import { useNavigate } from 'react-router-dom'
 
 function ProfileUpdate() {
+  const navigate = useNavigate()
   const [, setIsWithdrawModalOpen] = useState(false)
   const { user, updateUserProfile } = useUserStore()
   const isMd = useMediaQuery('(min-width: 768px)')
-  const { data: myData, isLoading: isLoadingMyData } = useQuery({
+  const {
+    data: myData,
+    isLoading: isLoadingMyData,
+    error,
+  } = useQuery({
     queryKey: ['mypage', user?.id],
     queryFn: () => fetchMyPageData(),
     enabled: !!user,
@@ -37,6 +43,19 @@ function ProfileUpdate() {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600"></div>
+      </div>
+    )
+  }
+
+  if (error || !myData) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="flex flex-col items-center gap-4">
+          <p>프로필 정보를 불러올 수 없습니다</p>
+          <button onClick={() => navigate('/my-page')} className="text-blue-600 hover:text-blue-800">
+            마이페이지로 돌아가기
+          </button>
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
## 📌 개요

- 전체 페이지의 에러 처리 및 로딩 상태 로직 개선

## 🔧 작업 내용

- [x] 에러 발생 시 사용자 친화적 메시지 표시
- [x] 에러 복구를 위한 네비게이션/재시도 버튼 제공
- [x] 무한 스크롤 시 초기 로딩에만 스피너 표시 (중복 방지)

## 📍 수정 파일

- UserPage.tsx
- ChattingPage.tsx / ChatLog.tsx
- CommunityDetail.tsx / CommunityPage.tsx
- Home.tsx
- MyPage.tsx
- ProductDetail.tsx
- ProfileUpdate.tsx

## 📎 관련 이슈

Closes #427

## 💬 리뷰어 참고 사항

- 9개 페이지에 일관된 에러 처리 패턴 적용
- 로딩 조건: `isLoading && !data` 로 무한 스크롤 시 스피너 중복 방지