### PR TITLE
refactor: 회원가입 생년월일 입력 UI 개선(#530)

### DIFF
--- a/src/pages/signup/components/BirthDateField.tsx
+++ b/src/pages/signup/components/BirthDateField.tsx
@@ -1,151 +1,116 @@
 import { RequiredLabel } from '@src/components/commons/RequiredLabel'
-import DatePicker from 'react-datepicker'
 import 'react-datepicker/dist/react-datepicker.css'
 import './BirthDateField.css'
-import { forwardRef } from 'react'
 import { Controller, type Control } from 'react-hook-form'
-import { Calendar, ChevronLeft as LeftArrow } from 'lucide-react'
-import { ko } from 'date-fns/locale'
 import type { SignUpFormValues } from './SignUpForm'
-import { Button } from '@src/components/commons/button/Button'
-
-interface CustomInputProps {
-  className?: string
-  value?: string
-  onClick?: () => void
-  placeholder: string
-}
 
 interface BirthDateFieldProps {
   control: Control<SignUpFormValues>
 }
 
-const CustomInput = forwardRef<HTMLInputElement, CustomInputProps>(({ value, onClick, placeholder }, ref) => {
-  const hasValue = value && value.trim() !== ''
+const validateBirthDate = (value: string): string | true => {
+  const [yearStr, monthStr, dayStr] = value.split('-')
 
-  return (
-    <div className="relative" onClick={onClick}>
-      <input
-        type="text"
-        value={hasValue ? value : ''}
-        placeholder={placeholder}
-        readOnly
-        ref={ref}
-        className="focus:border-primary-500 flex h-full w-full cursor-pointer rounded-lg border border-gray-400 px-3 py-3 text-sm placeholder:text-gray-400 focus:outline-none"
-      />
-      <div className="absolute top-0 right-0 flex h-full w-9 items-center justify-center">
-        <Calendar className="h-5 w-5 text-gray-400" strokeWidth={2} />
-      </div>
-    </div>
-  )
-})
+  const year = parseInt(yearStr, 10)
+  const month = parseInt(monthStr, 10)
+  const day = parseInt(dayStr, 10)
 
-CustomInput.displayName = 'CustomInput'
+  const currentYear = new Date().getFullYear()
+  const lastDayOfMonth = new Date(year, month, 0).getDate()
 
-const renderCustomHeader = ({
-  date,
-  changeYear,
-  changeMonth,
-  decreaseMonth,
-  increaseMonth,
-  prevMonthButtonDisabled,
-  nextMonthButtonDisabled,
-}: {
-  date: Date
-  changeYear: (year: number) => void
-  changeMonth: (month: number) => void
-  decreaseMonth: () => void
-  increaseMonth: () => void
-  prevMonthButtonDisabled: boolean
-  nextMonthButtonDisabled: boolean
-}) => {
-  const years = Array.from({ length: 100 }, (_, i) => new Date().getFullYear() - i)
-  const months = ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월']
+  // 미래 날짜 체크
+  const birthDate = new Date(year, month - 1, day)
+  const today = new Date()
 
-  return (
-    <div className="flex items-center justify-between gap-2 px-2 py-2">
-      <Button
-        type="button"
-        icon={LeftArrow}
-        size="xs"
-        onClick={decreaseMonth}
-        disabled={prevMonthButtonDisabled}
-        className="h-8 w-8 rounded hover:bg-gray-100"
-      />
-      <div className="flex gap-2">
-        <select value={date.getFullYear()} onChange={({ target: { value } }) => changeYear(Number(value))} className="py-1 text-sm">
-          {years.map((year) => (
-            <option key={year} value={year}>
-              {year}년
-            </option>
-          ))}
-        </select>
+  // 나이 계산 (만 14세 이상)
+  const age = today.getFullYear() - birthDate.getFullYear()
+  const isBeforeBirthday =
+    today.getMonth() < birthDate.getMonth() || (today.getMonth() === birthDate.getMonth() && today.getDate() < birthDate.getDate())
+  const actualAge = isBeforeBirthday ? age - 1 : age
 
-        <select value={date.getMonth()} onChange={({ target: { value } }) => changeMonth(Number(value))} className="py-1 text-sm">
-          {months.map((month, index) => (
-            <option key={month} value={index}>
-              {month}
-            </option>
-          ))}
-        </select>
-      </div>
-      <Button
-        type="button"
-        icon={LeftArrow}
-        size="xs"
-        onClick={increaseMonth}
-        disabled={nextMonthButtonDisabled}
-        className="h-8 w-8 rotate-180 rounded hover:bg-gray-100"
-      />
-    </div>
-  )
+  if (!value || value === '--') return '생년월일을 입력해주세요'
+  if (!yearStr || !monthStr || !dayStr) return '생년월일을 모두 입력해주세요'
+  if (year < 1900 || year > currentYear) return '유효한 년도를 입력해주세요'
+  if (month < 1 || month > 12) return '유효한 월을 입력해주세요'
+  if (day < 1 || day > lastDayOfMonth) return '유효한 일을 입력해주세요'
+  if (birthDate > today) return '미래 날짜는 선택할 수 없습니다'
+
+  return actualAge >= 14 || '만 14세 이상만 가입 가능합니다'
 }
 
 export function BirthDateField({ control }: BirthDateFieldProps) {
+  const isNumber = (e: React.ChangeEvent<HTMLInputElement>, maxLength: number) => {
+    const value = e.target.value.replace(/[^0-9]/g, '')
+    return value.slice(0, maxLength)
+  }
+
   return (
     <div className="flex flex-col gap-2.5">
       <RequiredLabel htmlFor="signup-birthdate">생년월일</RequiredLabel>
-      <div>
-        <Controller
-          name="birthDate"
-          control={control}
-          rules={{
-            required: '생년월일을 입력해주세요',
-            validate: (value) => {
-              const birthDate = new Date(value)
-              const today = new Date()
-              const age = today.getFullYear() - birthDate.getFullYear()
-              // 생일이 아직 안 지났으면 나이 -1
-              const isBeforeBirthday =
-                today.getMonth() < birthDate.getMonth() || (today.getMonth() === birthDate.getMonth() && today.getDate() < birthDate.getDate())
-              const actualAge = isBeforeBirthday ? age - 1 : age
+      <Controller
+        name="birthDate"
+        control={control}
+        rules={{
+          required: '생년월일을 입력해주세요',
+          validate: validateBirthDate,
+        }}
+        render={({ field, fieldState }) => {
+          const [year, month, day] = (field.value || '--').split('-')
+          const updateDate = (newYear: string, newMonth: string, newDay: string) => {
+            field.onChange(`${newYear}-${newMonth}-${newDay}`)
+          }
+          const handleBlur = () => {
+            const paddedMonth = month ? month.padStart(2, '0') : ''
+            const paddedDay = day ? day.padStart(2, '0') : ''
+            field.onChange(`${year}-${paddedMonth}-${paddedDay}`)
+            field.onBlur() // 유효성 검사 트리거
+          }
 
-              return actualAge >= 14 || '만 14세 이상만 가입 가능합니다'
-            },
-          }}
-          render={({ field, fieldState }) => (
+          return (
             <div className="flex flex-col gap-1">
-              <DatePicker
-                dateFormat="yyyy-MM-dd"
-                maxDate={new Date()}
-                shouldCloseOnSelect
-                selected={field.value && field.value !== '' ? new Date(field.value) : null}
-                onChange={(date) => {
-                  // Date 객체를 'yyyy-MM-dd' 문자열로 변환
-                  const formatted = date ? date.toISOString().split('T')[0] : ''
-                  field.onChange(formatted)
-                }}
-                popperPlacement="bottom-start"
-                locale={ko}
-                placeholderText="YYYY-MM-DD"
-                customInput={<CustomInput className="example-custom-input" placeholder="YYYY-MM-DD" />}
-                renderCustomHeader={renderCustomHeader}
-              />
+              <div className="flex items-center gap-4">
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  placeholder="YYYY"
+                  value={year}
+                  onChange={(e) => {
+                    const newValue = isNumber(e, 4)
+                    updateDate(newValue, month, day)
+                  }}
+                  onBlur={handleBlur}
+                  className="focus:border-primary-500 w-full rounded-lg border border-gray-400 px-3 py-2 text-sm placeholder:text-gray-400 focus:outline-none md:py-3"
+                />
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  placeholder="MM"
+                  value={month}
+                  onChange={(e) => {
+                    const newValue = isNumber(e, 2)
+                    updateDate(year, newValue, day)
+                  }}
+                  onBlur={handleBlur}
+                  className="focus:border-primary-500 w-full rounded-lg border border-gray-400 px-3 py-2 text-sm placeholder:text-gray-400 focus:outline-none md:py-3"
+                />
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  placeholder="DD"
+                  value={day}
+                  onChange={(e) => {
+                    const newValue = isNumber(e, 2)
+                    updateDate(year, month, newValue)
+                  }}
+                  onBlur={handleBlur}
+                  className="focus:border-primary-500 w-full rounded-lg border border-gray-400 px-3 py-2 text-sm placeholder:text-gray-400 focus:outline-none md:py-3"
+                />
+              </div>
               {fieldState.error && <p className="text-danger-500 text-xs font-semibold">{fieldState.error.message}</p>}
             </div>
-          )}
-        />
-      </div>
+          )
+        }}
+      />
     </div>
   )
 }

--- a/src/pages/signup/components/SignUpForm.tsx
+++ b/src/pages/signup/components/SignUpForm.tsx
@@ -104,8 +104,7 @@ export function SignUpForm() {
     }
 
     try {
-      const response = await signup(requestData)
-      console.log('회원가입 성공:', response)
+      await signup(requestData)
       const loginResponse = await login({
         email: data.email,
         password: data.password,


### PR DESCRIPTION
## 📌 개요

- DatePicker 라이브러리를 제거하고 직접 입력 필드로 변경하여 번들 사이즈 감소 및 모바일 UX 개선

## 🔧 작업 내용

- [x] DatePicker → YYYY, MM, DD 개별 입력 필드로 변경
- [x] 날짜 유효성 검사 로직 개선 (미래 날짜, 만 14세 제한 등)
- [x] 불필요한 console.log 제거

## 📎 관련 이슈

Closes #530

## 📸 스크린샷 (선택)

(필요시 추가)

## 💬 리뷰어 참고 사항

- 입력 필드 blur 시 월/일에 0 패딩 처리 (예: 1 → 01)
- inputMode="numeric"으로 모바일에서 숫자 키패드 표시