### PR TITLE
feat: 소셜 회원가입 닉네임 표시 및 중복 체크 기능 추가(#550)

### DIFF
--- a/src/pages/signup/components/NicknameField.tsx
+++ b/src/pages/signup/components/NicknameField.tsx
@@ -1,26 +1,33 @@
 import { RequiredLabel } from '@src/components/commons/RequiredLabel'
 import { InputWithButton } from '@src/components/commons/InputWithButton'
-import type { SignUpFormValues } from './SignUpForm'
-import { type UseFormRegister, type FieldErrors, type UseFormWatch, type UseFormClearErrors } from 'react-hook-form'
+import {
+  type FieldError,
+  type FieldValues,
+  type Path,
+  type UseFormRegister,
+  type FieldErrors,
+  type UseFormWatch,
+  type UseFormClearErrors,
+} from 'react-hook-form'
 import { signupValidationRules } from '../validationRules'
 import { checkNickname } from '@src/api/auth'
 import { useState } from 'react'
 
-interface NicknameFieldProps {
-  watch: UseFormWatch<SignUpFormValues>
-  register: UseFormRegister<SignUpFormValues>
-  errors: FieldErrors<SignUpFormValues>
+interface NicknameFieldProps<T extends FieldValues> {
+  watch: UseFormWatch<T>
+  register: UseFormRegister<T>
+  errors: FieldErrors<T>
   setIsNicknameVerified: (verified: boolean) => void
-  clearErrors: UseFormClearErrors<SignUpFormValues>
+  clearErrors: UseFormClearErrors<T>
 }
 
-export function NicknameField({ register, errors, watch, setIsNicknameVerified, clearErrors }: NicknameFieldProps) {
+export function NicknameField<T extends FieldValues>({ register, errors, watch, setIsNicknameVerified, clearErrors }: NicknameFieldProps<T>) {
   const [checkResult, setCheckResult] = useState<{
     status: 'idle' | 'success' | 'error'
     message: string
   }>({ status: 'idle', message: '' })
 
-  const nickname = watch('nickname')
+  const nickname = watch('nickname' as Path<T>)
 
   const handleNicknameCheck = async () => {
     try {
@@ -33,7 +40,7 @@ export function NicknameField({ register, errors, watch, setIsNicknameVerified, 
           message: response.message, // "사용 가능한 닉네임입니다."
         })
         setIsNicknameVerified(true)
-        clearErrors('nickname')
+        clearErrors('nickname' as Path<T>)
       } else {
         // 중복 (data: false)
         setCheckResult({
@@ -58,9 +65,9 @@ export function NicknameField({ register, errors, watch, setIsNicknameVerified, 
         id="signup-nickname"
         type="text"
         placeholder="닉네임을 입력해주세요"
-        error={errors.nickname}
+        error={errors.nickname as FieldError | undefined}
         checkResult={checkResult}
-        registration={register('nickname', signupValidationRules.nickname)}
+        registration={register('nickname' as Path<T>, signupValidationRules.nickname)}
         buttonText="중복체크"
         onButtonClick={handleNicknameCheck}
       />

--- a/src/pages/signup/components/SocialSignUpForm.tsx
+++ b/src/pages/signup/components/SocialSignUpForm.tsx
@@ -12,37 +12,57 @@ import { isAxiosError } from 'axios'
 import type { ToastType } from '@src/types/toast'
 import type { SocialSignUpRequestData } from '@src/types/auth'
 import { api } from '@src/api/api'
+import { NicknameField } from './NicknameField'
 
 export interface SocialSignUpFormValues {
   birthDate: string
+  nickname: string
   addressSido: Province | ''
   addressGugun: string
 }
 
 export function SocialSignUpForm() {
+  const user = useUserStore((state) => state.user)
+
   const {
     control,
+    register,
+    watch,
+    setError,
+    clearErrors,
     handleSubmit, // form onSubmit에 들어가는 함수 : 제출 시 실행할 함수를 감싸주는 함수
     setValue,
+    formState: { errors },
   } = useForm<SocialSignUpFormValues>({
     defaultValues: {
+      nickname: user?.nickname || '',
       birthDate: '',
       addressSido: '',
       addressGugun: '',
     },
   }) // 폼에서 관리할 필드들의 타입(이름) 정의.
-
+  const [isNicknameVerified, setIsNicknameVerified] = useState(false)
   const [signupNotification, setSignupNotification] = useState<{ message: string; type: ToastType } | null>(null)
   const navigate = useNavigate()
 
   const onSubmit = async (data: SocialSignUpFormValues) => {
     // 검증 완료 여부 확인
-    const hasError = false
+    let hasError = false
+
+    if (!isNicknameVerified) {
+      setError('nickname', {
+        type: 'manual',
+        message: '닉네임 중복 확인을 완료해주세요.',
+      })
+      hasError = true
+    }
+
     if (hasError) {
       return
     }
+
     const requestData: SocialSignUpRequestData = {
-      nickname: useUserStore.getState().user?.nickname || '',
+      nickname: user?.nickname || '',
       birthDate: data.birthDate,
       addressSido: data.addressSido,
       addressGugun: data.addressGugun,
@@ -79,6 +99,7 @@ export function SocialSignUpForm() {
       <fieldset className="flex flex-col gap-9">
         <legend className="sr-only">회원가입폼</legend>
         <div className="flex flex-col gap-6">
+          <NicknameField register={register} errors={errors} watch={watch} setIsNicknameVerified={setIsNicknameVerified} clearErrors={clearErrors} />
           <AddressField<SocialSignUpFormValues> control={control} setValue={setValue} primaryName="addressSido" secondaryName="addressGugun" />
           <BirthDateField control={control} />
         </div>


### PR DESCRIPTION
## 📌 개요

- 소셜 회원가입 시 소셜 계정에서 가져온 닉네임을 표시하고 중복 체크 기능 추가

## 🔧 작업 내용

- [x] `NicknameField`: 제네릭 타입 적용하여 재사용 가능하도록 수정
- [x] `SocialSignUpForm`: 소셜 닉네임을 defaultValue로 설정
- [x] `SocialSignUpForm`: NicknameField 컴포넌트 연동

## 📎 관련 이슈

Closes #550

## 📸 스크린샷 (선택)

(필요시 추가)

## 💬 리뷰어 참고 사항

- `NicknameField`를 제네릭으로 변경하여 `SignUpForm`과 `SocialSignUpForm` 모두에서 재사용 가능
- 관련 이슈: #546, #548