### PR TITLE
fix: 판매요청 상품 등록/삭제 버그 수정(#508)

### DIFF
--- a/src/api/products.ts
+++ b/src/api/products.ts
@@ -106,8 +106,9 @@ export const postProduct = async (requestData: ProductPostRequestData): Promise<
 }
 
 // 판매요청 상품 등록
-export const requestPostProduct = async (requestData: RequestProductPostRequestData): Promise<void> => {
-  await api.post(`/products/requests`, requestData)
+export const requestPostProduct = async (requestData: RequestProductPostRequestData): Promise<ProductPostResponse> => {
+  const response = await api.post<{ data: ProductPostResponse }>(`/products/requests`, requestData)
+  return response.data.data
 }
 
 // 판매요청 상품 수정

--- a/src/pages/my-page/MyPage.tsx
+++ b/src/pages/my-page/MyPage.tsx
@@ -110,7 +110,11 @@ function MyPage() {
     // },
     onSuccess: () => {
       // 삭제 성공 시 상품 목록 다시 불러오기
-      queryClient.invalidateQueries({ queryKey: ['myProducts'] })
+      if (activeMyPageTab === 'tab-sales') {
+        queryClient.invalidateQueries({ queryKey: ['myProducts', user?.id] })
+      } else if (activeMyPageTab === 'tab-purchases') {
+        queryClient.invalidateQueries({ queryKey: ['myRequest', user?.id] })
+      }
       setIsModalOpen(false)
       setSelectedProduct(null)
     },

--- a/src/pages/product-post/components/ProductRequestForm.tsx
+++ b/src/pages/product-post/components/ProductRequestForm.tsx
@@ -82,8 +82,8 @@ export function ProductRequestForm({ isEditMode, productId: id, initialData }: P
     }
 
     try {
-      await requestPostProduct(requestData)
-      navigate(`/products/${id}`)
+      const response = await requestPostProduct(requestData)
+      navigate(`/products/${isEditMode ? id : response.id}`)
     } catch {
       alert(isEditMode ? '상품 수정에 실패했습니다.' : '상품 등록에 실패했습니다.')
     }


### PR DESCRIPTION
## 📌 개요

- 판매요청 상품 등록 후 `/products/undefined`로 이동하는 버그 수정
- 마이페이지에서 판매요청 상품 삭제 후 목록이 갱신되지 않는 버그 수정

## 🔧 작업 내용

- [x] `requestPostProduct` API가 응답 데이터를 반환하도록 수정
- [x] `ProductRequestForm`에서 등록 후 `response.id`로 상세페이지 이동
- [x] `MyPage`에서 삭제 시 활성 탭에 따라 올바른 쿼리 무효화

## 📎 관련 이슈

Closes #508

## 💬 리뷰어 참고 사항

- `requestPostProduct` API의 반환 타입이 `void`에서 `ProductPostResponse`로 변경됨
- 삭제 시 쿼리 무효화가 활성 탭(`tab-sales` / `tab-purchases`)에 따라 분기 처리됨