### PR TITLE
fix: 상품 수정 모드에서 탭 숨김 처리(#481)

### DIFF
--- a/src/pages/product-post/ProductPost.tsx
+++ b/src/pages/product-post/ProductPost.tsx
@@ -63,13 +63,15 @@ function ProductPost() {
       <div className="bg-[#F3F4F6] pt-5">
         <div className="px-lg pb-4xl mx-auto max-w-7xl">
           <div className="gap-2xl flex w-full flex-col">
-            <Tabs
-              tabs={PRODUCT_TYPE_TABS}
-              activeTab={activeProductTypeTab}
-              onTabChange={handleTabChange}
-              ariaLabel="상품 타입"
-              excludeTabId="tab-all"
-            />
+            {!isEditMode && (
+              <Tabs
+                tabs={PRODUCT_TYPE_TABS}
+                activeTab={activeProductTypeTab}
+                onTabChange={handleTabChange}
+                ariaLabel="상품 타입"
+                excludeTabId="tab-all"
+              />
+            )}
             {activeProductTypeTab === 'tab-sales' && <ProductPostForm isEditMode={isEditMode} productId={id} initialData={productData} />}
             {activeProductTypeTab === 'tab-purchases' && <ProductRequestForm isEditMode={isEditMode} productId={id} initialData={productData} />}
           </div>


### PR DESCRIPTION
## 📌 개요

- 상품 수정 모드에서 불필요하게 표시되던 탭(판매/구매요청)을 숨김 처리합니다.

## 🔧 작업 내용

- [x] 상품 수정 모드(`isEditMode`)일 때 Tabs 컴포넌트 조건부 렌더링

## 📎 관련 이슈

Closes #481

## 📸 스크린샷 (선택)

없음

## 💬 리뷰어 참고 사항

- 수정 모드에서는 상품 타입 변경이 불가하므로 탭 숨김 처리