### PR TITLE
fix: 소셜 로그인 신규 회원 판단 조건 수정(#556)

### DIFF
--- a/src/pages/SocialCallback.tsx
+++ b/src/pages/SocialCallback.tsx
@@ -19,7 +19,7 @@ export default function SocialCallback() {
       const userResponse = await api.get('/profile/me')
       const user = userResponse.data.data
 
-      if (!user.nickname || !user.addressSido) {
+      if (!user.addressSido || !user.birthDate) {
         // 신규 회원: user 정보만 저장 (로그인 상태는 아님)
         useUserStore.getState().setUser(user)
         // 신규 회원: 프로필 완성 페이지로 이동 (handleLogin 호출 안 함 → 헤더 비로그인 상태)


### PR DESCRIPTION
## 📌 개요

- 카카오 소셜 로그인 시 nickname이 이미 있어서 신규 회원으로 판단되지 않는 버그 수정

## 🔧 작업 내용

- [x] SocialCallback.tsx에서 신규 회원 판단 조건 변경
  - Before: `!user.nickname || !user.addressSido`
  - After: `!user.addressSido || !user.birthDate`

## 📎 관련 이슈

Closes #556

## 💬 리뷰어 참고 사항

- 카카오에서 nickname을 이미 제공하므로 nickname 체크 제거
- 실제 추가 정보 입력 폼에서 받는 필수값(거주지, 생년월일)으로 신규 회원 판단