### PR TITLE
fix: 닉네임 변경 시 중복체크 결과 초기화(#554)

### DIFF
--- a/src/pages/signup/components/NicknameField.tsx
+++ b/src/pages/signup/components/NicknameField.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-hook-form'
 import { signupValidationRules } from '../validationRules'
 import { checkNickname } from '@src/api/auth'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 interface NicknameFieldProps<T extends FieldValues> {
   watch: UseFormWatch<T>
@@ -57,6 +57,11 @@ export function NicknameField<T extends FieldValues>({ register, errors, watch, 
       setIsNicknameVerified(false)
     }
   }
+
+  useEffect(() => {
+    setCheckResult({ status: 'idle', message: '' })
+    setIsNicknameVerified(false)
+  }, [nickname, setIsNicknameVerified])
 
   return (
     <div className="flex flex-col gap-2.5">


### PR DESCRIPTION
## 📌 개요

- 닉네임 중복체크 후 닉네임을 수정해도 이전 에러 메시지가 남아있는 버그 수정

## 🔧 작업 내용

- [x] NicknameField 컴포넌트에 useEffect 추가
- [x] nickname 값 변경 시 checkResult를 idle 상태로 초기화
- [x] nickname 값 변경 시 isNicknameVerified를 false로 설정

## 📎 관련 이슈

Closes #554

## 💬 리뷰어 참고 사항

- 일반 회원가입, 소셜 회원가입 두 페이지에서 동일하게 적용됩니다