### PR TITLE
fix: 알림 드롭다운 빈 알림 표시 버그 수정(#534)

### DIFF
--- a/src/components/header/components/notification-section/NotificationsDropdown.tsx
+++ b/src/components/header/components/notification-section/NotificationsDropdown.tsx
@@ -78,7 +78,7 @@ export default function NotificationsDropdown({ isNotificationOpen, setIsNotific
   return (
     <div
       ref={modalRef}
-      className={cn('absolute top-12 right-0 max-h-[819.2px] overflow-hidden rounded-lg border border-gray-200 bg-white', `${Z_INDEX.DROPDOWN}`)}
+      className={cn('absolute top-12 right-0 min-w-[364px] max-h-[819.2px] overflow-hidden rounded-lg border border-gray-200 bg-white', `${Z_INDEX.DROPDOWN}`)}
       onClick={(e) => e.stopPropagation()}
     >
       <div className="flex items-center justify-between border-b border-gray-200 px-4 pt-4 pb-[17px]">
@@ -98,7 +98,7 @@ export default function NotificationsDropdown({ isNotificationOpen, setIsNotific
       <div className="scrollbar-hide flex max-h-80 flex-col overflow-y-auto" role="tabpanel">
         {isLoading ? (
           <NotificationsSkeleton />
-        ) : notificationsData?.pages.length !== 0 ? (
+        ) : notificationsData?.pages.some((page) => page.content.length > 0) ? (
           <>
             {notificationsData?.pages.flatMap((page) =>
               page.content.map((notification: NotificationItemType) => (
@@ -110,10 +110,10 @@ export default function NotificationsDropdown({ isNotificationOpen, setIsNotific
                 />
               ))
             )}
-            <div ref={observerTargetRef} className="h-4" />
+            <div ref={observerTargetRef} className="h-1" />
           </>
         ) : (
-          <div className="flex h-32 min-w-[364px] items-center justify-center text-sm text-gray-500">표시할 알림이 없습니다.</div>
+          <div className="flex h-32 items-center justify-center text-sm text-gray-500">표시할 알림이 없습니다.</div>
         )}
       </div>
       <div className="flex h-[45px] border-t border-gray-200" />


### PR DESCRIPTION
## 📌 개요

- 알림 목록이 비어있을 때 "표시할 알림이 없습니다" 메시지가 정상적으로 표시되지 않는 버그 수정

## 🔧 작업 내용

- [x] 빈 알림 체크 로직 개선 (`pages.length !== 0` → `pages.some()`)
- [x] 드롭다운 최소 너비 설정 위치 조정
- [x] observer 타겟 높이 조정

## 📎 관련 이슈

Closes #534

## 💬 리뷰어 참고 사항

- 기존 `pages.length !== 0` 조건은 빈 content를 가진 페이지도 통과시켜 버그 발생
- `pages.some((page) => page.content.length > 0)`으로 실제 알림 존재 여부 확인