### PR TITLE
fix: 소셜 로그인 신규 회원 헤더 비로그인 상태 유지(#558)

### DIFF
--- a/src/pages/SocialCallback.tsx
+++ b/src/pages/SocialCallback.tsx
@@ -20,10 +20,8 @@ export default function SocialCallback() {
       const user = userResponse.data.data
 
       if (!user.addressSido || !user.birthDate) {
-        // 신규 회원: user 정보만 저장 (로그인 상태는 아님)
-        useUserStore.getState().setUser(user)
         // 신규 회원: 프로필 완성 페이지로 이동 (handleLogin 호출 안 함 → 헤더 비로그인 상태)
-        navigate('/auth/social-signup')
+        navigate('/auth/social-signup', { state: user })
         return
       } else {
         // 기존 회원: 로그인 처리 후 홈으로 이동

--- a/src/pages/signup/components/SocialSignUpForm.tsx
+++ b/src/pages/signup/components/SocialSignUpForm.tsx
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form'
 import { type Province } from '@src/constants/cities'
 import { useState } from 'react'
 import { BirthDateField } from './BirthDateField'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { useUserStore } from '@src/store/userStore'
 import { AnimatePresence } from 'framer-motion'
 import InlineNotification from '@src/components/commons/InlineNotification'
@@ -22,8 +22,9 @@ export interface SocialSignUpFormValues {
 }
 
 export function SocialSignUpForm() {
-  const user = useUserStore((state) => state.user)
-
+  // const user = useUserStore((state) => state.user)
+  const location = useLocation()
+  const user = location.state
   const {
     control,
     register,
@@ -62,7 +63,7 @@ export function SocialSignUpForm() {
     }
 
     const requestData: SocialSignUpRequestData = {
-      nickname: user?.nickname || '',
+      nickname: data?.nickname || '',
       birthDate: data.birthDate,
       addressSido: data.addressSido,
       addressGugun: data.addressGugun,


### PR DESCRIPTION
## 🐛 수정 내용
소셜 로그인 신규 회원이 추가 정보 입력 페이지로 이동할 때 헤더가 로그인 상태로 표시되는 문제 수정

## 📌 원인
- `SocialCallback.tsx`에서 `setAccessToken()`과 `setUser(user)` 모두 호출
- `isLogin()`이 `user && accessToken`을 체크하므로 true 반환
- 결과: 신규 회원도 헤더에 프로필 이미지 및 로그인 UI 표시

## 🛠 해결 방법
- `SocialCallback.tsx`: `setUser(user)` 제거, navigate state로 user 전달
- `SocialSignUpForm.tsx`: `useLocation().state`에서 user 데이터 획득
- 닉네임은 폼 데이터(`data.nickname`)에서 가져오도록 변경

## 변경 파일
- `src/pages/SocialCallback.tsx`
- `src/pages/signup/SocialSignUpForm.tsx`

closes #558