### PR TITLE
feat: 검색바 클리어 버튼 추가 및 검색 UX 개선(#477)

### DIFF
--- a/src/components/commons/Input.tsx
+++ b/src/components/commons/Input.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@src/utils/cn'
-import type { LucideIcon } from 'lucide-react'
+import { X, type LucideIcon } from 'lucide-react'
 
 interface InputProps {
   type: string
@@ -14,6 +14,7 @@ interface InputProps {
   inputClass?: string
   suffix?: string
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onClear?: () => void
   [key: string]: any // register에서 전달하는 다른 props들을 받기 위해
 }
 
@@ -30,6 +31,7 @@ export function Input({
   id,
   inputClass,
   suffix,
+  onClear,
   ...rest // 나머지 모든 props (register가 전달하는 ref, name 등)
 }: InputProps) {
   return (
@@ -64,6 +66,11 @@ export function Input({
         {...rest}
       />
       {suffix && <span className="absolute top-1/2 right-3 -translate-y-1/2 text-sm text-gray-500">{suffix}</span>}
+      {value && onClear && (
+        <button onClick={onClear} type="button" className="mr-2 rounded-full bg-gray-300 p-0.5">
+          <X size={14} />
+        </button>
+      )}
     </div>
   )
 }

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -9,19 +9,28 @@ import { cn } from '@src/utils/cn'
 const HIDE_HEADER_MOBILE_PATTERNS = [/^\/community\/\d+$/, /^\/community\/\d+\/edit$/, new RegExp(`^${ROUTES.COMMUNITY_POST}$`)]
 
 // SearchBar 숨김 경로 - 모바일만 (정적 경로)
-const HIDE_SEARCHBAR_MOBILE_PATHS: string[] = [ROUTES.PROFILE_UPDATE, ROUTES.PRODUCT_POST, ROUTES.LOGIN, ROUTES.SIGNUP, ROUTES.FIND_PASSWORD, ROUTES.MYPAGE]
+const HIDE_SEARCHBAR_MOBILE_PATHS: string[] = [ROUTES.MYPAGE]
 
 // SearchBar 숨김 경로 - 항상 (정적 경로)
-const HIDE_SEARCHBAR_ALWAYS_PATHS: string[] = [ROUTES.COMMUNITY, ROUTES.COMMUNITY_POST]
+const HIDE_SEARCHBAR_ALWAYS_PATHS: string[] = [
+  ROUTES.COMMUNITY,
+  ROUTES.COMMUNITY_POST,
+  ROUTES.LOGIN,
+  ROUTES.SIGNUP,
+  ROUTES.FIND_PASSWORD,
+  ROUTES.PROFILE_UPDATE,
+  ROUTES.PRODUCT_POST,
+  ROUTES.CHAT,
+]
 
 // 메뉴 버튼 숨김 경로
 const HIDE_MENU_BUTTON_PATHS: string[] = [ROUTES.LOGIN, ROUTES.SIGNUP]
 
 // SearchBar 숨김 패턴 - 모바일만 (동적 경로)
-const HIDE_SEARCHBAR_MOBILE_PATTERNS = [/^\/products\/\d+\/edit$/, /^\/user-profile\/\d+$/]
+const HIDE_SEARCHBAR_MOBILE_PATTERNS = [/^\/user-profile\/\d+$/]
 
 // SearchBar 숨김 패턴 - 항상 (동적 경로)
-const HIDE_SEARCHBAR_ALWAYS_PATTERNS = [/^\/community\/\d+$/, /^\/community\/\d+\/edit$/]
+const HIDE_SEARCHBAR_ALWAYS_PATTERNS = [/^\/community\/\d+$/, /^\/community\/\d+\/edit$/, /^\/products\/\d+\/edit$/, /^\/chat\/\d+$/]
 
 export default function MainLayout() {
   const isMd = useMediaQuery('(min-width: 768px)')


### PR DESCRIPTION
## 📌 개요

- 검색바에 클리어 버튼을 추가하고, 검색 UX를 개선합니다.

## 🔧 작업 내용

- [x] Input 컴포넌트에 클리어(X) 버튼 기능 추가 (`onClear` prop)
- [x] 메인페이지 외 다른 페이지에서 검색 시 메인페이지로 이동하며 검색어 전달
- [x] 검색바 표시/숨김 경로 정리 (로그인, 회원가입, 채팅 등에서 숨김)

## 📎 관련 이슈

- Close #477

## 📸 스크린샷 (선택)

없음

## 💬 리뷰어 참고 사항

- Input 컴포넌트의 `onClear` prop은 선택적이며, 값이 있을 때만 X 버튼이 표시됩니다.