### PR TITLE
feat: 사용자 차단 해제 실패 시 에러 알림 추가(#455)

### DIFF
--- a/src/components/profile/ProfileData.tsx
+++ b/src/components/profile/ProfileData.tsx
@@ -3,10 +3,7 @@ import { MapPin, Calendar, Settings, Flag, Ban, LockOpen, ShieldAlert } from 'lu
 import { ProductMetaItem } from '@src/components/product/ProductMetaItem'
 import { type Dispatch, type SetStateAction } from 'react'
 import { formatJoinDate } from '@src/utils/formatJoinDate'
-import { useUserStore } from '@src/store/userStore'
 import { Button } from '@src/components/commons/button/Button'
-import { userUnBlocked } from '@src/api/profile'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { ROUTES } from '@src/constants/routes'
 import { useMediaQuery } from '@src/hooks/useMediaQuery'
 
@@ -31,25 +28,21 @@ interface ProfileDataProps {
   setIsReportModalOpen?: Dispatch<SetStateAction<boolean>>
   setIsBlockModalOpen?: Dispatch<SetStateAction<boolean>>
   handleUserUnBlocked?: (id: number) => void
+  isMyProfile?: boolean
+  unblockUser?: () => void
 }
 
-export default function ProfileData({ setIsWithdrawModalOpen, setIsReportModalOpen, setIsBlockModalOpen, data }: ProfileDataProps) {
-  const { user } = useUserStore()
-  const isMyProfile = user?.id === data?.id
-  const queryClient = useQueryClient()
+export default function ProfileData({
+  setIsWithdrawModalOpen,
+  setIsReportModalOpen,
+  setIsBlockModalOpen,
+  data,
+  isMyProfile,
+  unblockUser,
+}: ProfileDataProps) {
   const isMd = useMediaQuery('(min-width: 768px)')
   const { pathname } = useLocation()
   const isProfileEditPage = /^\/profile-update$/.test(pathname)
-
-  const { mutate: unblockUser } = useMutation({
-    mutationFn: () => userUnBlocked(Number(data?.id)),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['userPage'] })
-    },
-    onError: (error) => {
-      console.error('차단 해제 실패:', error)
-    },
-  })
 
   const formattedJoinDate = data?.createdAt ? formatJoinDate(data.createdAt) : ''
 
@@ -124,7 +117,7 @@ export default function ProfileData({ setIsWithdrawModalOpen, setIsReportModalOp
                   </div>
                   <Button
                     icon={LockOpen}
-                    onClick={() => unblockUser()}
+                    onClick={() => unblockUser?.()}
                     className="bg-primary-200 flex cursor-pointer items-center justify-center gap-2.5 rounded-lg px-3 py-2 text-white transition-all"
                   >
                     차단 해제하기

--- a/src/pages/UserPage.tsx
+++ b/src/pages/UserPage.tsx
@@ -1,21 +1,29 @@
 import ProfileData from '@src/components/profile/ProfileData'
 import { useState } from 'react'
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useNavigate, useParams } from 'react-router-dom'
-import { fetchUserData, fetchUserProductData } from '@src/api/profile'
+import { fetchUserData, fetchUserProductData, userUnBlocked } from '@src/api/profile'
 import { ProductListItem } from '@src/components/product/ProductListItem'
 import { LoadMoreButton } from '@src/components/commons/button/LoadMoreButton'
 import { EmptyState } from '@src/components/EmptyState'
 import { Package } from 'lucide-react'
 import UserReportModal from '@src/components/modal/UserReportModal'
 import BlockModal from '@src/components/modal/BlockModal'
+import { useUserStore } from '@src/store/userStore'
+import { AnimatePresence } from 'framer-motion'
+import InlineNotification from '@src/components/commons/InlineNotification'
 
 function UserPage() {
+  const { user } = useUserStore()
+  const { id } = useParams()
+  const queryClient = useQueryClient()
+
   const navigate = useNavigate()
   const [, setIsWithdrawModalOpen] = useState(false)
   const [isReportModalOpen, setIsReportModalOpen] = useState(false)
   const [isBlockModalOpen, setIsBlockModalOpen] = useState(false)
-  const { id } = useParams()
+  const [unblockError, setUnblockError] = useState<React.ReactNode | null>(null)
+
   const {
     data: userData,
     isLoading: isLoadingUserData,
@@ -40,6 +48,26 @@ function UserPage() {
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.page + 1 : undefined),
     initialPageParam: 0,
     enabled: !!id,
+  })
+
+  const isMyProfile = user?.id === userData?.id
+
+  const { mutate: unblockUser } = useMutation({
+    mutationFn: () => userUnBlocked(Number(userData?.id)),
+    // mutationFn: (id: number) => {
+    //   throw new Error('테스트 에러') // 임시 추가
+    // },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['userPage'] })
+    },
+    onError: () => {
+      setUnblockError(
+        <div className="flex flex-col gap-0.5">
+          <p className="text-base font-semibold">차단 해제에 실패했습니다.</p>
+          <p>잠시 후 다시 시도해주세요.</p>
+        </div>
+      )
+    },
   })
 
   const totalProducts = userProductData?.pages[0]?.total ?? 0
