### PR TITLE
fix: 상품 이미지 URL 처리 로직 수정(#506)

### DIFF
--- a/src/pages/product-post/components/imageUploadField/components/DropzoneArea.tsx
+++ b/src/pages/product-post/components/imageUploadField/components/DropzoneArea.tsx
@@ -64,13 +64,18 @@ export default function DropzoneArea<T extends FieldValues>({
 
       try {
         const uploadedUrl = await uploadImage(acceptedFiles)
+        // 새로 업로드된 URL들
+        const newUrls = [uploadedUrl.mainImageUrl, ...(uploadedUrl.subImageUrls || [])]
+        // 기존 URL들과 합침
+        const allUrls = [...previewUrls, ...newUrls]
+
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        setValue(mainImageField, uploadedUrl.mainImageUrl as any)
+        setValue(mainImageField, allUrls[0] as any)
         if (subImagesField) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          setValue(subImagesField, uploadedUrl.subImageUrls as any)
+          setValue(subImagesField, allUrls.slice(1) as any)
         }
-        setPreviewUrls((prev) => [...prev, uploadedUrl.mainImageUrl, ...(uploadedUrl.subImageUrls || [])])
+        setPreviewUrls(allUrls)
       } catch {
         setError(mainImageField, {
           type: 'manual',


### PR DESCRIPTION
## 📌 개요

- 상품 이미지 업로드 시 기존 previewUrls와 새로 업로드된 URL을 합쳐서 처리하도록 수정합니다.

## 🔧 작업 내용

- [x] 기존 previewUrls와 새로 업로드된 URL들을 합쳐서 allUrls 생성
- [x] allUrls[0]을 mainImageUrl로 설정
- [x] allUrls.slice(1)을 subImageUrls로 설정

## 📎 관련 이슈

Closes #506

## 💬 리뷰어 참고 사항

- 기존에는 새로 업로드된 이미지 URL로 바로 덮어썼으나, 이제 기존 URL과 합쳐서 처리합니다.