### PR TITLE
fix: 소셜 로그인 시 기존 상태 클리어 로직 추가(#497)

### DIFF
--- a/src/pages/SocialCallback.tsx
+++ b/src/pages/SocialCallback.tsx
@@ -9,8 +9,9 @@ export default function SocialCallback() {
 
   const handleSocialAuth = useCallback(
     async (accessToken: string, refreshToken: string) => {
-      console.log('[SocialCallback] 1. 토큰 저장 시작', new Date().toISOString())
-      // 1. 토큰 먼저 저장
+      console.log('[SocialCallback] 1. 기존 상태 클리어 후 토큰 저장 시작', new Date().toISOString())
+      // 1. 기존 상태 클리어 후 새 토큰 저장 (회원탈퇴 후 재로그인 시 옛날 토큰 문제 방지)
+      useUserStore.getState().clearAll()
       setAccessToken(accessToken)
       setRefreshToken(refreshToken)
 


### PR DESCRIPTION
## 📌 개요

- 회원탈퇴 후 재로그인 시 이전 토큰이 남아있어 발생하는 문제 해결

## 🔧 작업 내용

- [x] `SocialCallback.tsx`에서 새 토큰 저장 전 기존 상태 클리어
- [x] `useUserStore.getState().clearAll()` 호출 추가

## 📎 관련 이슈

Closes #497

## 📸 스크린샷 (선택)

(해당 없음)

## 💬 리뷰어 참고 사항

- 회원탈퇴 후 재로그인 시나리오에서 옛날 토큰이 남아있는 문제를 방지