### PR TITLE
fix: TradeInfoSection 거래정보 복구(#501)

### DIFF
--- a/src/pages/product-post/components/ProductPostForm.tsx
+++ b/src/pages/product-post/components/ProductPostForm.tsx
@@ -9,6 +9,7 @@ import type { ProductDetailItem, ProductPostRequestData } from '@src/types'
 import { patchProduct, postProduct } from '@src/api/products'
 import { cn } from '@src/utils/cn'
 import { useEffect, useMemo } from 'react'
+import TradeInfoSection from './tradeInfoSection/TradeInfoSection'
 
 export interface ProductPostFormValues {
   petType: string
@@ -121,6 +122,7 @@ export function ProductPostForm({ isEditMode, productId: id, initialData }: Prod
           <div className="flex flex-col gap-5">
             <BasicInfoSection control={control} setValue={setValue} register={register} errors={errors} titleLength={watch('title')?.length ?? 0} />
             <PriceAndStatusSection control={control} register={register} errors={errors} />
+            <TradeInfoSection control={control} setValue={setValue} />
             <ProductImageUpload
               initialImages={initialImages}
               setValue={setValue}

--- a/src/pages/product-post/components/ProductRequestForm.tsx
+++ b/src/pages/product-post/components/ProductRequestForm.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom'
 import ProductImageUpload from './imageUploadField/ImageUploadField'
 import BasicInfoSection from './basicInfoSection/BasicInfoSection'
 import PriceAndStatusSection from './priceAndStatusSection/PriceAndStatusSection'
-// import TradeInfoSection from './tradeInfoSection/TradeInfoSection'
+import TradeInfoSection from './tradeInfoSection/TradeInfoSection'
 import type { ProductDetailItem, RequestProductPostRequestData } from '@src/types'
 import { requestPostProduct } from '@src/api/products'
 import { cn } from '@src/utils/cn'
@@ -110,7 +110,7 @@ export function ProductRequestForm({ isEditMode, productId: id, initialData }: P
     <div role="tabpanel" id="panel-REQUEST" aria-labelledby="tab-purchases">
       <form className="w-full" onSubmit={handleSubmit(onSubmit)}>
         <fieldset className="flex flex-col gap-5">
-          <legend className="sr-only">회원가입폼</legend>
+          <legend className="sr-only">판매요청 등록폼</legend>
           <div className="flex flex-col gap-5">
             <BasicInfoSection
               control={control}
@@ -130,6 +130,7 @@ export function ProductRequestForm({ isEditMode, productId: id, initialData }: P
               priceLabel="희망 가격"
               heading="가격"
             />
+            <TradeInfoSection control={control} setValue={setValue} />
             <ProductImageUpload
               initialImages={initialImages}
               setValue={setValue}
@@ -140,6 +141,7 @@ export function ProductRequestForm({ isEditMode, productId: id, initialData }: P
               subImagesField="subImageUrls"
             />
           </div>
+
           <div className="flex items-center gap-4">
             <Button size="md" className={cn('w-[80%] flex-1 cursor-pointer text-white', !isValid ? 'bg-gray-300' : 'bg-primary-300')} type="submit">
               {isEditMode ? '수정' : '등록'}

--- a/src/pages/product-post/components/tradeInfoSection/TradeInfoSection.tsx
+++ b/src/pages/product-post/components/tradeInfoSection/TradeInfoSection.tsx
@@ -1,36 +1,26 @@
-// import { AddressField } from '@src/components/commons/AddressField'
-// import type { ProductPostFormValues } from '../ProductPostForm'
-// import type { Control, UseFormSetValue, UseFormRegister } from 'react-hook-form'
-// import FormSectionHeader from '../FormSectionHeader'
+import { AddressField } from '@src/components/commons/AddressField'
+import type { ProductPostFormValues } from '../ProductPostForm'
+import type { Control, UseFormSetValue } from 'react-hook-form'
+import FormSectionHeader from '../FormSectionHeader'
 
-// interface TradeInfoSectionProps {
-//   control: Control<ProductPostFormValues>
-//   setValue: UseFormSetValue<ProductPostFormValues>
-//   register: UseFormRegister<ProductPostFormValues>
-//   showProductTradeFilter?: boolean
-// }
+interface TradeInfoSectionProps {
+  control: Control<ProductPostFormValues>
+  setValue: UseFormSetValue<ProductPostFormValues>
+}
 
-// export default function TradeInfoSection({ control, setValue, register, showProductTradeFilter = true }: TradeInfoSectionProps) {
-//   return (
-//     <div className="flex flex-col gap-5 rounded-xl border border-gray-100 bg-white px-6 py-5">
-//       <FormSectionHeader heading="거래 정보" />
-//       <AddressField<ProductPostFormValues>
-//         control={control}
-//         setValue={setValue}
-//         primaryName="addressSido"
-//         secondaryName="addressGugun"
-//         label="거래 희망 지역"
-//         labelClass="heading-h5"
-//         layoutClass="gap-1"
-//       />
-//       {showProductTradeFilter && (
-//         <div className="flex items-center gap-2.5">
-//           <input type="checkbox" id="isDeliveryAvailable" className="h-5 w-5" {...register('isDeliveryAvailable')} />
-//           <label htmlFor="isDeliveryAvailable" className="heading-h5">
-//             택배거래 가능
-//           </label>
-//         </div>
-//       )}
-//     </div>
-//   )
-// }
+export default function TradeInfoSection({ control, setValue }: TradeInfoSectionProps) {
+  return (
+    <div className="flex flex-col gap-5 rounded-xl border border-gray-100 bg-white px-6 py-5">
+      <FormSectionHeader heading="거래 정보" />
+      <AddressField<ProductPostFormValues>
+        control={control}
+        setValue={setValue}
+        primaryName="addressSido"
+        secondaryName="addressGugun"
+        label="거래 희망 지역"
+        labelClass="heading-h5"
+        layoutClass="gap-1"
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## 📌 개요

- 이전 작업에서 실수로 제거된 TradeInfoSection 거래정보 컴포넌트를 복구합니다.

## 🔧 작업 내용

- [x] TradeInfoSection 컴포넌트 코드 복구 (주석 해제 및 정리)
- [x] ProductPostForm에 TradeInfoSection 추가
- [x] ProductRequestForm에 TradeInfoSection 추가
- [x] ProductRequestForm의 legend 텍스트 수정 (회원가입폼 → 판매요청 등록폼)

## 📎 관련 이슈

Closes #501

## 📸 스크린샷 (선택)

(UI 변경 없음 - 기존 기능 복구)

## 💬 리뷰어 참고 사항

- 거래 희망 지역 선택 기능이 정상적으로 표시되는지 확인 부탁드립니다.