@@ -68,13 +96,26 @@ function UserPage() {
 
   return (
     <>
-      <div className="pb-4xl bg-white pt-0 md:pt-8">
+      <div className="pb-4xl relative bg-white pt-0 md:pt-8">
+        <div className="mx-auto max-w-7xl">
+          <AnimatePresence>
+            {unblockError && (
+              <div className="absolute top-4 left-1/2 z-50 -translate-x-1/2 md:pt-8">
+                <InlineNotification type="error" onClose={() => setUnblockError(null)}>
+                  {unblockError}
+                </InlineNotification>
+              </div>
+            )}
+          </AnimatePresence>
+        </div>
         <div className="mx-auto flex max-w-7xl flex-col gap-0 md:flex-row md:gap-8">
           <ProfileData
             setIsWithdrawModalOpen={setIsWithdrawModalOpen}
             setIsReportModalOpen={setIsReportModalOpen}
             setIsBlockModalOpen={setIsBlockModalOpen}
             data={userData!}
+            isMyProfile={isMyProfile}
+            unblockUser={unblockUser}
           />
           <section className="flex w-full flex-col gap-6 rounded-xl border-gray-200 p-5 md:border">
             <div className="flex justify-between">

--- a/src/pages/my-page/MyPage.tsx
+++ b/src/pages/my-page/MyPage.tsx
@@ -206,7 +206,7 @@ function MyPage() {
     <>
       <div className="pb-4xl bg-white pt-0 md:pt-8">
         <div className="mx-auto flex max-w-7xl flex-col gap-3.5 md:flex-row md:gap-8">
-          <ProfileData setIsWithdrawModalOpen={setIsWithdrawModalOpen} data={myData!} />
+          <ProfileData setIsWithdrawModalOpen={setIsWithdrawModalOpen} data={myData!} isMyProfile />
           <section className="flex flex-1 flex-col gap-3.5 md:gap-7">
             <Tabs
               tabs={MY_PAGE_TABS}

--- a/src/pages/profile-update/ProfileUpdate.tsx
+++ b/src/pages/profile-update/ProfileUpdate.tsx
@@ -63,7 +63,7 @@ function ProfileUpdate() {
   return (
     <div className="pb-4xl bg-[#F3F4F6] pt-0 md:bg-white md:pt-8">
       <div className="mx-auto flex max-w-7xl flex-col gap-0 md:flex-row md:gap-8 md:p-0">
-        {isMd && <ProfileData setIsWithdrawModalOpen={setIsWithdrawModalOpen} data={myData!} />}
+        {isMd && <ProfileData setIsWithdrawModalOpen={setIsWithdrawModalOpen} data={myData!} isMyProfile />}
         {!isMd && (
           <div className="flex flex-col gap-2 border-b border-gray-200 bg-white p-5">
             <h2 className="heading-h3">기본 정보</h2>


### PR DESCRIPTION
## Summary
- ProfileData 컴포넌트에 unblockUser, isMyProfile props 추가
- UserPage에서 차단 해제 mutation 관리 및 InlineNotification으로 에러 알림 표시
- MyPage, ProfileUpdate에 isMyProfile prop 전달

## Test plan
- [ ] 차단 해제 성공 시 정상 동작 확인
- [ ] 차단 해제 실패 시 에러 알림 표시 확인
- [ ] 에러 알림 닫기 버튼 동작 확인

closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)