### PR TITLE
design: 이미지 업로드 영역 및 신고 모달 모바일 반응형 개선(#429)

### DIFF
--- a/src/components/modal/ReportModalBase.tsx
+++ b/src/components/modal/ReportModalBase.tsx
@@ -66,7 +66,7 @@ export default function ReportModalBase({ isOpen, heading, description, reasons,
 
   return (
     <div className={`fixed inset-0 flex items-center justify-center bg-gray-900/70 p-4 ${Z_INDEX.MODAL}`}>
-      <div ref={modalRef} className="flex max-h-[90vh] w-11/12 flex-col gap-4 overflow-y-auto rounded-lg bg-white p-5 md:w-[16vw] md:min-w-96">
+      <div ref={modalRef} className="flex max-h-[90vh] w-11/12 flex-col gap-4 overflow-y-auto rounded-lg bg-white p-5 md:w-1/5 md:min-w-96">
         <ModalTitle heading={heading} description={description} />
 
         <form onSubmit={handleSubmit(handleFormSubmit)} className="flex flex-col gap-4">
@@ -97,7 +97,7 @@ export default function ReportModalBase({ isOpen, heading, description, reasons,
               <div className="flex flex-col gap-0.5">
                 <textarea
                   placeholder="신고 상세 사유를 입력해주세요."
-                  className="bg-primary-50 focus:border-primary-500 w-full resize-none rounded-lg px-3 py-3 text-sm placeholder:text-gray-400 focus:outline-none"
+                  className="bg-primary-50 focus:border-primary-500 min-h-32 w-full resize-none rounded-lg px-3 py-3 text-sm placeholder:text-gray-400 focus:outline-none md:min-h-20"
                   id="withdrawReasonDetail"
                   {...register('detailReason', {
                     maxLength: ReportApiErrors.detailReason.maxLength,

--- a/src/pages/product-post/components/imageUploadField/components/DropzoneArea.tsx
+++ b/src/pages/product-post/components/imageUploadField/components/DropzoneArea.tsx
@@ -11,9 +11,10 @@ import SortableImageList from './SortableImageList'
 const IMAGE_UPLOAD_ERRORS = {
   'file-too-large': '파일 크기는 5MB를 초과할 수 없습니다.',
   'file-invalid-type': '지원하지 않는 파일 형식입니다. (jpg, jpeg, png, webp만 가능)',
-  'too-many-files': `최대 ${MAX_FILES}개의 파일만 업로드할 수 있습니다.`,
   'upload-failed': '이미지 업로드에 실패했습니다. 다시 시도해주세요.',
 } as const
+
+const getTooManyFilesError = (max: number) => `최대 ${max}개의 파일만 업로드할 수 있습니다.`
 
 interface DropzoneAreaProps<T extends FieldValues> {
   setValue: UseFormSetValue<T>
@@ -45,7 +46,7 @@ export default function DropzoneArea<T extends FieldValues>({
 
       const totalCount = previewUrls.length + acceptedFiles.length
       if (totalCount > maxFiles) {
-        setError(mainImageField, { type: 'manual', message: IMAGE_UPLOAD_ERRORS['too-many-files'] })
+        setError(mainImageField, { type: 'manual', message: getTooManyFilesError(maxFiles) })
         return
       }
 
@@ -123,7 +124,7 @@ export default function DropzoneArea<T extends FieldValues>({
   }, [initialImages])
 
   return (
-    <div {...getRootProps()} className="cursor-pointer rounded-lg border border-dashed border-gray-400 px-6 py-10">
+    <div {...getRootProps()} className="cursor-pointer rounded-lg border border-dashed border-gray-400 px-4 py-4 md:px-6 md:py-10">
       <input {...getInputProps()} />
       {previewUrls.length === 0 ? (
         <DropzoneGuide maxFiles={maxFiles} />

--- a/src/pages/product-post/components/imageUploadField/components/SortableImageItem.tsx
+++ b/src/pages/product-post/components/imageUploadField/components/SortableImageItem.tsx
@@ -19,7 +19,7 @@ export default function SortableImageItem({ url, index, onRemove }: SortableImag
   }
 
   return (
-    <div ref={setNodeRef} style={style} {...attributes} className="relative h-40 w-40 overflow-hidden rounded-lg">
+    <div ref={setNodeRef} style={style} {...attributes} className="relative size-20 overflow-hidden rounded-lg md:size-28">
       <Button
         icon={X}
         size="xs"

--- a/src/pages/product-post/components/imageUploadField/components/SortableImageList.tsx
+++ b/src/pages/product-post/components/imageUploadField/components/SortableImageList.tsx
@@ -3,6 +3,7 @@ import { SortableContext, horizontalListSortingStrategy } from '@dnd-kit/sortabl
 import { Button } from '@src/components/commons/button/Button'
 import { Plus } from 'lucide-react'
 import SortableImageItem from './SortableImageItem'
+import { useMediaQuery } from '@src/hooks/useMediaQuery'
 
 interface SortableImageListProps {
   previewUrls: string[]
@@ -11,14 +12,17 @@ interface SortableImageListProps {
 }
 
 export default function SortableImageList({ previewUrls, onDragEnd, onRemoveImage }: SortableImageListProps) {
+  const isMd = useMediaQuery('(min-width: 768px)')
   return (
     <DndContext collisionDetection={closestCenter} onDragEnd={onDragEnd}>
       <SortableContext items={previewUrls} strategy={horizontalListSortingStrategy}>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-2 md:gap-3">
           {previewUrls.map((imgUrl, i) => (
             <SortableImageItem key={imgUrl} url={imgUrl} index={i} onRemove={() => onRemoveImage(i)} />
           ))}
-          {previewUrls.length < 5 && <Button size="lg" className="bg-primary-300 flex cursor-pointer flex-col rounded-full text-white" icon={Plus} />}
+          {previewUrls.length < 5 && (
+            <Button size={isMd ? 'lg' : 'sm'} className="bg-primary-300 flex cursor-pointer flex-col rounded-full text-white" icon={Plus} />
+          )}
         </div>
       </SortableContext>
     </DndContext>


### PR DESCRIPTION
## 📌 개요

- 이미지 업로드 영역 및 신고 모달의 모바일 화면 대응 UI 개선

## 🔧 작업 내용

- [x] 신고 모달 너비 및 textarea 최소 높이 조정
- [x] 이미지 업로드 Dropzone 패딩 반응형 처리
- [x] 이미지 썸네일 크기 반응형 처리 (size-20 md:size-28)
- [x] 이미지 리스트 flex-wrap 및 gap 반응형 처리
- [x] 이미지 추가 버튼 크기 반응형 처리

## 📎 관련 이슈

Closes #429

## 💬 리뷰어 참고 사항

- 모바일 화면에서 이미지 업로드 영역 확인 필요
- useMediaQuery 훅을 활용한 반응형 처리