### PR TITLE
refactor: 상품 등록 폼 거래 정보 섹션 제거(#453)

### DIFF
--- a/src/pages/product-post/components/ProductPostForm.tsx
+++ b/src/pages/product-post/components/ProductPostForm.tsx
@@ -5,7 +5,6 @@ import { useNavigate } from 'react-router-dom'
 import ProductImageUpload from './imageUploadField/ImageUploadField'
 import BasicInfoSection from './basicInfoSection/BasicInfoSection'
 import PriceAndStatusSection from './priceAndStatusSection/PriceAndStatusSection'
-import TradeInfoSection from './tradeInfoSection/TradeInfoSection'
 import type { ProductDetailItem, ProductPostRequestData } from '@src/types'
 import { patchProduct, postProduct } from '@src/api/products'
 import { cn } from '@src/utils/cn'
@@ -23,8 +22,6 @@ export interface ProductPostFormValues {
   subImageUrls?: string[]
   addressSido: Province | ''
   addressGugun: string
-  isDeliveryAvailable?: boolean
-  preferredMeetingPlace?: string
 }
 
 interface ProductPostFormProps {
@@ -58,8 +55,6 @@ export function ProductPostForm({ isEditMode, productId: id, initialData }: Prod
       subImageUrls: [],
       addressSido: '',
       addressGugun: '',
-      isDeliveryAvailable: false,
-      preferredMeetingPlace: '',
     },
   }) // 폼에서 관리할 필드들의 타입(이름) 정의.
   const navigate = useNavigate()
@@ -84,8 +79,6 @@ export function ProductPostForm({ isEditMode, productId: id, initialData }: Prod
       subImageUrls: data.subImageUrls ?? [],
       addressSido: data.addressSido,
       addressGugun: data.addressGugun,
-      isDeliveryAvailable: data.isDeliveryAvailable ?? false,
-      preferredMeetingPlace: data.preferredMeetingPlace ?? '',
     }
 
     try {
@@ -116,8 +109,6 @@ export function ProductPostForm({ isEditMode, productId: id, initialData }: Prod
         subImageUrls: initialData.subImageUrls ?? [],
         addressSido: initialData.addressSido as Province | '',
         addressGugun: initialData.addressGugun,
-        isDeliveryAvailable: initialData.isDeliveryAvailable ?? false,
-        preferredMeetingPlace: initialData.preferredMeetingPlace ?? '',
       })
     }
   }, [isEditMode, initialData, reset])
@@ -140,7 +131,6 @@ export function ProductPostForm({ isEditMode, productId: id, initialData }: Prod
               subImagesField="subImageUrls"
               description="상품 이미지를 업로드 해주세요. 첫번째 이미지가 대표 이미지가 됩니다. (최대 5장)"
             />
-            <TradeInfoSection control={control} setValue={setValue} register={register} />
           </div>
           <div className="flex items-center gap-4">
             <Button size="md" className={cn('w-[80%] flex-1 cursor-pointer text-white', !isValid ? 'bg-gray-300' : 'bg-primary-300')} type="submit">

--- a/src/pages/product-post/components/ProductRequestForm.tsx
+++ b/src/pages/product-post/components/ProductRequestForm.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom'
 import ProductImageUpload from './imageUploadField/ImageUploadField'
 import BasicInfoSection from './basicInfoSection/BasicInfoSection'
 import PriceAndStatusSection from './priceAndStatusSection/PriceAndStatusSection'
-import TradeInfoSection from './tradeInfoSection/TradeInfoSection'
+// import TradeInfoSection from './tradeInfoSection/TradeInfoSection'
 import type { ProductDetailItem, RequestProductPostRequestData } from '@src/types'
 import { requestPostProduct } from '@src/api/products'
 import { cn } from '@src/utils/cn'
@@ -23,8 +23,6 @@ export interface ProductRequestFormValues {
   subImageUrls?: string[]
   addressSido: Province | ''
   addressGugun: string
-  isDeliveryAvailable?: boolean
-  preferredMeetingPlace?: string
 }
 
 interface ProductRequestPostFormProps {
@@ -105,8 +103,6 @@ export function ProductRequestForm({ isEditMode, productId: id, initialData }: P
         subImageUrls: initialData.subImageUrls ?? [],
         addressSido: initialData.addressSido as Province | '',
         addressGugun: initialData.addressGugun,
-        isDeliveryAvailable: initialData.isDeliveryAvailable ?? false,
-        preferredMeetingPlace: initialData.preferredMeetingPlace ?? '',
       })
     }
   }, [isEditMode, initialData, reset])
