### PR TITLE
feat: 비밀번호 변경 시 알림 피드백 구현(#441)

### DIFF
--- a/src/pages/profile-update/components/ProfileUpdatePasswordForm.tsx
+++ b/src/pages/profile-update/components/ProfileUpdatePasswordForm.tsx
@@ -7,6 +7,8 @@ import { InputField } from '@src/components/commons/InputField'
 import AlertBox from '@src/components/modal/AlertBox'
 import { useEffect, useState } from 'react'
 import { changePassword } from '@src/api/profile'
+import InlineNotification from '@src/components/commons/InlineNotification'
+import { AnimatePresence } from 'framer-motion'
 
 export interface ProfileUpdatePasswordFormValues {
   currentPassword: string
@@ -31,6 +33,9 @@ export default function ProfileUpdatePasswordForm() {
       confirmPassword: '',
     },
   })
+  const [pwUpdateError, setPwUpdateError] = useState<React.ReactNode | null>(null)
+  const [pwUpdateSuccess, setPwUpdateSuccess] = useState<React.ReactNode | null>(null)
+  const [pwUpdateWarning, setPwUpdateWarning] = useState<React.ReactNode | null>(null)
 
   const [checkResult, setCheckResult] = useState<{
     status: 'idle' | 'success' | 'error'
@@ -40,11 +45,32 @@ export default function ProfileUpdatePasswordForm() {
   const passwordConfirm = watch('confirmPassword')
 
   const onSubmit = async (requestData: ProfileUpdatePasswordFormValues) => {
+    if (requestData.currentPassword === requestData.newPassword) {
+      setPwUpdateWarning(
+        <div className="flex flex-col gap-0.5">
+          <p className="text-base font-semibold">동일한 비밀번호입니다.</p>
+          <p>현재 비밀번호와 다른 비밀번호를 입력해주세요.</p>
+        </div>
+      )
+      return
+    }
+
     try {
       await changePassword({ ...requestData })
       reset()
-    } catch (error) {
-      console.error('비밀번호 변경 실패:', error)
+      setPwUpdateSuccess(
+        <div className="flex flex-col gap-0.5">
+          <p className="text-base font-semibold">성공적으로 비밀번호를 변경했습니다.</p>
+          <p>변경사항이 성공적으로 적용되었습니다.</p>
+        </div>
+      )
+    } catch {
+      setPwUpdateError(
+        <div className="flex flex-col gap-0.5">
+          <p className="text-base font-semibold">비밀번호 변경에 실패했습니다.</p>
+          <p>잠시 후 다시 시도해주세요.</p>
+        </div>
+      )
     }
   }
 
@@ -144,6 +170,23 @@ export default function ProfileUpdatePasswordForm() {
               listColor="text-[#155DFC]"
             />
           </div>
+          <AnimatePresence>
+            {pwUpdateError && (
+              <InlineNotification type="error" onClose={() => setPwUpdateError(null)}>
+                {pwUpdateError}
+              </InlineNotification>
+            )}
+            {pwUpdateSuccess && (
+              <InlineNotification type="success" onClose={() => setPwUpdateSuccess(null)}>
+                {pwUpdateSuccess}
+              </InlineNotification>
+            )}
+            {pwUpdateWarning && (
+              <InlineNotification type="warning" onClose={() => setPwUpdateWarning(null)}>
+                {pwUpdateWarning}
+              </InlineNotification>
+            )}
+          </AnimatePresence>
           <Button size="md" className="bg-primary-300 w-full cursor-pointer text-white" type="submit">
             비밀번호 변경
           </Button>


### PR DESCRIPTION
## 📌 개요

- 비밀번호 변경 API 호출 결과에 따라 사용자에게 알림 피드백을 제공

## 🔧 작업 내용

- [x] 비밀번호 변경 성공 알림 추가
- [x] 비밀번호 변경 실패 에러 알림 추가
- [x] 현재 비밀번호와 동일한 비밀번호 입력 시 경고 표시

## 📎 관련 이슈

Closes #441

## 💬 리뷰어 참고 사항

- InlineNotification 컴포넌트 (#439) 활용
- 기존 console.error 대신 사용자에게 실제 피드백 제공