### PR TITLE
feat: 사용자 차단 실패 시 에러 알림 추가(#445)

### DIFF
--- a/src/components/modal/BlockModal.tsx
+++ b/src/components/modal/BlockModal.tsx
@@ -4,9 +4,11 @@ import { USER_BLOCK_ALERT_LIST } from '@src/constants/constants'
 import ModalTitle from './ModalTitle'
 import { userBlocked } from '@src/api/profile'
 import { useQueryClient } from '@tanstack/react-query'
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 import { useOutsideClick } from '@src/hooks/useOutsideClick'
 import { Z_INDEX } from '@src/constants/ui'
+import { AnimatePresence } from 'framer-motion'
+import InlineNotification from '../commons/InlineNotification'
 
 interface BlockModalProps {
   isOpen: boolean
@@ -17,19 +19,27 @@ interface BlockModalProps {
 
 export default function BlockModal({ isOpen, onCancel, userNickname, userId }: BlockModalProps) {
   const queryClient = useQueryClient()
+  const modalRef = useRef<HTMLDivElement>(null)
+  const [userBlockError, setUserBlockError] = useState<React.ReactNode | null>(null)
+
   const handleCancel = () => {
     onCancel()
   }
-  const modalRef = useRef<HTMLDivElement>(null)
-  // 바깥 클릭 시 onCancel 호출
+
   useOutsideClick(isOpen, [modalRef], onCancel)
+
   const onUserBlock = async () => {
     try {
       await userBlocked(userId)
       queryClient.invalidateQueries({ queryKey: ['userPage'] })
       onCancel()
-    } catch (error) {
-      console.error('사용자 차단 실패:', error)
+    } catch {
+      setUserBlockError(
+        <div className="flex flex-col gap-0.5">
+          <p className="text-base font-semibold">사용자 차단에 실패했습니다.</p>
+          <p>잠시 후 다시 시도해주세요.</p>
+        </div>
+      )
     }
   }
   if (!isOpen) return null
@@ -37,8 +47,14 @@ export default function BlockModal({ isOpen, onCancel, userNickname, userId }: B
     <div className={`fixed inset-0 flex items-center justify-center bg-gray-900/70 ${Z_INDEX.MODAL}`}>
       <div ref={modalRef} className="flex w-11/12 flex-col gap-4 rounded-lg bg-white p-5 md:w-[16vw] md:min-w-max">
         <ModalTitle heading="사용자 차단하기" description={`정말로 ${userNickname}를 신고하시겠습니까?`} />
+        <AnimatePresence>
+          {userBlockError && (
+            <InlineNotification type="error" onClose={() => setUserBlockError(null)}>
+              {userBlockError}
+            </InlineNotification>
+          )}
+        </AnimatePresence>
         <AlertBox alertList={USER_BLOCK_ALERT_LIST} />
-
         <div className="flex justify-end gap-3">
           <Button type="button" onClick={handleCancel} size="sm" className="cursor-pointer rounded-lg border border-gray-300 bg-white">
             취소

--- a/src/pages/community/CommunityDetail.tsx
+++ b/src/pages/community/CommunityDetail.tsx
@@ -33,6 +33,7 @@ export default function CommunityDetail() {
       content: '',
     },
   })
+
   const user = useUserStore((state) => state.user)
   const setRedirectUrl = useUserStore((state) => state.setRedirectUrl)
   const openLoginModal = useLoginModalStore((state) => state.openLoginModal)
@@ -54,6 +55,7 @@ export default function CommunityDetail() {
     queryFn: () => fetchCommunityId(id!),
     enabled: !!id,
   })
+
   const { data: commentData, isLoading: isLoadingCommentData } = useQuery({
     queryKey: ['community', id, 'comments'],
     queryFn: () => fetchComments(id!),
@@ -67,6 +69,7 @@ export default function CommunityDetail() {
       reset()
     },
     onError: () => {
+      console.error('게시글 로드 실패:', error)
       alert('답글 등록에 실패했습니다.')
     },
   })
@@ -87,6 +90,7 @@ export default function CommunityDetail() {
   const handlePostEdit = (postId: number) => {
     navigate(`/community/${postId}/edit`)
   }
+
   const getHeaderContent = () => {
     switch (data?.boardType) {
       case 'FREE':

--- a/src/pages/community/components/CommentList.tsx
+++ b/src/pages/community/components/CommentList.tsx
@@ -58,6 +58,7 @@ export function CommentList({ comments, postId }: CommentListProps) {
       setOpenRepliesCommentId(parentId ?? null)
     },
     onError: () => {
+      console.error('답글 등록 실패')
       alert('답글 등록에 실패했습니다.')
     },
   })
@@ -71,6 +72,7 @@ export function CommentList({ comments, postId }: CommentListProps) {
       queryClient.invalidateQueries({ queryKey: ['community', postId, 'replies'] })
     },
     onError: () => {
+      console.error('답글 삭제 실패')
       alert('댓글 삭제에 실패했습니다.')
     },
   })

--- a/src/pages/community/components/CommunityPostForm.tsx
+++ b/src/pages/community/components/CommunityPostForm.tsx
@@ -61,13 +61,6 @@ export default function CommunityPostForm() {
 
   const formValues = watch()
 
-  // 새 글 작성 시 폼 데이터 변경마다 sessionStorage에 자동 저장
-  useEffect(() => {
-    if (!isEditMode) {
-      sessionStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(formValues))
-    }
-  }, [formValues, isEditMode])
-
   const handleCancel = () => {
     clearDraft()
     navigate('/community')
@@ -94,6 +87,7 @@ export default function CommunityPostForm() {
       alert(isEditMode ? '게시글 수정에 실패했습니다.' : '게시글 등록에 실패했습니다.')
     }
   }
+
   useEffect(() => {
     const loadPost = async () => {
       if (isEditMode && id) {
@@ -112,6 +106,13 @@ export default function CommunityPostForm() {
     }
     loadPost()
   }, [id, isEditMode, reset])
+
+  // 새 글 작성 시 폼 데이터 변경마다 sessionStorage에 자동 저장
+  useEffect(() => {
+    if (!isEditMode) {
+      sessionStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(formValues))
+    }
+  }, [formValues, isEditMode])
 
   return (
     <>


### PR DESCRIPTION
## 📌 개요

- 사용자 차단 실패 시 에러 알림을 표시하는 기능 추가

## 🔧 작업 내용

- [x] BlockModal에 userBlockError state 추가
- [x] InlineNotification 컴포넌트로 에러 표시
- [x] console.error 대신 사용자 친화적 에러 메시지로 변경
- [x] 커뮤니티 관련 코드 정리

## 📎 관련 이슈

- Close #445

## 📸 스크린샷 (선택)

## 💬 리뷰어 참고 사항

- 사용자 차단 API 실패 시 에러 알림이 표시되는지 확인 필요
- 에러 알림 닫기 버튼 및 자동 닫힘 동작 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)