### PR TITLE
feat: 차단 해제 기능 및 에러 알림 추가(#473)

### DIFF
--- a/src/pages/my-page/components/MyPagePanel.tsx
+++ b/src/pages/my-page/components/MyPagePanel.tsx
@@ -7,6 +7,7 @@ import { Button } from '@src/components/commons/button/Button'
 import { LoadMoreButton } from '@src/components/commons/button/LoadMoreButton'
 import { EmptyState } from '@src/components/EmptyState'
 import { Package, Heart, type LucideIcon } from 'lucide-react'
+import { Link } from 'react-router-dom'
 
 interface MyPagePanelProps {
   activeTabCode: string
@@ -23,6 +24,7 @@ interface MyPagePanelProps {
   hasNextPage?: boolean
   isFetchingNextPage: boolean
   handleConfirmModal: (e: React.MouseEvent, id: number, title: string, price: number, mainImageUrl: string) => void
+  unblockUser?: (blockedUserId: number) => void
 }
 
 const TAB_CONFIG: {
@@ -78,6 +80,7 @@ export default function MyPagePanel({
   hasNextPage,
   isFetchingNextPage,
   handleConfirmModal,
+  unblockUser,
 }: MyPagePanelProps) {
   const getProductData = () => {
     switch (activeMyPageTab) {
@@ -134,13 +137,13 @@ export default function MyPagePanel({
             <ul className="flex max-h-[60vh] flex-col items-center justify-start gap-2.5">
               {myBlockedData.map((user) => (
                 <li key={user.blockedUserId} className="flex w-full items-center justify-between gap-6 rounded-lg border border-gray-300 p-3.5">
-                  <div className="flex items-center gap-4">
+                  <Link to={`/user-profile/${user.blockedUserId}`} className="flex items-center gap-4">
                     <div className="aspect-square w-12 shrink-0 overflow-hidden rounded-full">
                       <img src={user.profileImageUrl || PlaceholderImage} alt={user.nickname} className="h-full w-full object-cover" />
                     </div>
                     <span className="font-medium">{user.nickname}</span>
-                  </div>
-                  <Button size="sm" className="border border-gray-300">
+                  </Link>
+                  <Button size="sm" className="border border-gray-300" onClick={() => unblockUser?.(user.blockedUserId)}>
                     차단 해제
                   </Button>
                 </li>


### PR DESCRIPTION
## 📌 개요

- 마이페이지 차단 목록에서 차단 해제 기능 구현 및 실패 시 에러 알림 표시

## 🔧 작업 내용

- [x] 차단 해제 API 연동 (userUnBlocked mutation)
- [x] 차단 해제 실패 시 InlineNotification 에러 알림 표시
- [x] 차단된 사용자 프로필 클릭 시 프로필 페이지로 이동 (Link 추가)

## 📎 관련 이슈

Closes #473

## 💬 리뷰어 참고 사항

- 차단 해제 성공 시 `myBlocked` 쿼리 무효화로 목록 갱신
- 에러 알림은 AnimatePresence로 애니메이션 적용