### PR TITLE
design: 상품 상세 메타데이터 모바일 반응형 레이아웃 개선(#475)

### DIFF
--- a/src/components/product/ProductMetaItem.tsx
+++ b/src/components/product/ProductMetaItem.tsx
@@ -11,7 +11,7 @@ export function ProductMetaItem({ icon: Icon, label, iconSize = 16, className = 
   return (
     <div className={`flex items-center gap-1 ${className}`}>
       <Icon size={iconSize} aria-hidden="true" />
-      <span className="font-medium">{label}</span>
+      <span className="font-medium whitespace-nowrap">{label}</span>
     </div>
   )
 }

--- a/src/pages/product-detail/components/ProductMetadataList.tsx
+++ b/src/pages/product-detail/components/ProductMetadataList.tsx
@@ -12,7 +12,7 @@ interface productMetadataListProps {
 
 export default function ProductMetadataList({ addressSido, addressGugun, createdAt, viewCount, favoriteCount }: productMetadataListProps) {
   return (
-    <div className="flex items-center gap-5">
+    <div className="flex flex-wrap items-center gap-2 md:gap-5">
       <ProductMetaItem icon={MapPin} label={`${addressSido} ${addressGugun}`} />
       <ProductMetaItem icon={Clock} label={getTimeAgo(createdAt)} />
       <ProductMetaItem icon={Eye} label={`조회 ${viewCount}`} />


### PR DESCRIPTION
## 📌 개요

- 상품 상세 페이지 메타데이터 영역의 모바일 반응형 레이아웃 개선

## 🔧 작업 내용

- [x] ProductMetaItem 텍스트 줄바꿈 방지 (whitespace-nowrap)
- [x] ProductMetadataList flex-wrap 추가로 모바일 줄바꿈 허용
- [x] 모바일/데스크탑 gap 반응형 적용 (gap-2 md:gap-5)

## 📎 관련 이슈

Closes #475

## 💬 리뷰어 참고 사항

- 모바일에서 메타데이터 항목이 한 줄에 모두 표시되지 않을 때 자연스럽게 줄바꿈되도록 개선
- 각 메타데이터 항목 내 텍스트는 줄바꿈 없이 유지