### PR TITLE
refactor: 마이페이지 UI 개선(#536)

### DIFF
--- a/src/pages/my-page/components/MyList.tsx
+++ b/src/pages/my-page/components/MyList.tsx
@@ -206,7 +206,7 @@ export default function MyList({ id, title, price, mainImageUrl, tradeStatus, vi
                   className="hover:bg-primary-300 flex-1 cursor-pointer border border-gray-300 hover:font-bold hover:text-white"
                   onClick={isWishlistTab ? handleCancelFavorite : (e: React.MouseEvent) => handleConfirmModal(e, id, title, price, mainImageUrl)}
                 >
-                  삭제
+                  찜 취소
                 </Button>
               </div>
             )}

--- a/src/pages/my-page/components/MyPagePanel.tsx
+++ b/src/pages/my-page/components/MyPagePanel.tsx
@@ -8,6 +8,7 @@ import { LoadMoreButton } from '@src/components/commons/button/LoadMoreButton'
 import { EmptyState } from '@src/components/EmptyState'
 import { Package, Heart, type LucideIcon } from 'lucide-react'
 import { Link } from 'react-router-dom'
+import { cn } from '@src/utils/cn'
 
 interface MyPagePanelProps {
   activeTabCode: string
@@ -97,13 +98,16 @@ export default function MyPagePanel({
 
   const productData = getProductData()
   const config = activeMyPageTab !== 'tab-blocked' ? TAB_CONFIG[activeMyPageTab] : null
+  const hasContent =
+    (activeMyPageTab !== 'tab-blocked' && (productData?.content?.length || config)) ||
+    (activeMyPageTab === 'tab-blocked' && myBlockedData?.length)
 
   return (
     <div
       role="tabpanel"
       id={`panel-${activeTabCode}`}
       aria-labelledby={activeMyPageTab}
-      className="flex flex-col gap-6 rounded-xl border-gray-200 px-5 py-7 md:border md:p-5"
+      className={cn('flex flex-col rounded-xl border-gray-200 px-5 py-7 md:border md:p-5', hasContent && 'gap-6')}
     >
       {config ? (
         <MyPageTitle


### PR DESCRIPTION
## 📌 개요

- 마이페이지 찜 목록 및 패널 UI/UX 개선

## 🔧 작업 내용

- [x] 찜 목록 버튼 텍스트 "삭제" → "찜 취소"로 명확화
- [x] 콘텐츠가 있을 때만 gap-6 적용하도록 조건부 스타일링

## 📎 관련 이슈

Closes #536

## 💬 리뷰어 참고 사항

- 버튼 텍스트 변경으로 사용자 혼란 방지
- 빈 상태일 때 불필요한 여백 제거로 레이아웃 개선