### PR TITLE
fix: 마이페이지 거래 상태 변경 시 캐시 동기화 및 페이지 이동 문제 수정(#564)

### DIFF
--- a/src/pages/my-page/components/MyList.tsx
+++ b/src/pages/my-page/components/MyList.tsx
@@ -37,6 +37,10 @@ export default function MyList({ id, title, price, mainImageUrl, tradeStatus, vi
   const queryClient = useQueryClient()
   const { mutate } = useMutation({
     mutationFn: (newStatus: TransactionStatus) => patchProductTradeStatus(id, newStatus),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['myRequest'] })
+      queryClient.invalidateQueries({ queryKey: ['myProducts'] })
+    },
   })
 
   const { mutate: cancelFavorite } = useMutation({
@@ -52,7 +56,8 @@ export default function MyList({ id, title, price, mainImageUrl, tradeStatus, vi
     mutate(koToEn as TransactionStatus)
   }
 
-  const productTradeStatusCompleted = () => {
+  const productTradeStatusCompleted = (e: React.MouseEvent) => {
+    e.preventDefault()
     setCurrentTradeStatus('COMPLETED')
     mutate('COMPLETED')
   }


### PR DESCRIPTION
## 📌 개요

- 마이페이지 판매요청 탭에서 "구매완료" 버튼 클릭 시 상세페이지로 이동되는 문제 수정
- 거래 상태 변경 후 새로고침해야 반영되는 캐시 동기화 문제 수정

## 🔧 작업 내용

- [x] 구매완료 버튼 클릭 시 상세페이지 이동 방지 (`e.preventDefault()` 추가)
- [x] 거래 상태 변경 후 캐시 무효화 추가 (`myRequest`, `myProducts`)

## 📎 관련 이슈

Closes #564

## 💬 리뷰어 참고 사항

- `useMutation`의 `onSuccess` 콜백에서 `queryClient.invalidateQueries`로 캐시 무효화 처리