### PR TITLE
feat: 채팅 이미지 업로드 실패 시 에러 알림 추가(#459)

### DIFF
--- a/src/pages/chatting-page/ChattingPage.tsx
+++ b/src/pages/chatting-page/ChattingPage.tsx
@@ -22,6 +22,8 @@ export default function ChattingPage() {
   const [isChatOpen, setIsChatOpen] = useState(false)
   const [selectedRoom, setSelectedRoom] = useState<fetchChatRoom | null>(null)
   const [inputMessage, setInputMessage] = useState('')
+  const [imageUploadError, setImageUploadError] = useState<React.ReactNode | null>(null)
+
   const navigate = useNavigate()
   const { user, accessToken } = useUserStore()
   const { id: chatRoomId } = useParams()
@@ -107,6 +109,7 @@ export default function ChattingPage() {
     if (!files || files.length === 0 || !selectedRoom) return
 
     try {
+      // throw new Error('테스트 에러')
       // 1. 이미지 업로드 API 호출
       const uploadResult = await uploadImage(Array.from(files))
       const imageUrl = uploadResult.mainImageUrl
@@ -114,8 +117,14 @@ export default function ChattingPage() {
       // 2. 업로드된 URL로 이미지 메시지 전송
       // content는 null, imageUrl에 업로드된 URL 전달
       sendMessage(selectedRoom.chatRoomId, '', 'IMAGE', imageUrl)
-    } catch (error) {
-      console.error('이미지 업로드 실패:', error)
+    } catch {
+      // console.error('이미지 업로드 실패:', error)
+      setImageUploadError(
+        <div className="flex flex-col gap-0.5">
+          <p className="text-base font-semibold">이미지 업로드에 실패했습니다.</p>
+          <p>잠시 후 다시 시도해주세요.</p>
+        </div>
+      )
     }
     e.target.value = ''
   }
@@ -227,6 +236,8 @@ export default function ChattingPage() {
                   hasMorePrevious={hasNextPage}
                   isLoadingPrevious={isFetchingNextPage}
                   onRetry={() => refetchMessages()}
+                  error={imageUploadError}
+                  onClearError={() => setImageUploadError(null)}
                 />
               </div>
               <div

--- a/src/pages/chatting-page/components/ChatLog.tsx
+++ b/src/pages/chatting-page/components/ChatLog.tsx
@@ -3,6 +3,8 @@ import { cn } from '@src/utils/cn'
 import { useUserStore } from '@src/store/userStore'
 import { useEffect, useRef } from 'react'
 import PlaceholderImage from '@assets/images/placeholder.png'
+import { AnimatePresence } from 'framer-motion'
+import InlineNotification from '@src/components/commons/InlineNotification'
 
 interface ChatLogProps {
   isLoadingMessages: boolean
@@ -12,6 +14,8 @@ interface ChatLogProps {
   hasMorePrevious?: boolean
   isLoadingPrevious?: boolean
   onRetry?: () => void
+  error?: React.ReactNode
+  onClearError?: () => void
 }
 
 // isMine 계산: HTTP API 응답은 isMine 포함, STOMP는 senderId로 비교
@@ -66,6 +70,8 @@ export function ChatLog({
   hasMorePrevious,
   isLoadingPrevious,
   onRetry,
+  error,
+  onClearError,
 }: ChatLogProps) {
   const { user } = useUserStore()
   const groupedMessages = groupMessagesByDate(roomMessages)
@@ -111,6 +117,15 @@ export function ChatLog({
 
   return (
     <div ref={scrollRef} onScroll={handleScroll} className="flex h-full flex-col gap-4 overflow-y-auto">
+      <AnimatePresence>
+        {error && (
+          <div className="sticky top-0 left-1/2 z-10 w-fit -translate-x-1/2">
+            <InlineNotification type="error" onClose={() => onClearError?.()}>
+              {error}
+            </InlineNotification>
+          </div>
+        )}
+      </AnimatePresence>
       {Object.entries(groupedMessages).map(([dateKey, messages]) => (
         <div key={dateKey} className="flex flex-col gap-2">
           <div className="flex justify-center">


### PR DESCRIPTION
## 📌 개요

- 채팅 이미지 업로드 실패 시 에러 알림을 표시하여 사용자에게 피드백 제공

## 🔧 작업 내용

- [x] ChattingPage에 imageUploadError 상태 추가
- [x] 이미지 업로드 실패 시 InlineNotification으로 에러 알림 표시
- [x] ChatLog 컴포넌트에 error, onClearError props 추가

## 📎 관련 이슈

Closes #459

## 💬 리뷰어 참고 사항

- 기존 에러 알림 패턴(InlineNotification)과 동일하게 구현

🤖 Generated with [Claude Code](https://claude.com/claude-code)