### PR TITLE
fix: 소셜 로그인 시 거주지 주소 null 표시 문제 해결(#538)

### DIFF
--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -28,5 +28,6 @@ export const ROUTES = {
   // Auth
   LOGIN: '/auth/login',
   SIGNUP: '/auth/signup',
+  SOCIAL_SIGNUP: '/auth/social-signup',
   FIND_PASSWORD: '/auth/find-password',
 } as const

--- a/src/pages/SocialCallback.tsx
+++ b/src/pages/SocialCallback.tsx
@@ -15,13 +15,18 @@ export default function SocialCallback() {
       setRefreshToken(refreshToken)
 
       // 2. 토큰으로 user 정보 조회 API 호출
+      // 유저 정보 확인 → nickname, addressSido가 없으면 프로필 완성 페이지로 리다이렉트
       const userResponse = await api.get('/profile/me')
       const user = userResponse.data.data
 
-      handleLogin(user, accessToken, refreshToken)
-
-      // 3. localStorage에 persist가 완료될 때까지 대기
-      await new Promise((resolve) => setTimeout(resolve, 100))
+      if (!user.nickname || !user.addressSido) {
+        // 토큰은 저장하되, 프로필 완성 페이지로 이동
+        handleLogin(user, accessToken, refreshToken)
+        // 3. localStorage에 persist가 완료될 때까지 대기
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        navigate('/auth/social-signup')
+        return
+      }
 
       // 4. 저장된 redirectUrl이 있으면 해당 페이지로, 없으면 홈으로 이동
       const redirectUrl = useUserStore.getState().redirectUrl
@@ -43,6 +48,7 @@ export default function SocialCallback() {
       navigate('/login')
     }
   }, [handleSocialAuth, navigate])
+
   return (
     <div style={{ textAlign: 'center', marginTop: '100px' }}>
       <h2>로그인 처리 중...</h2>

--- a/src/pages/signup/Signup.tsx
+++ b/src/pages/signup/Signup.tsx
@@ -2,7 +2,7 @@ import { TitleSection } from '../login/components/TitleSection'
 import { ROUTES } from '@src/constants/routes'
 import { SignUpForm } from './components/SignUpForm'
 
-function Signup() {
+export default function Signup() {
   return (
     <div className="flex min-h-screen flex-col items-center justify-baseline bg-white py-10 md:justify-center md:bg-[#F3F4F6]">
       <div className="flex min-w-full flex-col items-center gap-9 rounded-[20px] bg-white px-5 md:min-w-[530px] md:py-10">
@@ -12,5 +12,3 @@ function Signup() {
     </div>
   )
 }
-
-export default Signup

--- a/src/pages/signup/SocialSignup.tsx
+++ b/src/pages/signup/SocialSignup.tsx
@@ -1,0 +1,11 @@
+import { SocialSignUpForm } from './components/SocialSignUpForm'
+
+export default function SocialSignup() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-baseline bg-white py-10 md:justify-center md:bg-[#F3F4F6]">
+      <div className="flex min-w-full flex-col items-center gap-9 rounded-[20px] bg-white px-5 md:min-w-[530px] md:py-10">
+        <SocialSignUpForm />
+      </div>
+    </div>
+  )
+}

--- a/src/pages/signup/components/BirthDateField.tsx
+++ b/src/pages/signup/components/BirthDateField.tsx
@@ -1,11 +1,10 @@
 import { RequiredLabel } from '@src/components/commons/RequiredLabel'
 import 'react-datepicker/dist/react-datepicker.css'
 import './BirthDateField.css'
-import { Controller, type Control } from 'react-hook-form'
-import type { SignUpFormValues } from './SignUpForm'
+import { Controller, type Control, type FieldValues, type Path } from 'react-hook-form'
 
-interface BirthDateFieldProps {
-  control: Control<SignUpFormValues>
+interface BirthDateFieldProps<T extends FieldValues> {
+  control: Control<T>
 }
 
 const validateBirthDate = (value: string): string | true => {
@@ -38,7 +37,7 @@ const validateBirthDate = (value: string): string | true => {
   return actualAge >= 14 || '만 14세 이상만 가입 가능합니다'
 }
 
-export function BirthDateField({ control }: BirthDateFieldProps) {
+export function BirthDateField<T extends FieldValues>({ control }: BirthDateFieldProps<T>) {
   const isNumber = (e: React.ChangeEvent<HTMLInputElement>, maxLength: number) => {
     const value = e.target.value.replace(/[^0-9]/g, '')
     return value.slice(0, maxLength)
@@ -48,7 +47,7 @@ export function BirthDateField({ control }: BirthDateFieldProps) {
     <div className="flex flex-col gap-2.5">
       <RequiredLabel htmlFor="signup-birthdate">생년월일</RequiredLabel>
       <Controller
-        name="birthDate"
+        name={'birthDate' as Path<T>}
         control={control}
         rules={{
           required: '생년월일을 입력해주세요',

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,7 +2,6 @@
 // import AlarmPage from '@pages/AlarmPage';
 import Home from '@src/pages/home/Home'
 
-
 import Login from '@src/pages/login/Login'
 import MyPage from '@src/pages/my-page/MyPage'
 // import ProductDetail from '@pages/ProductDetail';
@@ -23,11 +22,13 @@ import CommunityPostForm from '@src/pages/community/components/CommunityPostForm
 import CommunityDetail from '@src/pages/community/CommunityDetail'
 import SocialCallback from '@src/pages/SocialCallback'
 import ChattingPage from '@src/pages/chatting-page/ChattingPage'
+import SocialSignup from '@src/pages/signup/SocialSignup'
 
 const routes = [
   { path: ROUTES.HOME, element: <Home /> },
   { path: ROUTES.LOGIN, element: <Login /> },
   { path: ROUTES.SIGNUP, element: <Signup /> },
+  { path: ROUTES.SOCIAL_SIGNUP, element: <SocialSignup /> },
   { path: ROUTES.FIND_PASSWORD, element: <FindPasswordPage /> },
   { path: ROUTES.MYPAGE, element: <MyPage /> },
   { path: ROUTES.DETAIL, element: <ProductDetail /> },

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -17,10 +17,16 @@ export interface EmailCheckResponse {
 }
 
 export interface SignUpRequestData {
-  email: string
-  password: string
-  name: string
-  nickname: string
+  email?: string
+  password?: string
+  name?: string
+  nickname?: string
+  birthDate: string
+  addressSido: Province | ''
+  addressGugun: string
+}
+
+export interface SocialSignUpRequestData {
   birthDate: string
   addressSido: Province | ''
   addressGugun: string
@@ -44,7 +50,7 @@ export interface SignUpResponse {
 }
 
 export interface LoginRequestData {
-  email: string
+  email?: string
   password: string
 }
 


### PR DESCRIPTION
## 📌 개요

- 소셜 로그인으로 회원가입 시 마이페이지에서 거주지 주소가 null로 표시되는 문제 해결

## 🔧 작업 내용

- [x] 소셜 회원가입 프로필 완성 페이지 추가 (SocialSignup, SocialSignUpForm)
- [x] 소셜 로그인 후 프로필 미완성 시 추가 정보 입력 페이지로 리다이렉트
- [x] BirthDateField 컴포넌트 제네릭 타입으로 재사용성 개선
- [x] 관련 라우트 및 타입 추가

## 📎 관련 이슈

Closes #538

## 💬 리뷰어 참고 사항

- 소셜 로그인 후 nickname, addressSido가 없으면 프로필 완성 페이지로 이동
- BirthDateField를 제네릭으로 변경하여 SocialSignUpForm에서도 재사용 가능