### PR TITLE
fix: 닉네임 중복체크 에러 시 폼 제출 차단 누락 수정(#562)

### DIFF
--- a/src/pages/signup/components/SocialSignUpForm.tsx
+++ b/src/pages/signup/components/SocialSignUpForm.tsx
@@ -65,6 +65,7 @@ export function SocialSignUpForm() {
 
     if (checkResult.status === 'error') {
       // 이미 중복 에러가 표시되어 있으므로 추가 에러 메시지 불필요
+      hasError = true
     } else if (!isNicknameVerified) {
       // 중복체크를 아예 안 한 경우에만 "닉네임 중복 확인을 완료해주세요" 표시
       setError('nickname', {


### PR DESCRIPTION
## 📌 개요

- 닉네임 중복체크 에러 상태에서 폼 제출 시 API 호출이 진행되는 문제 수정

## 🔧 작업 내용

- [x] SocialSignUpForm: checkResult.status === 'error' 시 hasError = true 추가

## 📎 관련 이슈

Closes #562

## 💬 리뷰어 참고 사항

- 이전 PR(#561)에서 `hasError = true` 설정이 누락되어 중복 닉네임 에러 상태에서도 API 호출이 진행되었음
- 이 PR에서 누락된 부분 보완