### PR TITLE
fix: 소셜 회원가입 시 nickname 필드 누락 오류 수정(#546)

### DIFF
--- a/src/pages/signup/components/SocialSignUpForm.tsx
+++ b/src/pages/signup/components/SocialSignUpForm.tsx
@@ -42,6 +42,7 @@ export function SocialSignUpForm() {
       return
     }
     const requestData: SocialSignUpRequestData = {
+      nickname: useUserStore.getState().user?.nickname || '',
       birthDate: data.birthDate,
       addressSido: data.addressSido,
       addressGugun: data.addressGugun,

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -27,6 +27,7 @@ export interface SignUpRequestData {
 }
 
 export interface SocialSignUpRequestData {
+  nickname?: string
   birthDate: string
   addressSido: Province | ''
   addressGugun: string


### PR DESCRIPTION
## 📌 개요

- 소셜 회원가입 시 PATCH /profile/me API 호출에서 nickname 필드가 누락되어 400 에러가 발생하는 문제 수정

## 🔧 작업 내용

- [x] `SocialSignUpForm.tsx`: 요청 데이터에 기존 nickname 포함
- [x] `auth.ts`: `SocialSignUpRequestData` 타입에 nickname 필드 추가

## 📎 관련 이슈

Closes #546

## 📸 스크린샷 (선택)

(필요시 추가)

## 💬 리뷰어 참고 사항

- 백엔드 PATCH API가 nickname을 필수 필드로 요구하여 store에서 기존 nickname을 가져와 전송
- 관련 이슈: #540, #544