### PR TITLE
refactor: InlineNotification 공통 컴포넌트 추출(#439)

### DIFF
--- a/src/components/commons/InlineNotification.tsx
+++ b/src/components/commons/InlineNotification.tsx
@@ -1,0 +1,68 @@
+import { motion } from 'framer-motion'
+import { X } from 'lucide-react'
+import { cn } from '@src/utils/cn'
+import { TOAST_ICONS } from '@src/constants/constants'
+import ToastProgress from './ToastProgress'
+import type { ToastType } from '@src/types/toast'
+
+const NOTIFICATION_STYLES: Record<ToastType, { box: string; icon: string; text: string; bar: string; iconWrapper: string }> = {
+  success: {
+    box: 'border-[#71ca77] bg-[#ddfae3] text-[#62b66a]',
+    icon: 'stroke-white stroke-5',
+    text: 'text-success-600 ',
+    bar: 'bg-success-200',
+    iconWrapper: 'bg-success-500 rounded-full p-1.5 mt-1',
+  },
+  error: {
+    box: 'border-[#db202a] bg-[#fff1f1] text-[#be5e5a]',
+    icon: 'stroke-white stroke-5 rotate-90',
+    text: 'text-danger-500 ',
+    bar: 'bg-danger-200',
+    iconWrapper: 'bg-danger-500 rounded-full p-1.5 mt-1',
+  },
+  warning: {
+    box: 'border-[#d0ad39] bg-[#faf7be] text-[#d2ad36]',
+    icon: 'stroke-[#d0ad39] stroke-3 h-4 w-4',
+    text: 'text-[#d9ac2c] ',
+    bar: 'bg-[#faf7be]',
+    iconWrapper: 'bg-[#faf7be] rounded-full p-1.5',
+  },
+}
+
+interface InlineNotificationProps {
+  type: ToastType
+  children: React.ReactNode
+  onClose: () => void
+  durationMs?: number
+}
+
+export default function InlineNotification({ type, children, onClose, durationMs = 5000 }: InlineNotificationProps) {
+  const Icon = TOAST_ICONS[type]
+  const styles = NOTIFICATION_STYLES[type]
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: 20 }}
+      animate={{ opacity: 1, x: 0 }}
+      exit={{ opacity: 0, x: 20 }}
+      transition={{ duration: 0.2 }}
+      className={cn('overflow-hidden rounded-lg border pt-2 text-sm', styles.box)}
+    >
+      <div className="flex items-start gap-2 px-2 pb-2">
+        <div className={styles.iconWrapper}>
+          <Icon className={cn('h-2 w-2 shrink-0', styles.icon)} />
+        </div>
+        <div className="text-sm">{children}</div>
+        <button
+          type="button"
+          aria-label="close notification"
+          onClick={onClose}
+          className={cn('ml-auto shrink-0 cursor-pointer rounded p-1 transition-colors focus:outline-none focus-visible:ring-2', styles.text)}
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+      <ToastProgress trackClass={styles.bar} fillClass={styles.text} durationMs={durationMs} onEnd={onClose} />
+    </motion.div>
+  )
+}

--- a/src/components/modal/DeleteConfirmModal.tsx
+++ b/src/components/modal/DeleteConfirmModal.tsx
@@ -2,22 +2,20 @@ import PlaceholderImage from '@assets/images/placeholder.png'
 import { formatPrice } from '@src/utils/formatPrice'
 import { Button } from '../commons/button/Button'
 import AlertBox from './AlertBox'
-import { PRODUCT_DELETE_ALERT_LIST, TOAST_COLORS, TOAST_ICONS } from '@src/constants/constants'
+import { PRODUCT_DELETE_ALERT_LIST } from '@src/constants/constants'
 import ModalTitle from './ModalTitle'
 import { useRef } from 'react'
 import { useOutsideClick } from '@src/hooks/useOutsideClick'
 import { Z_INDEX } from '@src/constants/ui'
-import { AnimatePresence, motion } from 'framer-motion'
-import ToastProgress from '../commons/ToastProgress'
-import { cn } from '@src/utils/cn'
-import { X } from 'lucide-react'
+import { AnimatePresence } from 'framer-motion'
+import InlineNotification from '../commons/InlineNotification'
 
 interface DeleteConfirmModalProps {
   isOpen: boolean
   product: { id: number; title: string; price: number; mainImageUrl: string } | null
   onConfirm: (id: number) => void
   onCancel: () => void
-  error?: string | null
+  error?: React.ReactNode
   onClearError?: () => void
 }
 
