### PR TITLE
feat: 채팅 WebSocket 연결 에러 알림 추가(#463)

### DIFF
--- a/src/pages/chatting-page/ChattingPage.tsx
+++ b/src/pages/chatting-page/ChattingPage.tsx
@@ -37,6 +37,8 @@ export default function ChattingPage() {
     clearUnreadCount,
     clearRoomMessages,
     chatRoomUpdates,
+    connectionError,
+    setConnectionError,
   } = chatSocketStore()
 
   const {
@@ -236,8 +238,10 @@ export default function ChattingPage() {
                   hasMorePrevious={hasNextPage}
                   isLoadingPrevious={isFetchingNextPage}
                   onRetry={() => refetchMessages()}
-                  error={imageUploadError}
-                  onClearError={() => setImageUploadError(null)}
+                  imageUploadError={imageUploadError}
+                  onClearImageUploadError={() => setImageUploadError(null)}
+                  connectionError={connectionError}
+                  onClearConnectionError={() => setConnectionError(null)}
                 />
               </div>
               <div

--- a/src/pages/chatting-page/components/ChatLog.tsx
+++ b/src/pages/chatting-page/components/ChatLog.tsx
@@ -14,8 +14,10 @@ interface ChatLogProps {
   hasMorePrevious?: boolean
   isLoadingPrevious?: boolean
   onRetry?: () => void
-  error?: React.ReactNode
-  onClearError?: () => void
+  connectionError?: React.ReactNode
+  onClearConnectionError?: () => void
+  imageUploadError?: React.ReactNode
+  onClearImageUploadError?: () => void
 }
 
 // isMine 계산: HTTP API 응답은 isMine 포함, STOMP는 senderId로 비교
@@ -70,8 +72,10 @@ export function ChatLog({
   hasMorePrevious,
   isLoadingPrevious,
   onRetry,
-  error,
-  onClearError,
+  connectionError,
+  onClearConnectionError,
+  imageUploadError,
+  onClearImageUploadError,
 }: ChatLogProps) {
   const { user } = useUserStore()
   const groupedMessages = groupMessagesByDate(roomMessages)
@@ -118,10 +122,20 @@ export function ChatLog({
   return (
     <div ref={scrollRef} onScroll={handleScroll} className="flex h-full flex-col gap-4 overflow-y-auto">
       <AnimatePresence>
-        {error && (
+        {connectionError && (
           <div className="sticky top-0 left-1/2 z-10 w-fit -translate-x-1/2">
-            <InlineNotification type="error" onClose={() => onClearError?.()}>
-              {error}
+            <InlineNotification type="error" onClose={() => onClearConnectionError?.()}>
+              <div className="flex flex-col gap-0.5">
+                <p className="text-base font-semibold">채팅 서버 연결에 문제가 발생했습니다.</p>
+                <p>{connectionError}</p>
+              </div>
+            </InlineNotification>
+          </div>
+        )}
+        {imageUploadError && (
+          <div className="sticky top-0 left-1/2 z-10 w-fit -translate-x-1/2">
+            <InlineNotification type="error" onClose={() => onClearImageUploadError?.()}>
+              {imageUploadError}
             </InlineNotification>
           </div>
         )}


### PR DESCRIPTION
## Summary
- chatSocketStore에 connectionError 상태 및 setConnectionError 함수 추가
- onStompError 콜백에서 연결 에러 발생 시 InlineNotification 에러 표시
- ChatLog에서 imageUploadError와 connectionError를 분리하여 각각 표시

## Test plan
- [ ] 채팅 페이지 진입 후 WebSocket 연결 에러 발생 시 에러 알림 표시 확인
- [ ] 연결 에러 알림과 이미지 업로드 에러 알림이 독립적으로 표시되는지 확인
- [ ] 에러 알림 닫기 버튼 동작 확인

## 📎 관련 이슈

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)