### PR TITLE
fix: 판매요청 상품 상세페이지 거래상태 Badge 조건부 렌더링(#510)

### DIFF
--- a/src/pages/product-detail/components/ProductBadges.tsx
+++ b/src/pages/product-detail/components/ProductBadges.tsx
@@ -22,7 +22,7 @@ export default function ProductBadges({ tradeStatus, petDetailType, category, pr
 
   return (
     <div className="flex items-center gap-2 md:gap-1">
-      <Badge className={cn('px-2.5 py-1.5 text-base font-semibold text-white', productTradeColor)}>{productTradeName}</Badge>
+      {tradeStatus && <Badge className={cn('px-2.5 py-1.5 text-base font-semibold text-white', productTradeColor)}>{productTradeName}</Badge>}
       <Badge className={cn('bg-primary-700 px-2.5 py-1.5 text-base font-semibold text-white')}>{petTypeName}</Badge>
       <Badge className={cn('border bg-white px-2.5 py-1.5 text-base font-semibold text-gray-900')}>{categoryName}</Badge>
       <Badge className={cn('bg-primary-200 px-2.5 py-1.5 text-base font-semibold')}>{productStatusName}</Badge>


### PR DESCRIPTION
## 📌 개요

- 판매요청 상품 상세페이지에서 `tradeStatus`가 없는 경우 빈 거래상태 Badge가 렌더링되는 문제 수정

## 🔧 작업 내용

- [x] `tradeStatus`가 존재할 때만 거래상태 Badge를 렌더링하도록 조건부 렌더링 추가

## 📎 관련 이슈

Closes #510

## 💬 리뷰어 참고 사항

- 판매요청 상품은 `tradeStatus`가 없으므로 해당 Badge가 표시되지 않아야 합니다