### PR TITLE
fix: 상품 수정 페이지 스크롤 위치 및 코드 순서 수정(#518)

### DIFF
--- a/src/pages/product-post/ProductPost.tsx
+++ b/src/pages/product-post/ProductPost.tsx
@@ -22,19 +22,6 @@ function ProductPost() {
 
   const isEditMode = !!id
 
-  // 비로그인 시 로그인 페이지로 리다이렉트
-  useEffect(() => {
-    if (!user?.id) {
-      setRedirectUrl(window.location.pathname)
-      navigate('/auth/login')
-    }
-  }, [user, navigate, setRedirectUrl])
-
-  const handleTabChange = (tabId: string) => {
-    setActiveProductTypeTab(tabId as ProductTypeTabId)
-    setSearchParams({ tab: tabId }, { replace: true })
-  }
-
   const isSalesTab = activeProductTypeTab === 'tab-sales'
   const headerTitle = isSalesTab ? (isEditMode ? '판매 상품 수정' : '판매 상품 등록') : isEditMode ? '판매 요청 수정' : '판매 요청 등록'
   const headerDescription = isSalesTab
@@ -45,10 +32,24 @@ function ProductPost() {
       ? '등록된 판매 요청 정보를 수정할 수 있습니다.'
       : '원하는 상품이 없을 때 판매를 요청할 수 있습니다.'
 
+  const handleTabChange = (tabId: string) => {
+    setActiveProductTypeTab(tabId as ProductTypeTabId)
+    setSearchParams({ tab: tabId }, { replace: true })
+  }
+
+  // 비로그인 시 로그인 페이지로 리다이렉트
+  useEffect(() => {
+    if (!user?.id) {
+      setRedirectUrl(window.location.pathname)
+      navigate('/auth/login')
+    }
+  }, [user, navigate, setRedirectUrl])
+
   useEffect(() => {
     const loadProduct = async () => {
       if (isEditMode && id) {
         const data = await fetchProductById(id)
+        window.scrollTo({ top: 0, behavior: 'smooth' })
         setProductData(data)
         const tabId = data.productType === 'SELL' ? 'tab-sales' : 'tab-purchases'
         setActiveProductTypeTab(tabId)


### PR DESCRIPTION
## 📌 개요

- 상품 수정 페이지 진입 시 스크롤이 상단으로 이동하지 않는 문제 수정
- 코드 순서 정리 (변수 선언 이후에 함수/훅 배치)

## 🔧 작업 내용

- [x] 상품 수정 페이지 진입 시 페이지 상단으로 스크롤 이동 추가
- [x] handleTabChange 함수 및 useEffect 훅 위치를 변수 선언 이후로 정리

## 📎 관련 이슈

Close #518

## 💬 리뷰어 참고 사항

- 기능 변경 없이 스크롤 동작 추가 및 코드 순서만 정리했습니다