### PR TITLE
fix: 커뮤니티 게시글 임시저장 및 UI 수정(#516)

### DIFF
--- a/src/pages/community/CommunityPage.tsx
+++ b/src/pages/community/CommunityPage.tsx
@@ -293,9 +293,9 @@ export default function CommunityPage() {
                 isMd ? (
                   <li
                     key={post.id}
-                    className="flex flex-col justify-center gap-2.5 rounded-lg border border-gray-400 bg-white px-3.5 pt-3.5 pb-5 shadow-xl"
+                    className="flex flex-col justify-center gap-2.5 rounded-lg border border-gray-400 bg-white px-3.5 pt-3.5 pb-3.5 shadow-xl"
                   >
-                    <Link to={ROUTES.COMMUNITY_DETAIL_ID(post.id)}>
+                    <Link to={ROUTES.COMMUNITY_DETAIL_ID(post.id)} className="flex flex-col gap-1">
                       <p className="font-semibold">{post.title}</p>
                       <div className="flex items-center gap-2.5">
                         <div className="flex items-center gap-1 text-gray-500">


### PR DESCRIPTION
## 📌 개요

- 커뮤니티 글 작성 시 게시판 타입별로 임시저장 데이터가 분리되지 않던 문제 수정
- 게시글 리스트 카드 UI 스타일 조정

## 🔧 작업 내용

- [x] 게시판 타입별 임시저장 키 분리 (`community-post-draft-{boardType}`)
- [x] URL 쿼리 파라미터에서 게시판 타입 초기값 설정
- [x] 게시글 리스트 카드 UI 패딩/gap 조정

## 📎 관련 이슈

Close #516

## 💬 리뷰어 참고 사항

- sessionStorage 키가 게시판 타입별로 분리되어 기존 임시저장 데이터와 호환되지 않을 수 있음