### PR TITLE
fix: 닉네임 중복체크 에러 메시지 중복 표시 방지(#560)

### DIFF
--- a/src/pages/signup/components/NicknameField.tsx
+++ b/src/pages/signup/components/NicknameField.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-hook-form'
 import { signupValidationRules } from '../validationRules'
 import { checkNickname } from '@src/api/auth'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 
 interface NicknameFieldProps<T extends FieldValues> {
   watch: UseFormWatch<T>
@@ -19,13 +19,23 @@ interface NicknameFieldProps<T extends FieldValues> {
   errors: FieldErrors<T>
   setIsNicknameVerified: (verified: boolean) => void
   clearErrors: UseFormClearErrors<T>
+  setCheckResult: (result: { status: 'idle' | 'success' | 'error'; message: string }) => void
+  checkResult: { status: 'idle' | 'success' | 'error'; message: string }
 }
 
-export function NicknameField<T extends FieldValues>({ register, errors, watch, setIsNicknameVerified, clearErrors }: NicknameFieldProps<T>) {
-  const [checkResult, setCheckResult] = useState<{
-    status: 'idle' | 'success' | 'error'
-    message: string
-  }>({ status: 'idle', message: '' })
+export function NicknameField<T extends FieldValues>({
+  register,
+  errors,
+  watch,
+  setIsNicknameVerified,
+  clearErrors,
+  setCheckResult,
+  checkResult,
+}: NicknameFieldProps<T>) {
+  // const [checkResult, setCheckResult] = useState<{
+  //   status: 'idle' | 'success' | 'error'
+  //   message: string
+  // }>({ status: 'idle', message: '' })
 
   const nickname = watch('nickname' as Path<T>)
 
@@ -61,7 +71,7 @@ export function NicknameField<T extends FieldValues>({ register, errors, watch, 
   useEffect(() => {
     setCheckResult({ status: 'idle', message: '' })
     setIsNicknameVerified(false)
-  }, [nickname, setIsNicknameVerified])
+  }, [nickname, setIsNicknameVerified, setCheckResult])
 
   return (
     <div className="flex flex-col gap-2.5">

--- a/src/pages/signup/components/SignUpForm.tsx
+++ b/src/pages/signup/components/SignUpForm.tsx
@@ -57,6 +57,10 @@ export function SignUpForm() {
   const [isEmailVerified, setIsEmailVerified] = useState(false)
   const [isEmailCodeVerified, setIsEmailCodeVerified] = useState(false)
   const [signupNotification, setSignupNotification] = useState<{ message: string; type: ToastType } | null>(null)
+  const [checkResult, setCheckResult] = useState<{
+    status: 'idle' | 'success' | 'error'
+    message: string
+  }>({ status: 'idle', message: '' })
   const navigate = useNavigate()
 
   const { handleLogin } = useUserStore()
@@ -65,7 +69,9 @@ export function SignUpForm() {
     // 검증 완료 여부 확인
     let hasError = false
 
-    if (!isNicknameVerified) {
+    if (checkResult.status === 'error') {
+      hasError = true
+    } else if (!isNicknameVerified) {
       setError('nickname', {
         type: 'manual',
         message: '닉네임 중복 확인을 완료해주세요.',
@@ -138,7 +144,15 @@ export function SignUpForm() {
         <legend className="sr-only">회원가입폼</legend>
         <div className="flex flex-col gap-6">
           <NameField register={register} errors={errors} />
-          <NicknameField register={register} errors={errors} watch={watch} setIsNicknameVerified={setIsNicknameVerified} clearErrors={clearErrors} />
+          <NicknameField
+            register={register}
+            errors={errors}
+            watch={watch}
+            setIsNicknameVerified={setIsNicknameVerified}
+            clearErrors={clearErrors}
+            checkResult={checkResult}
+            setCheckResult={setCheckResult}
+          />
           <AddressField<SignUpFormValues> control={control} setValue={setValue} primaryName="addressSido" secondaryName="addressGugun" />
           <BirthDateField control={control} />
           <EmailValidCode

--- a/src/pages/signup/components/SocialSignUpForm.tsx
+++ b/src/pages/signup/components/SocialSignUpForm.tsx
@@ -46,11 +46,27 @@ export function SocialSignUpForm() {
   const [signupNotification, setSignupNotification] = useState<{ message: string; type: ToastType } | null>(null)
   const navigate = useNavigate()
 
+  const [checkResult, setCheckResult] = useState<{
+    status: 'idle' | 'success' | 'error'
+    message: string
+  }>({ status: 'idle', message: '' })
+
   const onSubmit = async (data: SocialSignUpFormValues) => {
     // 검증 완료 여부 확인
     let hasError = false
 
-    if (!isNicknameVerified) {
+    // if (!isNicknameVerified) {
+    //   setError('nickname', {
+    //     type: 'manual',
+    //     message: '닉네임 중복 확인을 완료해주세요.',
+    //   })
+    //   hasError = true
+    // }
+
+    if (checkResult.status === 'error') {
+      // 이미 중복 에러가 표시되어 있으므로 추가 에러 메시지 불필요
+    } else if (!isNicknameVerified) {
+      // 중복체크를 아예 안 한 경우에만 "닉네임 중복 확인을 완료해주세요" 표시
       setError('nickname', {
         type: 'manual',
         message: '닉네임 중복 확인을 완료해주세요.',
@@ -100,7 +116,15 @@ export function SocialSignUpForm() {
       <fieldset className="flex flex-col gap-9">
         <legend className="sr-only">회원가입폼</legend>
         <div className="flex flex-col gap-6">
-          <NicknameField register={register} errors={errors} watch={watch} setIsNicknameVerified={setIsNicknameVerified} clearErrors={clearErrors} />
+          <NicknameField
+            register={register}
+            errors={errors}
+            watch={watch}
+            setIsNicknameVerified={setIsNicknameVerified}
+            clearErrors={clearErrors}
+            checkResult={checkResult}
+            setCheckResult={setCheckResult}
+          />
           <AddressField<SocialSignUpFormValues> control={control} setValue={setValue} primaryName="addressSido" secondaryName="addressGugun" />
           <BirthDateField control={control} />
         </div>


### PR DESCRIPTION
## 📌 개요

- 닉네임 중복체크 에러 시 폼 제출할 때 에러 메시지가 중복으로 표시되는 문제 수정

## 🔧 작업 내용

- [x] NicknameField: checkResult 상태를 부모 컴포넌트로 끌어올림
- [x] SignUpForm: 중복체크 에러 상태일 때 추가 에러 메시지 표시 안 함
- [x] SocialSignUpForm: 동일하게 수정

## 📎 관련 이슈

Closes #560

## 💬 리뷰어 참고 사항

- 기존: "이미 사용중인 닉네임입니다" + "닉네임 중복 확인을 완료해주세요" 두 개 표시
- 수정: "이미 사용중인 닉네임입니다"만 표시 (중복체크 에러 상태일 때)