### PR TITLE
feat: 프로필 수정 실패 시 에러 Toast 알림 구현(#437)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -90,5 +90,5 @@ input[type='date']::-webkit-calendar-picker-indicator {
   animation-name: toast-progress-fill;
   animation-timing-function: linear;
   animation-fill-mode: forwards;
-  animation-duration: var(--toast-duration, 3000ms);
+  animation-duration: var(--toast-duration, 4500ms);
 }

--- a/src/pages/my-page/components/MyList.tsx
+++ b/src/pages/my-page/components/MyList.tsx
@@ -19,10 +19,12 @@ import { useMediaQuery } from '@src/hooks/useMediaQuery'
 import { IconButton } from '@src/components/commons/button/IconButton'
 import { Z_INDEX } from '@src/constants/ui'
 import { useOutsideClick } from '@src/hooks/useOutsideClick'
+
 type MyListProps = Product & {
   activeTab?: MyPageTabId
   handleConfirmModal: (e: React.MouseEvent, id: number, title: string, price: number, mainImageUrl: string) => void
 }
+
 export default function MyList({ id, title, price, mainImageUrl, tradeStatus, viewCount, activeTab, handleConfirmModal }: MyListProps) {
   const [currentTradeStatus, setCurrentTradeStatus] = useState(tradeStatus)
   const currentTradeStatusKo = STATUS_EN_TO_KO.find((s) => s.value === currentTradeStatus)?.name ?? '판매중'


### PR DESCRIPTION
## 📌 개요

- 프로필 수정 API 호출 실패 시 사용자에게 에러 Toast 알림을 표시하여 피드백 제공

## 🔧 작업 내용

- [x] ProfileUpdateBaseForm에 에러 Toast UI 구현
- [x] Toast duration 조정 (3000ms → 4500ms)
- [x] 코드 스타일 정리

## 📎 관련 이슈

Closes #437

## 💬 리뷰어 참고 사항

- 기존 Toast 알림 시스템 (#435) 컴포넌트 재사용
- 에러 발생 시 5초 후 자동으로 Toast가 사라집니다