### PR TITLE
feat: 판매요청 상품 상태 배지 숨김 처리(#514)

### DIFF
--- a/src/components/product/components/ProductBadge.tsx
+++ b/src/components/product/components/ProductBadge.tsx
@@ -3,13 +3,14 @@ import { Badge } from '@src/components/commons/badge/Badge'
 interface ProductBadgeProps {
   petTypeName: string
   productStatusName: string
+  productTypeName?: string
 }
 
-export function ProductBadge({ petTypeName, productStatusName }: ProductBadgeProps) {
+export function ProductBadge({ petTypeName, productStatusName, productTypeName }: ProductBadgeProps) {
   return (
     <div className="gap-xs z-1 flex flex-wrap">
       <Badge className="bg-primary-700 text-white">{petTypeName}</Badge>
-      <Badge className="bg-primary-200 text-gray-900">{productStatusName}</Badge>
+      {productTypeName !== '판매요청' && <Badge className="bg-primary-200 text-gray-900">{productStatusName}</Badge>}
     </div>
   )
 }

--- a/src/components/product/components/ProductThumbnail.tsx
+++ b/src/components/product/components/ProductThumbnail.tsx
@@ -41,7 +41,7 @@ export function ProductThumbnail({
   return (
     <div className="relative flex-1 overflow-hidden pb-[35%] md:flex-none md:pb-[75%]">
       <div className="top-sm px-sm absolute flex w-full justify-between">
-        <ProductBadge petTypeName={petTypeName} productStatusName={productStatusName} />
+        <ProductBadge petTypeName={petTypeName} productStatusName={productStatusName} productTypeName={productTypeName} />
         <Button
           type="button"
           className="z-1 flex cursor-pointer items-center justify-center rounded-full bg-gray-100"


### PR DESCRIPTION
## Summary
- 판매요청 상품에서 상태 배지(새제품/중고)가 표시되지 않도록 수정
- `ProductBadge` 컴포넌트에 `productTypeName` prop 추가하여 조건부 렌더링 구현

## Test plan
- [ ] 판매요청 상품 목록에서 상태 배지가 숨겨지는지 확인
- [ ] 일반 판매 상품에서는 상태 배지가 정상 표시되는지 확인
- [ ] 마이페이지 판매요청 탭에서 상태 배지가 숨겨지는지 확인

close #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)