### PR TITLE
fix: 소셜 로그인 OAuth URL 이중 슬래시 오류 수정(#487)

### DIFF
--- a/src/pages/login/components/SocialLoginButtons.tsx
+++ b/src/pages/login/components/SocialLoginButtons.tsx
@@ -6,12 +6,12 @@ export function SocialLoginButtons() {
   const handleGoogleLogin = () => {
     // window.location.href = 'https://cuddle-market.duckdns.org/oauth2/authorization/google'
     // window.location.href = 'https://cmarket-api.duckdns.org/oauth2/authorization/google'
-    window.location.href = 'https://cuddle-market-fe.vercel.app//oauth2/authorization/google'
+    window.location.href = 'https://cuddle-market-fe.vercel.app/oauth2/authorization/google'
   }
   const handleKakaoLogin = () => {
     // window.location.href = 'https://cuddle-market.duckdns.org/oauth2/authorization/kakao'
     // window.location.href = 'https://cmarket-api.duckdns.org/oauth2/authorization/kakao'
-    window.location.href = 'https://cuddle-market-fe.vercel.app//oauth2/authorization/kakao'
+    window.location.href = 'https://cuddle-market-fe.vercel.app/oauth2/authorization/kakao'
   }
 
   return (


### PR DESCRIPTION
## 📌 개요

- 소셜 로그인 OAuth URL에 이중 슬래시(`//oauth2`)가 포함되어 인증 요청 실패하는 버그 수정

## 🔧 작업 내용

- [x] `SocialLoginButtons.tsx`의 Google/Kakao OAuth URL 경로 수정
- [x] `//oauth2/authorization/` → `/oauth2/authorization/`

## 📎 관련 이슈

Closes #487

## 📸 스크린샷 (선택)

(해당 없음)

## 💬 리뷰어 참고 사항

- URL 경로의 이중 슬래시를 단일 슬래시로 수정한 단순 버그 수정입니다