### PR TITLE
fix: 소셜 로그인 신규/기존 회원 분기 처리 수정(#540)

### DIFF
--- a/src/pages/SocialCallback.tsx
+++ b/src/pages/SocialCallback.tsx
@@ -20,12 +20,14 @@ export default function SocialCallback() {
       const user = userResponse.data.data
 
       if (!user.nickname || !user.addressSido) {
-        // 토큰은 저장하되, 프로필 완성 페이지로 이동
-        handleLogin(user, accessToken, refreshToken)
-        // 3. localStorage에 persist가 완료될 때까지 대기
-        await new Promise((resolve) => setTimeout(resolve, 100))
+        // 신규 회원: 프로필 완성 페이지로 이동 (handleLogin 호출 안 함 → 헤더 비로그인 상태)
         navigate('/auth/social-signup')
         return
+      } else {
+        // 기존 회원: 로그인 처리 후 홈으로 이동
+        handleLogin(user, accessToken, refreshToken)
+        // localStorage에 persist가 완료될 때까지 대기
+        await new Promise((resolve) => setTimeout(resolve, 100))
       }
 
       // 4. 저장된 redirectUrl이 있으면 해당 페이지로, 없으면 홈으로 이동


### PR DESCRIPTION
## 📌 개요

- 소셜 로그인 시 신규 회원과 기존 회원의 분기 처리가 올바르게 동작하지 않는 버그 수정

## 🔧 작업 내용

- [x] `SocialCallback.tsx`: 신규 회원일 때 `handleLogin` 호출 제거 (헤더 비로그인 상태 유지)
- [x] `SocialCallback.tsx`: 기존 회원일 때 `handleLogin` 호출 추가

## 📎 관련 이슈

Closes #540

## 📸 스크린샷 (선택)

(필요시 추가)

## 💬 리뷰어 참고 사항

| 상황 | 기대 동작 |
|------|----------|
| 신규 소셜 회원 | 헤더 비로그인 상태 → `/auth/social-signup` 이동 |
| 기존 회원 (일반 가입 이메일과 동일한 구글 계정) | 헤더 로그인 상태 → `/` 이동 |