### PR TITLE
fix: 소셜 로그인 후 상태 저장 타이밍 문제 해결(#493)

### DIFF
--- a/src/pages/SocialCallback.tsx
+++ b/src/pages/SocialCallback.tsx
@@ -19,7 +19,10 @@ export default function SocialCallback() {
 
       handleLogin(user, accessToken, refreshToken)
 
-      // 저장된 redirectUrl이 있으면 해당 페이지로, 없으면 홈으로 이동
+      // 3. localStorage에 persist가 완료될 때까지 대기
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      // 4. 저장된 redirectUrl이 있으면 해당 페이지로, 없으면 홈으로 이동
       const redirectUrl = useUserStore.getState().redirectUrl
       navigate(redirectUrl || '/')
       useUserStore.getState().setRedirectUrl(null)


### PR DESCRIPTION
## 📌 개요

- 소셜 로그인 후 zustand persist가 완료되기 전에 리다이렉트되어 상태가 유실되는 문제 해결

## 🔧 작업 내용

- [x] `SocialCallback.tsx`에 localStorage persist 완료 대기 로직 추가
- [x] 100ms 대기 후 리다이렉트 수행

## 📎 관련 이슈

Closes #493

## 📸 스크린샷 (선택)

(해당 없음)

## 💬 리뷰어 참고 사항

- zustand persist가 localStorage에 저장 완료되기 전에 리다이렉트되는 타이밍 이슈를 해결하기 위해 100ms 대기 추가