### PR TITLE
feat: 사용자 신고 실패 시 에러 알림 추가(#456)

### DIFF
--- a/src/components/modal/ReportModalBase.tsx
+++ b/src/components/modal/ReportModalBase.tsx
@@ -7,6 +7,8 @@ import ImageUploadField from '@src/pages/product-post/components/imageUploadFiel
 import { useRef, type ReactNode } from 'react'
 import { useOutsideClick } from '@src/hooks/useOutsideClick'
 import { Z_INDEX } from '@src/constants/ui'
+import { AnimatePresence } from 'framer-motion'
+import InlineNotification from '../commons/InlineNotification'
 
 export interface ReportFormValues {
   reasonCode: string
@@ -26,9 +28,11 @@ interface ReportModalBaseProps {
   reasons: ReportReason[]
   onCancel: () => void
   onSubmit: (data: ReportFormValues) => Promise<void>
+  error?: React.ReactNode
+  onClearError?: () => void
 }
 
-export default function ReportModalBase({ isOpen, heading, description, reasons, onCancel, onSubmit }: ReportModalBaseProps) {
+export default function ReportModalBase({ isOpen, heading, description, reasons, onCancel, onSubmit, error, onClearError }: ReportModalBaseProps) {
   const {
     handleSubmit,
     register,
@@ -68,7 +72,13 @@ export default function ReportModalBase({ isOpen, heading, description, reasons,
     <div className={`fixed inset-0 flex items-center justify-center bg-gray-900/70 p-4 ${Z_INDEX.MODAL}`}>
       <div ref={modalRef} className="flex max-h-[90vh] w-11/12 flex-col gap-4 overflow-y-auto rounded-lg bg-white p-5 md:w-1/5 md:min-w-96">
         <ModalTitle heading={heading} description={description} />
-
+        <AnimatePresence>
+          {error && (
+            <InlineNotification type="error" onClose={() => onClearError?.()}>
+              {error}
+            </InlineNotification>
+          )}
+        </AnimatePresence>
         <form onSubmit={handleSubmit(handleFormSubmit)} className="flex flex-col gap-4">
           <div className="flex flex-col gap-6 pt-2">
             <div className="flex flex-col gap-1">

--- a/src/components/modal/UserReportModal.tsx
+++ b/src/components/modal/UserReportModal.tsx
@@ -2,6 +2,7 @@ import { userReported } from '@src/api/profile'
 import { USER_REPORT_REASON } from '@src/constants/constants'
 import ReportModalBase, { type ReportFormValues } from './ReportModalBase'
 import { useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
 
 interface UserReportModalProps {
   isOpen: boolean
@@ -12,14 +13,21 @@ interface UserReportModalProps {
 
 export default function UserReportModal({ isOpen, userNickname, userId, onCancel }: UserReportModalProps) {
   const queryClient = useQueryClient()
+  const [userReportError, setUserReportError] = useState<React.ReactNode | null>(null)
 
   const handleSubmit = async (data: ReportFormValues) => {
     try {
       await userReported(userId, { ...data })
       queryClient.invalidateQueries({ queryKey: ['userPage'] })
       onCancel()
-    } catch (error) {
-      console.error('회원신고 실패:', error)
+    } catch {
+      // console.error('회원신고 실패:', error)
+      setUserReportError(
+        <div className="flex flex-col gap-0.5">
+          <p className="text-base font-semibold">사용자 신고에 실패했습니다.</p>
+          <p>잠시 후 다시 시도해주세요.</p>
+        </div>
+      )
     }
   }
 
@@ -31,6 +39,8 @@ export default function UserReportModal({ isOpen, userNickname, userId, onCancel
       reasons={USER_REPORT_REASON}
       onCancel={onCancel}
       onSubmit={handleSubmit}
+      error={userReportError}
+      onClearError={() => setUserReportError(null)}
     />
   )
 }


### PR DESCRIPTION
## Summary
- ReportModalBase에 error, onClearError props 추가
- UserReportModal에서 신고 실패 시 InlineNotification으로 에러 알림 표시

## Test plan
- [ ] 사용자 신고 성공 시 정상 동작 확인
- [ ] 사용자 신고 실패 시 에러 알림 표시 확인
- [ ] 에러 알림 닫기 버튼 동작 확인

closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)