@@ -143,7 +139,6 @@ export function ProductRequestForm({ isEditMode, productId: id, initialData }: P
               mainImageField="mainImageUrl"
               subImagesField="subImageUrls"
             />
-            <TradeInfoSection control={control} setValue={setValue} showProductTradeFilter={false} register={register} />
           </div>
           <div className="flex items-center gap-4">
             <Button size="md" className={cn('w-[80%] flex-1 cursor-pointer text-white', !isValid ? 'bg-gray-300' : 'bg-primary-300')} type="submit">

--- a/src/pages/product-post/components/tradeInfoSection/TradeInfoSection.tsx
+++ b/src/pages/product-post/components/tradeInfoSection/TradeInfoSection.tsx
@@ -1,50 +1,36 @@
-import { AddressField } from '@src/components/commons/AddressField'
-import type { ProductPostFormValues } from '../ProductPostForm'
-import type { Control, UseFormSetValue, UseFormRegister } from 'react-hook-form'
-import FormSectionHeader from '../FormSectionHeader'
+// import { AddressField } from '@src/components/commons/AddressField'
+// import type { ProductPostFormValues } from '../ProductPostForm'
+// import type { Control, UseFormSetValue, UseFormRegister } from 'react-hook-form'
+// import FormSectionHeader from '../FormSectionHeader'
 
-interface TradeInfoSectionProps {
-  control: Control<ProductPostFormValues>
-  setValue: UseFormSetValue<ProductPostFormValues>
-  register: UseFormRegister<ProductPostFormValues>
-  showProductTradeFilter?: boolean
-}
+// interface TradeInfoSectionProps {
+//   control: Control<ProductPostFormValues>
+//   setValue: UseFormSetValue<ProductPostFormValues>
+//   register: UseFormRegister<ProductPostFormValues>
+//   showProductTradeFilter?: boolean
+// }
 
-export default function TradeInfoSection({ control, setValue, register, showProductTradeFilter = true }: TradeInfoSectionProps) {
-  return (
-    <div className="flex flex-col gap-5 rounded-xl border border-gray-100 bg-white px-6 py-5">
-      <FormSectionHeader heading="거래 정보" />
-      <AddressField<ProductPostFormValues>
-        control={control}
-        setValue={setValue}
-        primaryName="addressSido"
-        secondaryName="addressGugun"
-        label="거래 희망 지역"
-        labelClass="heading-h5"
-        layoutClass="gap-1"
-      />
-      {showProductTradeFilter && (
-        <>
-          <div className="flex items-center gap-2.5">
-            <input type="checkbox" id="isDeliveryAvailable" className="h-5 w-5" {...register('isDeliveryAvailable')} />
-            <label htmlFor="isDeliveryAvailable" className="heading-h5">
-              택배거래 가능
-            </label>
-          </div>
-          <div className="flex flex-col gap-1">
-            <label htmlFor="preferredMeetingPlace" className="heading-h5">
-              선호하는 만남 장소 (선택항목)
-            </label>
-            <input
-              id="preferredMeetingPlace"
-              type="text"
-              placeholder="예: 지하철역, 카페, 공원 등"
-              className="rounded-lg border border-gray-100 bg-white px-3 py-3"
-              {...register('preferredMeetingPlace')}
-            />
-          </div>
-        </>
-      )}
-    </div>
-  )
-}
+// export default function TradeInfoSection({ control, setValue, register, showProductTradeFilter = true }: TradeInfoSectionProps) {
+//   return (
+//     <div className="flex flex-col gap-5 rounded-xl border border-gray-100 bg-white px-6 py-5">
+//       <FormSectionHeader heading="거래 정보" />
+//       <AddressField<ProductPostFormValues>
+//         control={control}
+//         setValue={setValue}
+//         primaryName="addressSido"
+//         secondaryName="addressGugun"
+//         label="거래 희망 지역"
+//         labelClass="heading-h5"
+//         layoutClass="gap-1"
+//       />
+//       {showProductTradeFilter && (
+//         <div className="flex items-center gap-2.5">
+//           <input type="checkbox" id="isDeliveryAvailable" className="h-5 w-5" {...register('isDeliveryAvailable')} />
+//           <label htmlFor="isDeliveryAvailable" className="heading-h5">
+//             택배거래 가능
+//           </label>
+//         </div>
+//       )}
+//     </div>
+//   )
+// }

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -12,8 +12,6 @@ export interface Product {
   createdAt: string
   favoriteCount: number
   isFavorite: boolean
-  isDeliveryAvailable?: boolean
-  preferredMeetingPlace?: string
   viewCount?: number
 }
 
@@ -70,8 +68,6 @@ export interface ProductPostRequestData {
   subImageUrls: string[]
   addressSido: string
   addressGugun: string
-  isDeliveryAvailable: boolean
-  preferredMeetingPlace: string
 }
 
 export interface ProductPostResponse {
@@ -90,8 +86,6 @@ export interface ProductPostResponse {
   subImageUrls: string[]
   addressSido: string
   addressGugun: string
-  isDeliveryAvailable: boolean
-  preferredMeetingPlace: string
   viewCount: number
   favoriteCount: number
   isFavorite: boolean


### PR DESCRIPTION
## 📌 개요
상품 등록 폼에서 미사용 거래 정보 섹션을 제거하여 코드를 간소화합니다.

## 🔧 작업 내용
- TradeInfoSection 컴포넌트 코드 주석 처리
- ProductPostForm에서 TradeInfoSection 제거
- ProductRequestForm에서 TradeInfoSection 제거
- `isDeliveryAvailable`, `preferredMeetingPlace` 필드 및 타입 정의 제거

## 📎 관련 이슈

Closes #453

## 📸 스크린샷 (선택)
-

## 💬 리뷰어 참고 사항
- 미사용 기능 정리를 위한 리팩토링입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)