### PR TITLE
feat: 인증 필요 페이지 로그인 리다이렉트 추가(#479)

### DIFF
--- a/src/pages/community/components/CommunityPostForm.tsx
+++ b/src/pages/community/components/CommunityPostForm.tsx
@@ -17,6 +17,7 @@ import { SimpleHeader } from '@src/components/header/SimpleHeader'
 import { Z_INDEX } from '@src/constants/ui'
 import { AnimatePresence } from 'framer-motion'
 import InlineNotification from '@src/components/commons/InlineNotification'
+import { useUserStore } from '@src/store/userStore'
 
 const DRAFT_STORAGE_KEY = 'community-post-draft'
 
@@ -50,6 +51,15 @@ export default function CommunityPostForm() {
   const isMd = useMediaQuery('(min-width: 768px)')
   const { id } = useParams()
   const isEditMode = !!id
+  const { user, setRedirectUrl } = useUserStore()
+
+  // 비로그인 시 로그인 페이지로 리다이렉트
+  useEffect(() => {
+    if (!user?.id) {
+      setRedirectUrl(window.location.pathname)
+      navigate('/auth/login')
+    }
+  }, [user, navigate, setRedirectUrl])
 
   const {
     control,

--- a/src/pages/product-post/ProductPost.tsx
+++ b/src/pages/product-post/ProductPost.tsx
@@ -1,14 +1,16 @@
 import { SimpleHeader } from '@src/components/header/SimpleHeader'
 import { useEffect, useState } from 'react'
-import { useParams, useSearchParams } from 'react-router-dom'
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { PRODUCT_TYPE_TABS, type ProductTypeTabId } from '../../constants/constants'
 import { Tabs } from '@src/components/Tabs'
 import { ProductPostForm } from './components/ProductPostForm'
 import { ProductRequestForm } from './components/ProductRequestForm'
 import { fetchProductById } from '@src/api/products'
 import type { ProductDetailItem } from '@src/types'
+import { useUserStore } from '@src/store/userStore'
 
 function ProductPost() {
+  const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
   const tabParam = searchParams.get('tab') as ProductTypeTabId | null
   const initialTab = tabParam === 'tab-purchases' ? 'tab-purchases' : 'tab-sales'
@@ -16,8 +18,17 @@ function ProductPost() {
   const [activeProductTypeTab, setActiveProductTypeTab] = useState<ProductTypeTabId>(initialTab)
   const [productData, setProductData] = useState<ProductDetailItem | null>(null)
   const { id } = useParams()
+  const { user, setRedirectUrl } = useUserStore()
 
   const isEditMode = !!id
+
+  // 비로그인 시 로그인 페이지로 리다이렉트
+  useEffect(() => {
+    if (!user?.id) {
+      setRedirectUrl(window.location.pathname)
+      navigate('/auth/login')
+    }
+  }, [user, navigate, setRedirectUrl])
 
   const handleTabChange = (tabId: string) => {
     setActiveProductTypeTab(tabId as ProductTypeTabId)

--- a/src/pages/profile-update/ProfileUpdate.tsx
+++ b/src/pages/profile-update/ProfileUpdate.tsx
@@ -11,7 +11,15 @@ import { useNavigate } from 'react-router-dom'
 function ProfileUpdate() {
   const navigate = useNavigate()
   const [, setIsWithdrawModalOpen] = useState(false)
-  const { user, updateUserProfile } = useUserStore()
+  const { user, updateUserProfile, setRedirectUrl } = useUserStore()
+
+  // 비로그인 시 로그인 페이지로 리다이렉트
+  useEffect(() => {
+    if (!user?.id) {
+      setRedirectUrl(window.location.pathname)
+      navigate('/auth/login')
+    }
+  }, [user, navigate, setRedirectUrl])
   const isMd = useMediaQuery('(min-width: 768px)')
   const {
     data: myData,


### PR DESCRIPTION
## 📌 개요

- 인증이 필요한 페이지에서 비로그인 사용자를 로그인 페이지로 리다이렉트합니다.

## 🔧 작업 내용

- [x] 커뮤니티 글 작성 페이지 로그인 리다이렉트 추가
- [x] 상품 등록 페이지 로그인 리다이렉트 추가
- [x] 프로필 수정 페이지 로그인 리다이렉트 추가

## 📎 관련 이슈

Closes #479

## 📸 스크린샷 (선택)

없음

## 💬 리뷰어 참고 사항

- `setRedirectUrl`로 현재 경로를 저장하여 로그인 후 원래 페이지로 복귀 가능