### PR TITLE
fix: 커뮤니티 게시글 임시저장 boardType 기본값 수정(#522)

### DIFF
--- a/src/pages/community/components/CommunityPostForm.tsx
+++ b/src/pages/community/components/CommunityPostForm.tsx
@@ -26,6 +26,14 @@ export interface CommunityPostFormValues {
   imageUrls?: string[]
 }
 
+// Storage key 생성 함수
+const getDraftStorageKey = (boardType: string) => `community-post-draft-${boardType}`
+
+// 임시 저장 데이터 삭제
+const clearDraft = (boardType: string) => {
+  sessionStorage.removeItem(getDraftStorageKey(boardType))
+}
+
 // sessionStorage에서 임시 저장된 데이터 불러오기
 const getSavedDraft = (boardType: string): CommunityPostFormValues => {
   const saved = sessionStorage.getItem(getDraftStorageKey(boardType))
@@ -33,18 +41,10 @@ const getSavedDraft = (boardType: string): CommunityPostFormValues => {
     try {
       return JSON.parse(saved)
     } catch {
-      return { boardType: 'FREE', title: '', content: '', imageUrls: [] }
+      return { boardType, title: '', content: '', imageUrls: [] }
     }
   }
-  return { boardType: 'FREE', title: '', content: '', imageUrls: [] }
-}
-
-// const DRAFT_STORAGE_KEY = 'community-post-draft'
-const getDraftStorageKey = (boardType: string) => `community-post-draft-${boardType}`
-
-// 임시 저장 데이터 삭제
-const clearDraft = (boardType: string) => {
-  sessionStorage.removeItem(getDraftStorageKey(boardType))
+  return { boardType, title: '', content: '', imageUrls: [] }
 }
 
 export default function CommunityPostForm() {


### PR DESCRIPTION
## 📌 개요

- `getSavedDraft` 함수에서 임시저장 데이터가 없거나 파싱 실패 시 기본값의 `boardType`이 항상 `'FREE'`로 하드코딩되어 있던 문제 수정

## 🔧 작업 내용

- [x] `getSavedDraft` 함수의 기본값에서 `boardType: 'FREE'` → 파라미터로 받은 `boardType` 사용
- [x] 코드 순서 정리: `getDraftStorageKey`, `clearDraft` 함수를 `getSavedDraft` 함수보다 위로 이동

## 📎 관련 이슈

Close #522

## 💬 리뷰어 참고 사항

- 기존에 `boardType`이 하드코딩되어 다른 게시판 타입에서 올바르게 동작하지 않던 문제를 수정했습니다