### PR TITLE
refactor: 회원가입 이름 입력 필드 자동 포커스 추가(#532)

### DIFF
--- a/src/components/commons/InputField.tsx
+++ b/src/components/commons/InputField.tsx
@@ -18,6 +18,7 @@ interface InputFieldProps {
   registration: UseFormRegisterReturn
   id?: string
   suffix?: string
+  autoFocus?: boolean
 }
 
 export function InputField({ error, checkResult, registration, classname, inputClass, id, suffix, ...inputProps }: InputFieldProps) {

--- a/src/pages/signup/components/NameField.tsx
+++ b/src/pages/signup/components/NameField.tsx
@@ -23,6 +23,7 @@ export function NameField({ register, errors }: NameFieldProps) {
         classname="flex flex-col gap-2.5"
         error={errors.name}
         registration={register('name', signupValidationRules.name)}
+        autoFocus
       />
     </div>
   )


### PR DESCRIPTION
## 📌 개요

- 회원가입 페이지 진입 시 이름 입력 필드에 자동 포커스되도록 개선

## 🔧 작업 내용

- [x] InputField 컴포넌트에 autoFocus prop 추가
- [x] NameField 컴포넌트에 autoFocus 적용

## 📎 관련 이슈

Closes #532

## 💬 리뷰어 참고 사항

- InputField 공통 컴포넌트에 autoFocus prop을 추가하여 다른 곳에서도 재사용 가능