### PR TITLE
fix: 소셜 신규 회원 시 user 정보 store 저장 누락 수정(#548)

### DIFF
--- a/src/pages/SocialCallback.tsx
+++ b/src/pages/SocialCallback.tsx
@@ -20,6 +20,8 @@ export default function SocialCallback() {
       const user = userResponse.data.data
 
       if (!user.nickname || !user.addressSido) {
+        // 신규 회원: user 정보만 저장 (로그인 상태는 아님)
+        useUserStore.getState().setUser(user)
         // 신규 회원: 프로필 완성 페이지로 이동 (handleLogin 호출 안 함 → 헤더 비로그인 상태)
         navigate('/auth/social-signup')
         return


### PR DESCRIPTION
## 📌 개요

- 소셜 신규 회원일 때 user 정보가 store에 저장되지 않아 SocialSignUpForm에서 nickname을 가져올 수 없는 문제 수정

## 🔧 작업 내용

- [x] `SocialCallback.tsx`: 신규 회원일 때 `setUser(user)` 호출 추가

## 📎 관련 이슈

Closes #548

## 📸 스크린샷 (선택)

(필요시 추가)

## 💬 리뷰어 참고 사항

- `setUser`만 호출하여 user 정보는 저장하되, `handleLogin`은 호출하지 않아 헤더는 비로그인 상태 유지
- 관련 이슈: #546