### PR TITLE
refactor: 커뮤니티 자유게시판 제거(#566)

### DIFF
--- a/src/api/community.ts
+++ b/src/api/community.ts
@@ -14,30 +14,6 @@ import axios from 'axios'
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
 import { api } from './api'
-// 커뮤니티 자유게시판 목록 조회
-export const fetchFreeCommunity = async (
-  page: number = 0,
-  size: number = 10,
-  searchType?: string | null,
-  keyword?: string | null,
-  sortBy?: string | null
-) => {
-  const params = new URLSearchParams({
-    page: page.toString(),
-    size: size.toString(),
-  })
-  if (searchType) {
-    params.append('searchType', searchType)
-  }
-  if (keyword) {
-    params.append('keyword', keyword)
-  }
-  if (sortBy) {
-    params.append('sortBy', sortBy)
-  }
-  const response = await axios.get<CommunityResponse>(`${API_BASE_URL}/community/posts?boardType=FREE&${params.toString()}`)
-  return response.data.data
-}
 
 // 커뮤니티 질문 있어요 목록 조회
 export const fetchQuestionCommunity = async (

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -16,9 +16,6 @@ function Footer() {
             <h4 className="font-semibold text-gray-500">커뮤니티</h4>
             <ul className="flex flex-col gap-3 text-gray-500">
               <li>
-                <Link to={`${ROUTES.COMMUNITY}?tab=tab-free`}>자유게시판</Link>
-              </li>
-              <li>
                 <Link to={`${ROUTES.COMMUNITY}?tab=tab-info`}>정보 공유해요</Link>
               </li>
               <li>

--- a/src/components/header/components/MobileNavigation.tsx
+++ b/src/components/header/components/MobileNavigation.tsx
@@ -147,9 +147,6 @@ export default function MobileNavigation({ isOpen, onClose }: MobileNavigationPr
               style={{ height: isCommunityOpen ? `${communityHeight}px` : '0' }}
             >
               <div className="flex flex-col gap-2 pt-2 pl-4">
-                <Link to={`${ROUTES.COMMUNITY}?tab=tab-free`} onClick={onClose}>
-                  자유게시판
-                </Link>
                 <Link to={`${ROUTES.COMMUNITY}?tab=tab-question`} onClick={onClose}>
                   질문 있어요
                 </Link>

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -141,7 +141,6 @@ export type MyPageTabId = (typeof MY_PAGE_TABS)[number]['id']
 
 // 커뮤니티 용 탭
 export const COMMUNITY_TABS = [
-  { id: 'tab-free', label: '자유게시판', code: 'FREE' },
   { id: 'tab-question', label: '질문 있어요', code: 'QUESTION' },
   { id: 'tab-info', label: '정보 공유', code: 'INFO' },
 ] as const

--- a/src/pages/community/CommunityDetail.tsx
+++ b/src/pages/community/CommunityDetail.tsx
@@ -110,14 +110,12 @@ export default function CommunityDetail() {
 
   const getHeaderContent = () => {
     switch (data?.boardType) {
-      case 'FREE':
-        return { title: '자유게시판', description: '일상 이야기를 마음껏 나눠보세요!', tabId: 'tab-free' }
       case 'QUESTION':
         return { title: '질문 있어요', description: '궁금한 점을 질문해보세요!', tabId: 'tab-question' }
       case 'INFO':
         return { title: '정보 공유', description: '유용한 정보를 공유해보세요!', tabId: 'tab-info' }
       default:
-        return { title: '자유게시판', description: '일상 이야기를 마음껏 나눠보세요!', tabId: 'tab-free' }
+        return { title: '질문 있어요', description: '궁금한 점을 질문해보세요!', tabId: 'tab-question' }
     }
   }
   const { title: headerTitle, description: headerDescription } = getHeaderContent()

--- a/src/pages/community/CommunityPage.tsx
+++ b/src/pages/community/CommunityPage.tsx
@@ -6,7 +6,7 @@ import { SearchBar } from '@src/components/header/components/SearchBar'
 import { SelectDropdown } from '@src/components/commons/select/SelectDropdown'
 import { ROUTES } from '@src/constants/routes'
 import { useInfiniteQuery } from '@tanstack/react-query'
-import { fetchFreeCommunity, fetchInfoCommunity, fetchQuestionCommunity } from '@src/api/community'
+import { fetchInfoCommunity, fetchQuestionCommunity } from '@src/api/community'
 import { UserRound, Clock, MessageSquare, Eye, Dot, Plus, MessageSquareText } from 'lucide-react'
 import { LoadMoreButton } from '@src/components/commons/button/LoadMoreButton'
 import { getTimeAgo } from '@src/utils/getTimeAgo'
@@ -21,7 +21,7 @@ import { EmptyState } from '@src/components/EmptyState'
 export default function CommunityPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const tabParam = searchParams.get('tab') as CommunityTabId | null
-  const initialTab = tabParam === 'tab-question' ? 'tab-question' : tabParam === 'tab-info' ? 'tab-info' : 'tab-free'
+  const initialTab = tabParam === 'tab-question' ? 'tab-question' : 'tab-info'
   const isMd = useMediaQuery('(min-width: 768px)')
   const { isCollapsed: isFilterCollapsed } = useScrollDirection()
 
@@ -68,22 +68,6 @@ export default function CommunityPage() {
     setSelectedSearchType(searchTypeItem.label)
   }
 
-  // 자유게시판
-  const {
-    data: freeData,
-    fetchNextPage: fetchNextFree,
-    hasNextPage: hasNextFree,
-    isFetchingNextPage: isFetchingNextFree,
-    isLoading: isLoadingFree,
-    error: errorFree,
-  } = useInfiniteQuery({
-    queryKey: ['community', 'free', searchType, currentKeyword, sortBy],
-    queryFn: ({ pageParam }) => fetchFreeCommunity(pageParam, 10, searchType, currentKeyword, sortBy),
-    getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.page + 1 : undefined),
-    initialPageParam: 0,
-    enabled: activeCommunityTypeTab === 'tab-free',
-  })
-
   // 질문 게시판
   const {
     data: questionData,
@@ -117,18 +101,15 @@ export default function CommunityPage() {
   })
 
   // 현재 탭에 맞는 로딩/에러 상태 선택
-  const currentData = activeCommunityTypeTab === 'tab-free' ? freeData : activeCommunityTypeTab === 'tab-question' ? questionData : infoData
+  const currentData = activeCommunityTypeTab === 'tab-question' ? questionData : infoData
 
-  const isLoading =
-    activeCommunityTypeTab === 'tab-free' ? isLoadingFree : activeCommunityTypeTab === 'tab-question' ? isLoadingQuestion : isLoadingInfo
+  const isLoading = activeCommunityTypeTab === 'tab-question' ? isLoadingQuestion : isLoadingInfo
 
-  const error = activeCommunityTypeTab === 'tab-free' ? errorFree : activeCommunityTypeTab === 'tab-question' ? errorQuestion : errorInfo
+  const error = activeCommunityTypeTab === 'tab-question' ? errorQuestion : errorInfo
 
   // 현재 탭에 맞는 데이터 선택
   const communityPosts = (() => {
     switch (activeCommunityTypeTab) {
-      case 'tab-free':
-        return freeData?.pages.flatMap((page) => page.content) ?? []
       case 'tab-question':
         return questionData?.pages.flatMap((page) => page.content) ?? []
       case 'tab-info':
@@ -139,17 +120,11 @@ export default function CommunityPage() {
   })()
 
   // 현재 탭에 맞는 페이지네이션 함수/상태
-  const fetchNextPage =
-    activeCommunityTypeTab === 'tab-free' ? fetchNextFree : activeCommunityTypeTab === 'tab-question' ? fetchNextQuestion : fetchNextInfo
+  const fetchNextPage = activeCommunityTypeTab === 'tab-question' ? fetchNextQuestion : fetchNextInfo
 
-  const hasNextPage = activeCommunityTypeTab === 'tab-free' ? hasNextFree : activeCommunityTypeTab === 'tab-question' ? hasNextQuestion : hasNextInfo
+  const hasNextPage = activeCommunityTypeTab === 'tab-question' ? hasNextQuestion : hasNextInfo
 
-  const isFetchingNextPage =
-    activeCommunityTypeTab === 'tab-free'
-      ? isFetchingNextFree
-      : activeCommunityTypeTab === 'tab-question'
-        ? isFetchingNextQuestion
-        : isFetchingNextInfo
+  const isFetchingNextPage = activeCommunityTypeTab === 'tab-question' ? isFetchingNextQuestion : isFetchingNextInfo
 
   // const { title: headerTitle, description: headerDescription } = getHeaderContent()
   const { isLogin } = useUserStore()
@@ -245,7 +220,11 @@ export default function CommunityPage() {
               <div className="flex items-center justify-between">
                 <CommunityTabs tabs={COMMUNITY_TABS} activeTab={activeCommunityTypeTab} onTabChange={handleTabChange} ariaLabel="커뮤니티 타입" />
                 {isLogin() && (
-                  <Link to={`${ROUTES.COMMUNITY_POST}?tab=${activeCommunityTypeTab}`} type="button" className="bg-primary-300 rounded-lg px-3 py-2 text-white">
+                  <Link
+                    to={`${ROUTES.COMMUNITY_POST}?tab=${activeCommunityTypeTab}`}
+                    type="button"
+                    className="bg-primary-300 rounded-lg px-3 py-2 text-white"
+                  >
                     글쓰기
                   </Link>
                 )}

--- a/src/pages/community/components/CommunityPostForm.tsx
+++ b/src/pages/community/components/CommunityPostForm.tsx
@@ -55,7 +55,7 @@ export default function CommunityPostForm() {
   const isEditMode = !!id
   const { user, setRedirectUrl } = useUserStore()
   const [searchParams] = useSearchParams()
-  const initialBoardType = searchParams.get('tab') === 'tab-question' ? 'QUESTION' : searchParams.get('tab') === 'tab-info' ? 'INFO' : 'FREE'
+  const initialBoardType = searchParams.get('tab') === 'tab-question' ? 'QUESTION' : 'INFO'
   const [showDraftModal, setShowDraftModal] = useState(false)
   const [isDraftChecked, setIsDraftChecked] = useState(false)
 
@@ -223,7 +223,7 @@ export default function CommunityPostForm() {
                           value: category.code,
                           label: category.label,
                         }))}
-                        placeholder="자유게시판"
+                        placeholder="질문 있어요"
                         optionClassName="text-base"
                         buttonClassName="border-gray-400 bg-white border text-gray-900 px-3 py-3 border text-base"
                       />


### PR DESCRIPTION
## 📌 개요

- 서비스 방향성에 따라 커뮤니티 탭을 '질문있어요', '정보공유' 2개로 운영하기로 결정
- 자유게시판 관련 코드 전체 제거

## 🔧 작업 내용

- [x] constants.ts - COMMUNITY_TABS에서 tab-free 제거
- [x] CommunityPage.tsx - 자유게시판 관련 useInfiniteQuery 및 렌더링 로직 제거
- [x] CommunityPostForm.tsx - placeholder 텍스트 수정
- [x] CommunityDetail.tsx - 자유게시판 관련 코드 제거
- [x] MobileNavigation.tsx - 자유게시판 네비게이션 링크 제거
- [x] Footer.tsx - 자유게시판 푸터 링크 제거
- [x] community.ts - fetchFreeCommunity 함수 제거

## 📎 관련 이슈

Closes #566

## 💬 리뷰어 참고 사항

- 커뮤니티 탭이 '질문있어요', '정보공유' 2개로 정리됨
- 불필요한 코드 제거로 유지보수성 향상