### PR TITLE
fix: 메시지 전송 시 채팅방 목록 lastMessage 즉시 반영(#483)

### DIFF
--- a/src/store/chatSocketStore.ts
+++ b/src/store/chatSocketStore.ts
@@ -221,7 +221,20 @@ export const chatSocketStore = create<ChatSocketState>((set, get) => ({
       destination: '/app/chat/message',
       body: JSON.stringify(message),
     })
-    // console.log('✅ STOMP publish 완료')
+
+    // 채팅방 목록의 lastMessage 즉시 업데이트 (UI 반영)
+    const lastMessageText = messageType === 'IMAGE' ? '사진을 보냈습니다' : content
+    set((state) => ({
+      chatRoomUpdates: {
+        ...state.chatRoomUpdates,
+        [chatRoomId]: {
+          ...(state.chatRoomUpdates[chatRoomId] || {}),
+          chatRoomId,
+          lastMessage: lastMessageText,
+          lastMessageTime: new Date().toISOString(),
+        },
+      },
+    }))
   },
 
   unsubscribeFromRoom: (chatRoomId: number) => {


### PR DESCRIPTION
## 📌 개요

- 메시지 전송 후 채팅방 목록의 lastMessage가 즉시 업데이트되지 않는 문제 수정

## 🔧 작업 내용

- [x] 메시지 전송 시 chatRoomUpdates 상태를 즉시 업데이트하여 UI에 반영
- [x] 이미지 메시지인 경우 "사진을 보냈습니다"로 표시

## 📎 관련 이슈

Closes #483

## 💬 리뷰어 참고 사항

- `sendMessage` 함수에서 STOMP publish 후 chatRoomUpdates 상태를 즉시 업데이트하여 채팅방 목록 UI에 바로 반영되도록 수정