@@ -27,34 +25,16 @@ function DeleteConfirmModal({ isOpen, product, onConfirm, onCancel, error, onCle
   useOutsideClick(isOpen, [modalRef], onCancel)
 
   if (!isOpen || !product) return null
-  const LeadingIcon = TOAST_ICONS['error']
+
   return (
     <div className={`fixed inset-0 flex items-center justify-center bg-gray-900/70 ${Z_INDEX.MODAL}`}>
       <div className="flex w-11/12 flex-col gap-4 rounded-lg bg-white p-5 md:w-[16vw] md:min-w-96" ref={modalRef}>
         <ModalTitle heading="상품 삭제" description="정말로 이 상품을 삭제하시겠습니까?" />
         <AnimatePresence>
           {error && (
-            <motion.div
-              initial={{ opacity: 0, x: 20 }}
-              animate={{ opacity: 1, x: 0 }}
-              exit={{ opacity: 0, x: 20 }}
-              transition={{ duration: 0.2 }}
-              className="overflow-hidden rounded-lg border border-[#db202a] bg-[#fff1f1] pt-2 text-sm text-gray-900"
-            >
-              <div className="flex items-center gap-2 px-2 pb-2">
-                <LeadingIcon className={cn('h-5 w-5 rotate-90', TOAST_COLORS['error'].icon)} />
-                <div className="text-sm">{error}</div>
-                <button
-                  type="button"
-                  aria-label="close toast"
-                  onClick={() => onClearError?.()}
-                  className="text-danger-500 hover:bg-danger-200 ml-auto cursor-pointer transition-colors focus:outline-none focus-visible:ring-2"
-                >
-                  <X className="h-4 w-4" />
-                </button>
-              </div>
-              <ToastProgress trackClass="bg-danger-200" fillClass="text-danger-500" durationMs={5000} onEnd={() => onClearError?.()} />
-            </motion.div>
+            <InlineNotification type="error" onClose={() => onClearError?.()}>
+              {error}
+            </InlineNotification>
           )}
         </AnimatePresence>
         <AlertBox alertList={PRODUCT_DELETE_ALERT_LIST} />

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -7,9 +7,9 @@ import {
   Trash2,
   Reply,
   MessageCircle,
-  AlertTriangle,
-  CheckCircle2,
-  CircleSlash,
+  TriangleAlert,
+  Check,
+  Slash,
   type LucideIcon,
 } from 'lucide-react'
 import type { ToastType } from '@src/types/toast'
@@ -281,16 +281,16 @@ export const TOAST_DURATION_BY_TYPE: Record<ToastType, number> = {
 
 /** 타입별 아이콘 */
 export const TOAST_ICONS: Record<ToastType, LucideIcon> = {
-  success: CheckCircle2,
-  warning: AlertTriangle,
-  error: CircleSlash,
+  success: Check,
+  warning: TriangleAlert,
+  error: Slash,
 }
 
 /** 타입별 색상 스타일 */
 export const TOAST_COLORS: Record<ToastType, { box: string; icon: string; text: string; bar: string }> = {
   success: {
     box: 'bg-success-100 border-success-500',
-    icon: 'text-success-500',
+    icon: 'text-success-100',
     text: 'text-success-500',
     bar: 'bg-success-100',
   },

--- a/src/pages/my-page/MyPage.tsx
+++ b/src/pages/my-page/MyPage.tsx
@@ -12,7 +12,7 @@ import { withDraw } from '@src/api/profile'
 import ProfileData from '@src/components/profile/ProfileData'
 
 function MyPage() {
-  const [deleteError, setDeleteError] = useState<string | null>(null)
+  const [deleteError, setDeleteError] = useState<React.ReactNode | null>(null)
 
   const { user, clearAll, updateUserProfile, setRedirectUrl } = useUserStore()
   const [searchParams, setSearchParams] = useSearchParams()
@@ -107,7 +107,12 @@ function MyPage() {
       setSelectedProduct(null)
     },
     onError: () => {
-      setDeleteError('삭제에 실패했습니다. 다시 시도해주세요.')
+      setDeleteError(
+        <div className="flex flex-col gap-0.5">
+          <p className="text-base font-semibold">상품 삭제에 실패했습니다.</p>
+          <p>잠시 후 다시 시도해주세요.</p>
+        </div>
+      )
     },
   })
 


### PR DESCRIPTION
## 📌 개요

- 에러/성공/경고 알림 UI를 InlineNotification 공통 컴포넌트로 추출하여 코드 재사용성 향상

## 🔧 작업 내용

- [x] InlineNotification 공통 컴포넌트 생성
- [x] DeleteConfirmModal에서 InlineNotification 사용
- [x] ProfileUpdateBaseForm에서 InlineNotification 사용
- [x] 프로필 수정 성공/경고 알림 추가
- [x] 변경사항 없이 제출 시 경고 표시 기능
- [x] Toast 아이콘 변경 (Check, TriangleAlert, Slash)

## 📎 관련 이슈

Closes #439

## 💬 리뷰어 참고 사항

- InlineNotification 컴포넌트는 error/success/warning 3가지 타입 지원
- 기존 Toast 시스템의 ToastProgress 컴포넌트 재사용