### PR TITLE
fix: 판매요청 상품 수정 기능 수정(#520)

### DIFF
--- a/src/api/products.ts
+++ b/src/api/products.ts
@@ -111,9 +111,15 @@ export const requestPostProduct = async (requestData: RequestProductPostRequestD
   return response.data.data
 }
 
-// 판매요청 상품 수정
+// 판매 상품 수정
 export const patchProduct = async (requestData: ProductPostRequestData, id: number): Promise<ProductPostResponse> => {
   const response = await api.patch<{ data: ProductPostResponse }>(`/products/${id}`, requestData)
+  return response.data.data
+}
+
+// 판매요청 상품 수정
+export const patchRequestProduct = async (requestData: RequestProductPostRequestData, id: number): Promise<ProductPostResponse> => {
+  const response = await api.patch<{ data: ProductPostResponse }>(`/products/requests/${id}`, requestData)
   return response.data.data
 }
 

--- a/src/pages/product-post/components/ProductRequestForm.tsx
+++ b/src/pages/product-post/components/ProductRequestForm.tsx
@@ -7,7 +7,7 @@ import BasicInfoSection from './basicInfoSection/BasicInfoSection'
 import PriceAndStatusSection from './priceAndStatusSection/PriceAndStatusSection'
 import TradeInfoSection from './tradeInfoSection/TradeInfoSection'
 import type { ProductDetailItem, RequestProductPostRequestData } from '@src/types'
-import { requestPostProduct } from '@src/api/products'
+import { patchRequestProduct, requestPostProduct } from '@src/api/products'
 import { cn } from '@src/utils/cn'
 import { useEffect, useMemo } from 'react'
 
@@ -82,8 +82,15 @@ export function ProductRequestForm({ isEditMode, productId: id, initialData }: P
     }
 
     try {
-      const response = await requestPostProduct(requestData)
-      navigate(`/products/${isEditMode ? id : response.id}`)
+      if (isEditMode && id) {
+        // 편집 모드: 기존 상품 ID로 수정
+        await patchRequestProduct(requestData, Number(id))
+        navigate(`/products/${id}`)
+      } else {
+        // 새 등록: 서버에서 생성된 ID로 이동
+        const response = await requestPostProduct(requestData)
+        navigate(`/products/${response.id}`)
+      }
     } catch {
       alert(isEditMode ? '상품 수정에 실패했습니다.' : '상품 등록에 실패했습니다.')
     }


### PR DESCRIPTION
## 📌 개요

- 판매요청 상품 수정 시 등록 API가 아닌 수정 API를 호출하도록 변경

## 🔧 작업 내용

- [x] 판매요청 상품 수정 API 함수 추가 (`patchRequestProduct`)
- [x] ProductRequestForm에서 편집 모드일 때 수정 API 호출하도록 변경

## 📎 관련 이슈

Close #520

## 💬 리뷰어 참고 사항

- 기존에는 편집 모드에서도 `requestPostProduct`를 호출하여 새 상품이 등록되던 문제를 수정했습니다