### PR TITLE
fix: 소셜 회원가입 페이지 타이틀 문구 수정(#544)

### DIFF
--- a/src/pages/signup/SocialSignup.tsx
+++ b/src/pages/signup/SocialSignup.tsx
@@ -5,7 +5,7 @@ export default function SocialSignup() {
   return (
     <div className="flex min-h-screen flex-col items-center justify-baseline bg-white py-10 md:justify-center md:bg-[#F3F4F6]">
       <div className="flex min-w-full flex-col items-center gap-9 rounded-[20px] bg-white px-5 md:min-w-[530px] md:py-10">
-        <TitleSection title="회원가입" desc="추가정보를 입력해주세요" />
+        <TitleSection title="추가 정보 입력" desc="서비스 이용을 위해 아래 정보가 필요합니다" />
         <SocialSignUpForm />
       </div>
     </div>


### PR DESCRIPTION
## 📌 개요

- 소셜 회원가입 페이지의 타이틀이 "회원가입"으로 되어 있어 사용자에게 혼란을 줄 수 있는 문제 수정

## 🔧 작업 내용

- [x] `SocialSignup.tsx`: title "회원가입" → "추가 정보 입력" 수정
- [x] `SocialSignup.tsx`: desc "추가정보를 입력해주세요" → "서비스 이용을 위해 아래 정보가 필요합니다" 수정

## 📎 관련 이슈

Closes #544

## 📸 스크린샷 (선택)

(필요시 추가)

## 💬 리뷰어 참고 사항

- 소셜 로그인 사용자는 이미 구글 계정으로 인증을 완료한 상태이므로 "회원가입"보다 "추가 정보 입력"이 적절
- 관련 이슈: #542