### PR TITLE
feat: 게시글 삭제 실패 시 에러 알림 추가(#449)

### DIFF
--- a/src/components/modal/DeletePostConfirmModal.tsx
+++ b/src/components/modal/DeletePostConfirmModal.tsx
@@ -3,15 +3,19 @@ import { Button } from '../commons/button/Button'
 import ModalTitle from './ModalTitle'
 import { useOutsideClick } from '@src/hooks/useOutsideClick'
 import { Z_INDEX } from '@src/constants/ui'
+import { AnimatePresence } from 'framer-motion'
+import InlineNotification from '../commons/InlineNotification'
 
 interface DeletePostConfirmProps {
   isOpen: boolean
   postId: number | null
   onConfirm: (id: number) => void
   onCancel: () => void
+  error?: React.ReactNode
+  onClearError?: () => void
 }
 
-export default function DeletePostConfirmModal({ isOpen, postId, onConfirm, onCancel }: DeletePostConfirmProps) {
+export default function DeletePostConfirmModal({ isOpen, postId, onConfirm, onCancel, error, onClearError }: DeletePostConfirmProps) {
   const modalRef = useRef<HTMLDivElement>(null)
   // 바깥 클릭 시 onCancel 호출
   useOutsideClick(isOpen, [modalRef], onCancel)
@@ -21,6 +25,13 @@ export default function DeletePostConfirmModal({ isOpen, postId, onConfirm, onCa
     <div className={`fixed inset-0 flex items-center justify-center bg-gray-900/70 ${Z_INDEX.MODAL}`}>
       <div className="flex w-11/12 flex-col gap-4 rounded-lg bg-white p-5 md:w-[16vw] md:min-w-96" ref={modalRef}>
         <ModalTitle heading="게시글 삭제" description="정말로 이 게시글을 삭제하시겠습니까?" />
+        <AnimatePresence>
+          {error && (
+            <InlineNotification type="error" onClose={() => onClearError?.()}>
+              {error}
+            </InlineNotification>
+          )}
+        </AnimatePresence>
         <div className="flex justify-end gap-3">
           <Button onClick={onCancel} size="sm" className="cursor-pointer rounded-lg border border-gray-300 bg-white">
             취소

--- a/src/pages/community/CommunityDetail.tsx
+++ b/src/pages/community/CommunityDetail.tsx
@@ -42,6 +42,8 @@ export default function CommunityDetail() {
   const [isMoreMenuOpen, setIsMoreMenuOpen] = useState(false)
   const [isReportModalOpen, setIsReportModalOpen] = useState(false)
   const [isPostDeleteModalOpen, setIsPostDeleteModalOpen] = useState(false)
+  const [postDeleteError, setIsPostDeleteError] = useState<React.ReactNode | null>(null)
+
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const { id } = useParams<{ id: string }>()
@@ -69,18 +71,23 @@ export default function CommunityDetail() {
       reset()
     },
     onError: () => {
-      console.error('게시글 로드 실패:', error)
-      alert('답글 등록에 실패했습니다.')
+      alert('댓글 등록에 실패했습니다.')
     },
   })
 
   const handlePostDelete = async (id: number) => {
     try {
+      // throw new Error('테스트 에러')
       await deletePost(id)
       queryClient.invalidateQueries({ queryKey: ['community'] })
       navigate('/community')
-    } catch (error) {
-      console.error('게시글 삭제 실패:', error)
+    } catch {
+      setIsPostDeleteError(
+        <div className="flex flex-col gap-0.5">
+          <p className="text-base font-semibold">게시글 삭제에 실패했습니다.</p>
+          <p>잠시 후 다시 시도해주세요.</p>
+        </div>
+      )
     }
   }
   const handleMoreToggle = () => {
@@ -137,6 +144,18 @@ export default function CommunityDetail() {
       </div>
     )
   }
+  //  if (postLoadError) {
+  //   return (
+  //     <div className="flex min-h-screen items-center justify-center">
+  //       <div className="flex flex-col items-center gap-4">
+  //         <p>게시글 정보를 불러올 수 없습니다</p>
+  //         <button onClick={() => navigate('/community')} className="text-blue-600 hover:text-blue-800">
+  //           목록으로 돌아가기
+  //         </button>
+  //       </div>
+  //     </div>
+  //   )
+  // }
 
   return (
     <>
@@ -254,6 +273,8 @@ export default function CommunityDetail() {
         postId={Number(id)}
         onConfirm={handlePostDelete}
         onCancel={() => setIsPostDeleteModalOpen(false)}
+        error={postDeleteError}
+        onClearError={() => setIsPostDeleteError(null)}
       />
     </>
   )


### PR DESCRIPTION
## 📌 개요

- 게시글 삭제 실패 시 사용자에게 에러 알림을 표시하는 기능 추가

## 🔧 작업 내용

- [x] DeletePostConfirmModal에 error, onClearError props 추가
- [x] InlineNotification 컴포넌트로 에러 표시
- [x] console.error 대신 사용자 친화적 에러 메시지로 변경

## 📎 관련 이슈

- Close #449

## 📸 스크린샷 (선택)

## 💬 리뷰어 참고 사항

- 게시글 삭제 API 실패 시 에러 알림이 표시되는지 확인 필요
- 에러 알림 닫기 버튼 및 자동 닫힘 동작 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)