### PR TITLE
fix: 상품 등록 페이지 취소 버튼 동작 추가(#512)

### DIFF
--- a/src/pages/product-post/components/ProductPostForm.tsx
+++ b/src/pages/product-post/components/ProductPostForm.tsx
@@ -138,7 +138,7 @@ export function ProductPostForm({ isEditMode, productId: id, initialData }: Prod
             <Button size="md" className={cn('w-[80%] flex-1 cursor-pointer text-white', !isValid ? 'bg-gray-300' : 'bg-primary-300')} type="submit">
               {isEditMode ? '수정' : '등록'}
             </Button>
-            <Button size="md" className="w-[20%] cursor-pointer bg-gray-100 text-gray-900" type="button">
+            <Button size="md" className="w-[20%] cursor-pointer bg-gray-100 text-gray-900" type="button" onClick={() => navigate(-1)}>
               취소
             </Button>
           </div>

--- a/src/pages/product-post/components/ProductRequestForm.tsx
+++ b/src/pages/product-post/components/ProductRequestForm.tsx
@@ -146,7 +146,7 @@ export function ProductRequestForm({ isEditMode, productId: id, initialData }: P
             <Button size="md" className={cn('w-[80%] flex-1 cursor-pointer text-white', !isValid ? 'bg-gray-300' : 'bg-primary-300')} type="submit">
               {isEditMode ? '수정' : '등록'}
             </Button>
-            <Button size="md" className="w-[20%] cursor-pointer bg-gray-100 text-gray-900" type="button">
+            <Button size="md" className="w-[20%] cursor-pointer bg-gray-100 text-gray-900" type="button" onClick={() => navigate(-1)}>
               취소
             </Button>
           </div>


### PR DESCRIPTION
## 📌 개요

- 상품 등록 페이지에서 취소 버튼 클릭 시 아무 반응이 없는 문제 수정

## 🔧 작업 내용

- [x] 판매 상품 등록 폼(`ProductPostForm.tsx`) 취소 버튼에 `onClick` 핸들러 추가
- [x] 판매요청 상품 등록 폼(`ProductRequestForm.tsx`) 취소 버튼에 `onClick` 핸들러 추가

## 📎 관련 이슈

Closes #512

## 💬 리뷰어 참고 사항

- 취소 버튼 클릭 시 `navigate(-1)`을 호출하여 이전 페이지로 이동합니다