### PR TITLE
feat: 회원탈퇴 실패 시 에러 알림 추가(#443)

### DIFF
--- a/src/components/modal/WithdrawModal.tsx
+++ b/src/components/modal/WithdrawModal.tsx
@@ -9,6 +9,8 @@ import ModalTitle from './ModalTitle'
 import { useRef } from 'react'
 import { useOutsideClick } from '@src/hooks/useOutsideClick'
 import { Z_INDEX } from '@src/constants/ui'
+import { AnimatePresence } from 'framer-motion'
+import InlineNotification from '../commons/InlineNotification'
 
 export interface WithDrawFormValues {
   reason: string
@@ -20,9 +22,11 @@ interface WithdrawModalProps {
   isOpen: boolean
   onConfirm: (data: WithDrawFormValues) => void
   onCancel: () => void
+  error?: React.ReactNode
+  onClearError?: () => void
 }
 
-export default function WithdrawModal({ isOpen, onConfirm, onCancel }: WithdrawModalProps) {
+export default function WithdrawModal({ isOpen, onConfirm, onCancel, error, onClearError }: WithdrawModalProps) {
   const {
     control,
     handleSubmit,
@@ -40,8 +44,9 @@ export default function WithdrawModal({ isOpen, onConfirm, onCancel }: WithdrawM
   })
   const titleLength = watch('detailReason')?.length ?? 0
   const modalRef = useRef<HTMLDivElement>(null)
-  // 바깥 클릭 시 onCancel 호출
+
   useOutsideClick(isOpen, [modalRef], onCancel)
+
   const handleCancel = () => {
     reset()
     onCancel()
@@ -59,6 +64,13 @@ export default function WithdrawModal({ isOpen, onConfirm, onCancel }: WithdrawM
     <div className={`fixed inset-0 flex items-center justify-center bg-gray-900/70 ${Z_INDEX.MODAL}`}>
       <div ref={modalRef} className="flex w-11/12 flex-col gap-4 rounded-lg bg-white p-5 md:w-[16vw] md:min-w-96">
         <ModalTitle heading="회원탈퇴" description="정말로 탈퇴하시겠습니까?" />
+        <AnimatePresence>
+          {error && (
+            <InlineNotification type="error" onClose={() => onClearError?.()}>
+              {error}
+            </InlineNotification>
+          )}
+        </AnimatePresence>
         <AlertBox alertList={WITH_DRAW_ALERT_LIST} />
 
         <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">

--- a/src/pages/my-page/MyPage.tsx
+++ b/src/pages/my-page/MyPage.tsx
@@ -20,6 +20,7 @@ function MyPage() {
   const navigate = useNavigate()
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [isWithdrawModalOpen, setIsWithdrawModalOpen] = useState(false)
+  const [withdrawError, setWithdrawError] = useState<React.ReactNode | null>(null)
   const [selectedProduct, setSelectedProduct] = useState<{
     id: number
     title: string
@@ -100,6 +101,10 @@ function MyPage() {
 
   const { mutate: deleteProductMutate } = useMutation({
     mutationFn: (id: number) => deleteProduct(id),
+    // mutationFn: (id: number) => {
+    //   throw new Error('테스트 에러') // 임시 추가
+    //   // return deleteProduct(id)     // 주석 처리
+    // },
     onSuccess: () => {
       // 삭제 성공 시 상품 목록 다시 불러오기
       queryClient.invalidateQueries({ queryKey: ['myProducts'] })
@@ -134,12 +139,17 @@ function MyPage() {
 
   const handleWithdraw = async (data: WithDrawFormValues) => {
     try {
+      // throw new Error('테스트 에러') // 임시 추가
       await withDraw(data)
-      clearAll() // 모든 사용자 상태 초기화 (user, accessToken, refreshToken, redirectUrl)
-      // 로그인 페이지로 이동
+      clearAll()
       navigate('/')
-    } catch (error) {
-      console.error('회원탈퇴 실패:', error)
+    } catch {
+      setWithdrawError(
+        <div className="flex flex-col gap-0.5">
+          <p className="text-base font-semibold">회원탈퇴에 실패했습니다.</p>
+          <p>잠시 후 다시 시도해주세요.</p>
+        </div>
+      )
     }
   }
 
@@ -255,7 +265,13 @@ function MyPage() {
         error={deleteError}
         onClearError={() => setDeleteError(null)}
       />
-      <WithdrawModal isOpen={isWithdrawModalOpen} onConfirm={handleWithdraw} onCancel={() => setIsWithdrawModalOpen(false)} />
+      <WithdrawModal
+        isOpen={isWithdrawModalOpen}
+        onConfirm={handleWithdraw}
+        onCancel={() => setIsWithdrawModalOpen(false)}
+        error={withdrawError}
+        onClearError={() => setWithdrawError(null)}
+      />
     </>
   )
 }


### PR DESCRIPTION
## 📌 개요

- 회원탈퇴 실패 시 사용자에게 에러 알림을 표시하는 기능 추가

## 🔧 작업 내용

- [x] WithdrawModal에 error, onClearError props 추가
- [x] InlineNotification 컴포넌트로 에러 표시
- [x] console.error 대신 사용자 친화적 에러 메시지로 변경

## 📎 관련 이슈

- Close #443

## 📸 스크린샷 (선택)

## 💬 리뷰어 참고 사항

- 회원탈퇴 API 실패 시 에러 알림이 표시되는지 확인 필요
- 에러 알림 닫기 버튼 및 자동 닫힘 동작 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)