### PR TITLE
feat: 커뮤니티 게시글 폼 개선(#447)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -90,5 +90,6 @@ input[type='date']::-webkit-calendar-picker-indicator {
   animation-name: toast-progress-fill;
   animation-timing-function: linear;
   animation-fill-mode: forwards;
+  /* animation-duration: var(--toast-duration, 90000ms); */
   animation-duration: var(--toast-duration, 4500ms);
 }

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -5,37 +5,35 @@ import { useMediaQuery } from '@src/hooks/useMediaQuery'
 import { ROUTES } from '@src/constants/routes'
 import { cn } from '@src/utils/cn'
 
-// Header 숨김 패턴 (정규표현식 필요)
-const HIDE_HEADER_PATTERNS = [/^\/community\/\d+\/edit$/, new RegExp(`^${ROUTES.COMMUNITY_POST}$`)]
-
 // Header 숨김 패턴 (모바일에서만 숨김)
-const HIDE_HEADER_MOBILE_PATTERNS = [/^\/community\/\d+$/]
+const HIDE_HEADER_MOBILE_PATTERNS = [/^\/community\/\d+$/, /^\/community\/\d+\/edit$/, new RegExp(`^${ROUTES.COMMUNITY_POST}$`)]
 
-// SearchBar 숨김 경로 (정적 경로)
-const HIDE_SEARCHBAR_PATHS: string[] = [
-  ROUTES.COMMUNITY,
-  ROUTES.PROFILE_UPDATE,
-  ROUTES.PRODUCT_POST,
-  ROUTES.LOGIN,
-  ROUTES.SIGNUP,
-  ROUTES.FIND_PASSWORD,
-  ROUTES.MYPAGE,
-]
+// SearchBar 숨김 경로 - 모바일만 (정적 경로)
+const HIDE_SEARCHBAR_MOBILE_PATHS: string[] = [ROUTES.PROFILE_UPDATE, ROUTES.PRODUCT_POST, ROUTES.LOGIN, ROUTES.SIGNUP, ROUTES.FIND_PASSWORD, ROUTES.MYPAGE]
+
+// SearchBar 숨김 경로 - 항상 (정적 경로)
+const HIDE_SEARCHBAR_ALWAYS_PATHS: string[] = [ROUTES.COMMUNITY, ROUTES.COMMUNITY_POST]
 
 // 메뉴 버튼 숨김 경로
 const HIDE_MENU_BUTTON_PATHS: string[] = [ROUTES.LOGIN, ROUTES.SIGNUP]
 
-// SearchBar 숨김 패턴 (동적 경로)
-const HIDE_SEARCHBAR_PATTERNS = [/^\/products\/\d+\/edit$/, /^\/user-profile\/\d+$/]
+// SearchBar 숨김 패턴 - 모바일만 (동적 경로)
+const HIDE_SEARCHBAR_MOBILE_PATTERNS = [/^\/products\/\d+\/edit$/, /^\/user-profile\/\d+$/]
+
+// SearchBar 숨김 패턴 - 항상 (동적 경로)
+const HIDE_SEARCHBAR_ALWAYS_PATTERNS = [/^\/community\/\d+$/, /^\/community\/\d+\/edit$/]
 
 export default function MainLayout() {
   const isMd = useMediaQuery('(min-width: 768px)')
   const { pathname } = useLocation()
 
-  const hideHeaderAlways = HIDE_HEADER_PATTERNS.some((pattern) => pattern.test(pathname))
   const hideHeaderMobile = !isMd && HIDE_HEADER_MOBILE_PATTERNS.some((pattern) => pattern.test(pathname))
-  const showHeader = !hideHeaderAlways && !hideHeaderMobile
-  const hideSearchBar = !isMd && (HIDE_SEARCHBAR_PATHS.includes(pathname) || HIDE_SEARCHBAR_PATTERNS.some((pattern) => pattern.test(pathname)))
+  const showHeader = !hideHeaderMobile
+  const hideSearchBarMobile =
+    !isMd && (HIDE_SEARCHBAR_MOBILE_PATHS.includes(pathname) || HIDE_SEARCHBAR_MOBILE_PATTERNS.some((pattern) => pattern.test(pathname)))
+  const hideSearchBarAlways =
+    HIDE_SEARCHBAR_ALWAYS_PATHS.includes(pathname) || HIDE_SEARCHBAR_ALWAYS_PATTERNS.some((pattern) => pattern.test(pathname))
+  const hideSearchBar = hideSearchBarMobile || hideSearchBarAlways
   const hideMenuButton = HIDE_MENU_BUTTON_PATHS.includes(pathname)
   return (
     <div className="flex min-h-screen flex-col">


### PR DESCRIPTION
## 📌 개요

- 커뮤니티 게시글 등록/수정 폼의 에러 처리 및 레이아웃 개선

## 🔧 작업 내용

- [x] CommunityPostForm에 InlineNotification으로 에러 표시
- [x] 게시글 로드 실패 시 에러 화면 표시
- [x] 반응형 헤더 개선 (모바일: ArrowLeft, 데스크탑: SimpleHeader)
- [x] MainLayout 헤더/검색바 숨김 로직 개선

## 📎 관련 이슈

- Close #447

## 📸 스크린샷 (선택)

## 💬 리뷰어 참고 사항

- 게시글 등록/수정 실패 시 에러 알림 표시 확인 필요
- 게시글 로드 실패 시 에러 화면 표시 확인 필요
- 모바일/데스크탑 헤더 표시 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)