### PR TITLE
fix: MyList 버튼 텍스트 탭별 분기 처리(#552)

### DIFF
--- a/src/pages/my-page/components/MyList.tsx
+++ b/src/pages/my-page/components/MyList.tsx
@@ -206,7 +206,7 @@ export default function MyList({ id, title, price, mainImageUrl, tradeStatus, vi
                   className="hover:bg-primary-300 flex-1 cursor-pointer border border-gray-300 hover:font-bold hover:text-white"
                   onClick={isWishlistTab ? handleCancelFavorite : (e: React.MouseEvent) => handleConfirmModal(e, id, title, price, mainImageUrl)}
                 >
-                  찜 취소
+                  {isWishlistTab ? '찜 취소' : '삭제'}
                 </Button>
               </div>
             )}


### PR DESCRIPTION
## 📌 개요

- 마이페이지에서 찜 목록/구매내역/판매내역 탭에 따라 버튼 텍스트가 적절히 표시되도록 수정

## 🔧 작업 내용

- [x] MyList.tsx에서 isWishlistTab에 따라 버튼 텍스트 분기 처리
  - 찜 목록 탭: "찜 취소"
  - 구매내역/판매내역 탭: "삭제"

## 📎 관련 이슈

Closes #552

## 💬 리뷰어 참고 사항

- 단순 텍스트 분기 처리입니다