### PR TITLE
fix: 커뮤니티 글쓰기 버튼에 현재 탭 정보 전달(#524)

### DIFF
--- a/src/pages/community/CommunityPage.tsx
+++ b/src/pages/community/CommunityPage.tsx
@@ -245,7 +245,7 @@ export default function CommunityPage() {
               <div className="flex items-center justify-between">
                 <CommunityTabs tabs={COMMUNITY_TABS} activeTab={activeCommunityTypeTab} onTabChange={handleTabChange} ariaLabel="커뮤니티 타입" />
                 {isLogin() && (
-                  <Link to={ROUTES.COMMUNITY_POST} type="button" className="bg-primary-300 rounded-lg px-3 py-2 text-white">
+                  <Link to={`${ROUTES.COMMUNITY_POST}?tab=${activeCommunityTypeTab}`} type="button" className="bg-primary-300 rounded-lg px-3 py-2 text-white">
                     글쓰기
                   </Link>
                 )}
@@ -364,7 +364,7 @@ export default function CommunityPage() {
       </div>
       {!isMd && isLogin() && (
         <Link
-          to={ROUTES.COMMUNITY_POST}
+          to={`${ROUTES.COMMUNITY_POST}?tab=${activeCommunityTypeTab}`}
           type="button"
           className={`bg-primary-200 fixed right-4 bottom-4 rounded-full px-3 py-3 text-white ${Z_INDEX.FLOATING_BUTTON}`}
         >


### PR DESCRIPTION
## 📌 개요

- 커뮤니티 페이지에서 글쓰기 버튼 클릭 시 현재 선택된 게시판 타입 정보가 전달되지 않던 문제 수정

## 🔧 작업 내용

- [x] 글쓰기 버튼 링크에 현재 활성화된 탭 정보를 쿼리 파라미터로 전달 (`?tab=${activeCommunityTypeTab}`)
- [x] 데스크탑/모바일 글쓰기 버튼 모두 동일하게 수정

## 📎 관련 이슈

Close #524

## 💬 리뷰어 참고 사항

- 글쓰기 페이지에서 현재 탭 정보를 받아 해당 게시판 타입으로 자동 선택되도록 개선했습니다