### PR TITLE
fix: 커뮤니티 페이지 레이아웃 및 네비게이션 버그 수정(#433)

### DIFF
--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -3,6 +3,7 @@ import Header from '@components/header/Header'
 import { Outlet, useLocation } from 'react-router-dom'
 import { useMediaQuery } from '@src/hooks/useMediaQuery'
 import { ROUTES } from '@src/constants/routes'
+import { cn } from '@src/utils/cn'
 
 // Header 숨김 패턴 (정규표현식 필요)
 const HIDE_HEADER_PATTERNS = [/^\/community\/\d+\/edit$/, new RegExp(`^${ROUTES.COMMUNITY_POST}$`)]
@@ -40,7 +41,7 @@ export default function MainLayout() {
     <div className="flex min-h-screen flex-col">
       {showHeader && <Header hideSearchBar={hideSearchBar} hideMenuButton={hideMenuButton} />}
       {/* <ChatFloatButton /> */}
-      <main className="w-full flex-1 pt-16 md:pt-24">
+      <main className={cn('w-full flex-1', showHeader ? 'pt-16 md:pt-24' : 'pt-0')}>
         <Outlet />
       </main>
     </div>

--- a/src/pages/community/CommunityDetail.tsx
+++ b/src/pages/community/CommunityDetail.tsx
@@ -146,6 +146,7 @@ export default function CommunityDetail() {
         <SimpleHeader
           title={headerTitle}
           description={isMd ? headerDescription : undefined}
+          to={`/community?tab=${getHeaderContent().tabId}`}
           layoutClassname="py-5 flex-col justify-between border-b border-gray-200"
         />
       )}

--- a/src/pages/community/CommunityPage.tsx
+++ b/src/pages/community/CommunityPage.tsx
@@ -1,4 +1,3 @@
-import { SimpleHeader } from '@src/components/header/SimpleHeader'
 import { useState, useEffect } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { COMMUNITY_SEARCH_TYPE, COMMUNITY_SORT_TYPE, COMMUNITY_TABS, type CommunityTabId } from '@src/constants/constants'
@@ -47,18 +46,6 @@ export default function CommunityPage() {
     setSelectedSearchType('제목')
   }
 
-  const getHeaderContent = () => {
-    switch (activeCommunityTypeTab) {
-      case 'tab-free':
-        return { title: '자유게시판', description: '일상 이야기를 마음껏 나눠보세요!' }
-      case 'tab-question':
-        return { title: '질문 있어요', description: '궁금한 점을 질문해보세요!' }
-      case 'tab-info':
-        return { title: '정보 공유', description: '유용한 정보를 공유해보세요!' }
-      default:
-        return { title: '자유게시판', description: '일상 이야기를 마음껏 나눠보세요!' }
-    }
-  }
   const handleSortChange = (value: string) => {
     const sortItem = COMMUNITY_SORT_TYPE.find((sort) => sort.label === value)
 
@@ -164,8 +151,13 @@ export default function CommunityPage() {
         ? isFetchingNextQuestion
         : isFetchingNextInfo
 
-  const { title: headerTitle, description: headerDescription } = getHeaderContent()
+  // const { title: headerTitle, description: headerDescription } = getHeaderContent()
   const { isLogin } = useUserStore()
+
+  // 페이지 진입 시 스크롤 최상단으로 이동
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [])
 
   // URL의 tab 파라미터가 변경되면 탭 상태 동기화
   useEffect(() => {
@@ -196,77 +188,25 @@ export default function CommunityPage() {
   }
 
   return (
-    <>
-      <SimpleHeader
-        title={headerTitle}
-        description={isMd ? headerDescription : undefined}
-        layoutClassname={`py-5 justify-between border-b border-gray-200 md:static sticky top-16 ${Z_INDEX.DROPDOWN}`}
-      />
-      <div className="relative min-h-screen bg-[#F3F4F6] pt-0 md:pt-5">
-        <div className="pb-4xl mx-auto max-w-7xl px-0 md:px-4">
-          <div className="flex w-full flex-col">
-            {/* 모바일: 필터 영역 */}
-            {!isMd && (
-              <div className={`sticky top-32 bg-white ${Z_INDEX.DROPDOWN}`}>
-                {/* 접히는 필터 영역 */}
-                <div
-                  className={cn(
-                    'transition-all duration-300 ease-out',
-                    isFilterCollapsed ? 'max-h-0 overflow-hidden' : 'max-h-[300px] overflow-visible'
-                  )}
-                >
-                  <div className="flex items-center justify-between border-b border-gray-200 p-3.5">
-                    <CommunityTabs tabs={COMMUNITY_TABS} activeTab={activeCommunityTypeTab} onTabChange={handleTabChange} ariaLabel="커뮤니티 타입" />
-                  </div>
-
-                  <div className="flex flex-row-reverse items-center justify-between gap-3 border-b border-gray-200 px-3.5 pt-4 pb-3.5">
-                    <div className="h-11 w-24">
-                      <SelectDropdown
-                        value={selectSearchType}
-                        onChange={handleSearchTypeChange}
-                        options={COMMUNITY_SEARCH_TYPE.map((sort) => ({
-                          value: sort.label,
-                          label: sort.label,
-                        }))}
-                        buttonClassName="border border-gray-300 bg-primary-50 text-gray-900 text-base px-3 py-2"
-                      />
-                    </div>
-                    <SearchBar placeholder="게시글 검색" borderColor="border-gray-300" className="h-11 max-w-full" paramName="communityKeyword" />
-                  </div>
-                  <div className="flex gap-2 border-b border-gray-200 px-3.5 py-3.5">
-                    {COMMUNITY_SORT_TYPE.map((sortType) => (
-                      <Button
-                        key={sortType.id}
-                        type="button"
-                        size="sm"
-                        onClick={() => handleSortChange(sortType.label)}
-                        className={cn(
-                          'cursor-pointer rounded-full whitespace-nowrap',
-                          selectedSort === sortType.label ? 'bg-primary-500 font-bold text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-                        )}
-                      >
-                        {sortType.label}
-                      </Button>
-                    ))}
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/* 데스크탑 */}
-            {isMd && (
-              <div className="mb-7 flex w-full flex-col gap-4">
-                <div className="flex items-center justify-between">
+    <div className="relative min-h-screen bg-[#F3F4F6] pt-0 md:pt-5">
+      <div className="pb-4xl mx-auto max-w-7xl px-0 md:px-4">
+        <div className="flex w-full flex-col">
+          {/* 모바일: 필터 영역 */}
+          {!isMd && (
+            <div className={cn(!isFilterCollapsed && `sticky top-16 ${Z_INDEX.DROPDOWN}`)}>
+              {/* 접히는 필터 영역 */}
+              <div
+                className={cn(
+                  'bg-white transition-all duration-300 ease-out',
+                  isFilterCollapsed ? 'max-h-0 overflow-hidden' : 'max-h-[300px] overflow-visible'
+                )}
+              >
+                <div className="flex items-center justify-between border-b border-gray-200 p-3.5">
                   <CommunityTabs tabs={COMMUNITY_TABS} activeTab={activeCommunityTypeTab} onTabChange={handleTabChange} ariaLabel="커뮤니티 타입" />
-                  {isLogin() && (
-                    <Link to={ROUTES.COMMUNITY_POST} type="button" className="bg-primary-300 rounded-lg px-3 py-2 text-white">
-                      글쓰기
-                    </Link>
-                  )}
                 </div>
 
-                <div className="flex flex-row items-center justify-between gap-5">
-                  <div className="h-auto w-36">
+                <div className="flex flex-row-reverse items-center justify-between gap-3 border-b border-gray-200 px-3.5 pt-4 pb-3.5">
+                  <div className="h-11 w-24">
                     <SelectDropdown
                       value={selectSearchType}
                       onChange={handleSearchTypeChange}
@@ -274,116 +214,163 @@ export default function CommunityPage() {
                         value: sort.label,
                         label: sort.label,
                       }))}
-                      buttonClassName="border border-gray-300 bg-primary-50 text-gray-900 text-base px-3 py-2 "
-                    />
-                  </div>
-                  <SearchBar
-                    placeholder="게시글 제목이나 내용, 작성자로 검색해보세요"
-                    borderColor="border-gray-300"
-                    className="h-11 max-w-full"
-                    paramName="communityKeyword"
-                  />
-                  <div className="w-36">
-                    <SelectDropdown
-                      value={selectedSort}
-                      onChange={handleSortChange}
-                      options={COMMUNITY_SORT_TYPE.map((category) => ({
-                        value: category.label,
-                        label: category.label,
-                      }))}
                       buttonClassName="border border-gray-300 bg-primary-50 text-gray-900 text-base px-3 py-2"
                     />
                   </div>
+                  <SearchBar placeholder="게시글 검색" borderColor="border-gray-300" className="h-11 max-w-full" paramName="communityKeyword" />
+                </div>
+                <div className="flex gap-2 border-b border-gray-200 bg-white px-3.5 py-3.5">
+                  {COMMUNITY_SORT_TYPE.map((sortType) => (
+                    <Button
+                      key={sortType.id}
+                      type="button"
+                      size="sm"
+                      onClick={() => handleSortChange(sortType.label)}
+                      className={cn(
+                        'cursor-pointer rounded-full whitespace-nowrap',
+                        selectedSort === sortType.label ? 'bg-primary-500 font-bold text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                      )}
+                    >
+                      {sortType.label}
+                    </Button>
+                  ))}
                 </div>
               </div>
-            )}
-            {communityPosts.length === 0 ? (
+            </div>
+          )}
+
+          {/* 데스크탑 */}
+          {isMd && (
+            <div className="mb-7 flex w-full flex-col gap-4">
+              <div className="flex items-center justify-between">
+                <CommunityTabs tabs={COMMUNITY_TABS} activeTab={activeCommunityTypeTab} onTabChange={handleTabChange} ariaLabel="커뮤니티 타입" />
+                {isLogin() && (
+                  <Link to={ROUTES.COMMUNITY_POST} type="button" className="bg-primary-300 rounded-lg px-3 py-2 text-white">
+                    글쓰기
+                  </Link>
+                )}
+              </div>
+
+              <div className="flex flex-row items-center justify-between gap-5">
+                <div className="h-auto w-36">
+                  <SelectDropdown
+                    value={selectSearchType}
+                    onChange={handleSearchTypeChange}
+                    options={COMMUNITY_SEARCH_TYPE.map((sort) => ({
+                      value: sort.label,
+                      label: sort.label,
+                    }))}
+                    buttonClassName="border border-gray-300 bg-primary-50 text-gray-900 text-base px-3 py-2 "
+                  />
+                </div>
+                <SearchBar
+                  placeholder="게시글 제목이나 내용, 작성자로 검색해보세요"
+                  borderColor="border-gray-300"
+                  className="h-11 max-w-full"
+                  paramName="communityKeyword"
+                />
+                <div className="w-36">
+                  <SelectDropdown
+                    value={selectedSort}
+                    onChange={handleSortChange}
+                    options={COMMUNITY_SORT_TYPE.map((category) => ({
+                      value: category.label,
+                      label: category.label,
+                    }))}
+                    buttonClassName="border border-gray-300 bg-primary-50 text-gray-900 text-base px-3 py-2"
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+          {communityPosts.length === 0 ? (
+            <div className={cn('px-3.5 md:px-0', !isMd && (isFilterCollapsed ? 'mt-20' : 'mt-4'))}>
               <EmptyState icon={MessageSquareText} title="아직 게시글이 없어요" description="첫 번째 이야기를 나눠보세요!" />
-            ) : (
-              <ul className="mt-7 flex flex-col gap-2.5 px-3.5 md:mt-0 md:p-0">
-                {communityPosts.map((post) =>
-                  isMd ? (
-                    <li
-                      key={post.id}
-                      className="flex flex-col justify-center gap-2.5 rounded-lg border border-gray-400 bg-white px-3.5 pt-3.5 pb-5 shadow-xl"
-                    >
-                      <Link to={ROUTES.COMMUNITY_DETAIL_ID(post.id)}>
-                        <p className="font-semibold">{post.title}</p>
+            </div>
+          ) : (
+            <ul className={cn('flex flex-col gap-2.5 px-3.5 md:p-0', !isMd && (isFilterCollapsed ? 'mt-20' : 'mt-4'))}>
+              {communityPosts.map((post) =>
+                isMd ? (
+                  <li
+                    key={post.id}
+                    className="flex flex-col justify-center gap-2.5 rounded-lg border border-gray-400 bg-white px-3.5 pt-3.5 pb-5 shadow-xl"
+                  >
+                    <Link to={ROUTES.COMMUNITY_DETAIL_ID(post.id)}>
+                      <p className="font-semibold">{post.title}</p>
+                      <div className="flex items-center gap-2.5">
+                        <div className="flex items-center gap-1 text-gray-500">
+                          <UserRound size={16} className="text-gray-500" strokeWidth={2.3} />
+                          <p>{post.authorNickname}</p>
+                        </div>
+                        <div className="flex items-center gap-1 text-gray-500">
+                          <Clock size={16} className="text-gray-500" strokeWidth={2.3} />
+                          <p>{getTimeAgo(post.createdAt)}</p>
+                        </div>
+                        <div className="flex items-center gap-1 text-gray-500">
+                          <MessageSquare size={16} className="text-gray-500" strokeWidth={2.3} />
+                          <p>{post.commentCount}</p>
+                        </div>
+                        <div className="flex items-center gap-1 text-gray-500">
+                          <Eye size={16} className="text-gray-500" strokeWidth={2.3} />
+                          <span>조회</span>
+                          <span>{post.viewCount}</span>
+                        </div>
+                      </div>
+                    </Link>
+                  </li>
+                ) : (
+                  <li
+                    key={post.id}
+                    className="flex flex-col justify-center gap-2.5 rounded-lg border border-gray-400 bg-white px-3.5 pt-3.5 pb-5 shadow-xl"
+                  >
+                    <Link to={ROUTES.COMMUNITY_DETAIL_ID(post.id)} className="flex flex-col gap-4">
+                      <div className="flex flex-col gap-2">
+                        <p className="text-lg font-semibold">{post.title}</p>
+
+                        <p className="line-clamp-1">{post.contentPreview}</p>
+                      </div>
+                      <div className="flex items-center justify-between gap-2.5">
+                        <div className="flex items-center text-gray-500">
+                          <p>{post.authorNickname}</p>
+                          <Dot size={12} />
+                          <p>{getTimeAgo(post.createdAt)}</p>
+                        </div>
                         <div className="flex items-center gap-2.5">
-                          <div className="flex items-center gap-1 text-gray-500">
-                            <UserRound size={16} className="text-gray-500" strokeWidth={2.3} />
-                            <p>{post.authorNickname}</p>
-                          </div>
-                          <div className="flex items-center gap-1 text-gray-500">
-                            <Clock size={16} className="text-gray-500" strokeWidth={2.3} />
-                            <p>{getTimeAgo(post.createdAt)}</p>
-                          </div>
                           <div className="flex items-center gap-1 text-gray-500">
                             <MessageSquare size={16} className="text-gray-500" strokeWidth={2.3} />
                             <p>{post.commentCount}</p>
                           </div>
                           <div className="flex items-center gap-1 text-gray-500">
                             <Eye size={16} className="text-gray-500" strokeWidth={2.3} />
-                            <span>조회</span>
                             <span>{post.viewCount}</span>
                           </div>
                         </div>
-                      </Link>
-                    </li>
-                  ) : (
-                    <li
-                      key={post.id}
-                      className="flex flex-col justify-center gap-2.5 rounded-lg border border-gray-400 bg-white px-3.5 pt-3.5 pb-5 shadow-xl"
-                    >
-                      <Link to={ROUTES.COMMUNITY_DETAIL_ID(post.id)} className="flex flex-col gap-4">
-                        <div className="flex flex-col gap-2">
-                          <p className="text-lg font-semibold">{post.title}</p>
-
-                          <p className="line-clamp-1">{post.contentPreview}</p>
-                        </div>
-                        <div className="flex items-center justify-between gap-2.5">
-                          <div className="flex items-center text-gray-500">
-                            <p>{post.authorNickname}</p>
-                            <Dot size={12} />
-                            <p>{getTimeAgo(post.createdAt)}</p>
-                          </div>
-                          <div className="flex items-center gap-2.5">
-                            <div className="flex items-center gap-1 text-gray-500">
-                              <MessageSquare size={16} className="text-gray-500" strokeWidth={2.3} />
-                              <p>{post.commentCount}</p>
-                            </div>
-                            <div className="flex items-center gap-1 text-gray-500">
-                              <Eye size={16} className="text-gray-500" strokeWidth={2.3} />
-                              <span>{post.viewCount}</span>
-                            </div>
-                          </div>
-                        </div>
-                      </Link>
-                    </li>
-                  )
-                )}
-              </ul>
-            )}
-            {hasNextPage &&
-              (isMd ? (
+                      </div>
+                    </Link>
+                  </li>
+                )
+              )}
+            </ul>
+          )}
+          {hasNextPage &&
+            (isMd ? (
+              <LoadMoreButton onClick={() => fetchNextPage()} isLoading={isFetchingNextPage} classname="border-0" />
+            ) : (
+              <div className="px-3.5">
                 <LoadMoreButton onClick={() => fetchNextPage()} isLoading={isFetchingNextPage} classname="border-0" />
-              ) : (
-                <div className="px-3.5">
-                  <LoadMoreButton onClick={() => fetchNextPage()} isLoading={isFetchingNextPage} classname="border-0" />
-                </div>
-              ))}
-          </div>
+              </div>
+            ))}
         </div>
-        {!isMd && isLogin() && (
-          <Link
-            to={ROUTES.COMMUNITY_POST}
-            type="button"
-            className={`bg-primary-200 fixed right-4 bottom-4 rounded-full px-3 py-3 text-white ${Z_INDEX.FLOATING_BUTTON}`}
-          >
-            <Plus />
-          </Link>
-        )}
       </div>
-    </>
+      {!isMd && isLogin() && (
+        <Link
+          to={ROUTES.COMMUNITY_POST}
+          type="button"
+          className={`bg-primary-200 fixed right-4 bottom-4 rounded-full px-3 py-3 text-white ${Z_INDEX.FLOATING_BUTTON}`}
+        >
+          <Plus />
+        </Link>
+      )}
+    </div>
   )
 }


### PR DESCRIPTION
## 📌 개요

- 커뮤니티 페이지에서 발생하는 여러 UI/UX 관련 버그를 수정합니다.

## 🔧 작업 내용

- [x] CommunityDetail에서 뒤로가기 링크에 탭 파라미터 추가
- [x] MainLayout에서 헤더 유무에 따른 동적 padding 적용
- [x] CommunityPage에서 SimpleHeader 제거 및 레이아웃 정리
- [x] 페이지 진입 시 스크롤 최상단으로 이동하는 로직 추가
- [x] 필터 접힘 상태에 따른 sticky/여백 동작 개선

## 📎 관련 이슈

Closes #433

## 💬 리뷰어 참고 사항

- 커뮤니티 상세 페이지에서 뒤로가기 시 해당 탭으로 정확히 돌아가는지 확인 부탁드립니다
- 모바일에서 필터 접힘/펼침 상태에 따른 레이아웃이 자연스러운지 확인 부탁드립니다