### PR TITLE
refactor: 헤더 반응형 breakpoint xl(1280px)로 변경(#568)

### DIFF
--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -21,12 +21,12 @@ export default function Logo({ logoClassname, textClassname, onClick }: LogoProp
   }
 
   return (
-    <Link to={ROUTES.HOME} onClick={handleLogoClick} className="flex items-center gap-2 md:mr-5">
-      <div className={cn('h-11 w-auto object-contain md:h-16', logoClassname)}>
+    <Link to={ROUTES.HOME} onClick={handleLogoClick} className="flex items-center gap-2 xl:mr-5">
+      <div className={cn('h-11 w-auto object-contain', logoClassname)}>
         <img src={CuddleMarketLogo} alt="CuddleMarket 로고" className="h-full w-full object-cover" />
       </div>
 
-      <p className={cn('logo flex flex-col text-xl leading-none text-white md:text-2xl', textClassname)}>
+      <p className={cn('logo flex flex-col text-xl leading-none text-white', textClassname)}>
         <span>CUDDLE</span>
         <span>MARKET</span>
       </p>

--- a/src/components/commons/Input.tsx
+++ b/src/components/commons/Input.tsx
@@ -67,7 +67,7 @@ export function Input({
       />
       {suffix && <span className="absolute top-1/2 right-3 -translate-y-1/2 text-sm text-gray-500">{suffix}</span>}
       {value && onClear && (
-        <button onClick={onClear} type="button" className="mr-2 rounded-full bg-gray-300 p-0.5">
+        <button onClick={onClear} type="button" className="mr-2 cursor-pointer rounded-full bg-gray-300 p-0.5">
           <X size={14} />
         </button>
       )}

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -17,7 +17,7 @@ interface HeaderProps {
 }
 
 function Header({ hideSearchBar = false, hideMenuButton = false }: HeaderProps) {
-  const isMd = useMediaQuery('(min-width: 768px)')
+  const isXl = useMediaQuery('(min-width: 1280px)')
   const [isSideOpen, setIsSideOpen] = useState(false)
   const [isSearchOpen, setIsSearchOpen] = useState(false)
   const searchBarRef = useRef<HTMLDivElement>(null)
@@ -29,20 +29,34 @@ function Header({ hideSearchBar = false, hideMenuButton = false }: HeaderProps) 
     }
   }, [])
 
+  // 헤더 높이를 CSS 변수로 설정 (검색바 열림/닫힘에 따라)
+  useEffect(() => {
+    // 기본 헤더 높이: pt-3(12px) + h-12(48px) + pb-3(12px) = 72px
+    // 검색바 열림 시: 72px + marginTop(12px) + searchBarHeight + marginBottom(12px)
+    const baseHeight = 72
+    const expandedHeight = baseHeight + 12 + searchBarHeight + 12
+
+    if (!isXl && isSearchOpen) {
+      document.documentElement.style.setProperty('--header-height', `${expandedHeight}px`)
+    } else {
+      document.documentElement.style.setProperty('--header-height', `${baseHeight}px`)
+    }
+  }, [isSearchOpen, searchBarHeight, isXl])
+
   return (
     <>
       <header
         className={cn(
-          'bg-primary-200 fixed top-0 flex w-full items-center justify-center py-3',
-          hideSearchBar ? 'h-16 md:h-24' : 'h-auto pb-0 md:h-24',
+          'bg-primary-200 fixed top-0 flex w-full items-center justify-center pt-3 xl:pb-3',
+          !isXl && (isSearchOpen ? 'pb-0' : 'pb-3'),
           `${Z_INDEX.HEADER}`
         )}
       >
-        <div className="flex w-full flex-col px-4 md:block md:max-w-7xl md:gap-3 md:px-3.5">
-          <div className="flex items-center justify-between gap-4">
+        <div className="flex w-full flex-col px-4 xl:block xl:max-w-7xl xl:gap-3 xl:px-3.5">
+          <div className="flex h-12 items-center justify-between gap-4">
             <div className="flex items-center gap-8">
               <Logo />
-              {isMd && (
+              {isXl && (
                 <>
                   <NavLink
                     to={ROUTES.HOME}
@@ -59,10 +73,10 @@ function Header({ hideSearchBar = false, hideMenuButton = false }: HeaderProps) 
                 </>
               )}
             </div>
-            <div className="flex items-center gap-1 md:gap-8">
-              {!hideSearchBar && <SearchBar className="hidden md:block" />}
+            <div className="flex items-center gap-1 xl:gap-8">
+              {!hideSearchBar && <SearchBar className="hidden xl:block" />}
               {/* 모바일 검색 아이콘 */}
-              {!hideSearchBar && !isMd && (
+              {!hideSearchBar && !isXl && (
                 <IconButton aria-label="검색" onClick={() => setIsSearchOpen(!isSearchOpen)}>
                   <Search className="text-white" />
                 </IconButton>
@@ -74,13 +88,14 @@ function Header({ hideSearchBar = false, hideMenuButton = false }: HeaderProps) 
           {!hideSearchBar && (
             <div
               ref={searchBarRef}
-              className="mt-3 overflow-hidden transition-[height] duration-300 md:hidden"
+              className="overflow-hidden transition-all duration-300 xl:hidden"
               style={{
                 height: isSearchOpen ? `${searchBarHeight}px` : '0',
+                marginTop: isSearchOpen ? '12px' : '0',
                 marginBottom: isSearchOpen ? '12px' : '0',
               }}
             >
-              <SearchBar className="h-8 md:hidden" inputClass="py-1 text-sm" />
+              <SearchBar className="h-8 xl:hidden" inputClass="py-1 text-sm" />
             </div>
           )}
         </div>

--- a/src/components/header/components/UserControls.tsx
+++ b/src/components/header/components/UserControls.tsx
@@ -33,7 +33,7 @@ export default function UserControls({ isSideOpen, setIsSideOpen, hideMenuButton
   })
 
   return (
-    <div className="flex items-center gap-2 md:gap-4">
+    <div className="flex items-center gap-2 xl:gap-4">
       {isLogin() ? (
         <div className="flex items-center gap-1">
           <Link to={ROUTES.CHAT} className="ml-1">

--- a/src/components/header/components/user-section/AuthMenu.tsx
+++ b/src/components/header/components/user-section/AuthMenu.tsx
@@ -11,13 +11,13 @@ interface AuthMenuProps {
 }
 
 export default function AuthMenu({ isSideOpen, setIsSideOpen, hideMenuButton = false }: AuthMenuProps) {
-  const isMd = useMediaQuery('(min-width: 768px)')
-  return isMd ? (
+  const isXl = useMediaQuery('(min-width: 1280px)')
+  return isXl ? (
     <div className="flex items-center gap-5">
       <Link to={ROUTES.LOGIN} className="font-bold text-white">
         로그인
       </Link>
-      <Link to={ROUTES.SIGNUP} className="rounded-lg bg-white px-2 py-1 md:px-4 md:py-2">
+      <Link to={ROUTES.SIGNUP} className="rounded-lg bg-white px-2 py-1 xl:px-4 xl:py-2">
         회원가입
       </Link>
     </div>

--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -43,7 +43,7 @@ function ProductCard({ data, 'data-index': dataIndex }: ProductCardProps) {
 
   return (
     <Link
-      className="border-border bg-bg text-text-primary flex cursor-pointer flex-row-reverse overflow-hidden rounded-xl border shadow-md transition-shadow duration-200 hover:shadow-xl md:flex-col-reverse"
+      className="border-border text-text-primary flex cursor-pointer flex-row-reverse overflow-hidden rounded-xl border bg-white shadow-md transition-shadow duration-200 hover:shadow-xl md:flex-col-reverse"
       onClick={handleCardClick}
       data-index={dataIndex}
       aria-label={`${title}, ${price}원, ${productStatusName}, ${petTypeName}, ${productTradeName}`}

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -3,7 +3,6 @@ import Header from '@components/header/Header'
 import { Outlet, useLocation } from 'react-router-dom'
 import { useMediaQuery } from '@src/hooks/useMediaQuery'
 import { ROUTES } from '@src/constants/routes'
-import { cn } from '@src/utils/cn'
 
 // Header 숨김 패턴 (모바일에서만 숨김)
 const HIDE_HEADER_MOBILE_PATTERNS = [/^\/community\/\d+$/, /^\/community\/\d+\/edit$/, new RegExp(`^${ROUTES.COMMUNITY_POST}$`)]
@@ -33,13 +32,13 @@ const HIDE_SEARCHBAR_MOBILE_PATTERNS = [/^\/user-profile\/\d+$/]
 const HIDE_SEARCHBAR_ALWAYS_PATTERNS = [/^\/community\/\d+$/, /^\/community\/\d+\/edit$/, /^\/products\/\d+\/edit$/, /^\/chat\/\d+$/]
 
 export default function MainLayout() {
-  const isMd = useMediaQuery('(min-width: 768px)')
+  const isXl = useMediaQuery('(min-width: 1280px)')
   const { pathname } = useLocation()
 
-  const hideHeaderMobile = !isMd && HIDE_HEADER_MOBILE_PATTERNS.some((pattern) => pattern.test(pathname))
+  const hideHeaderMobile = !isXl && HIDE_HEADER_MOBILE_PATTERNS.some((pattern) => pattern.test(pathname))
   const showHeader = !hideHeaderMobile
   const hideSearchBarMobile =
-    !isMd && (HIDE_SEARCHBAR_MOBILE_PATHS.includes(pathname) || HIDE_SEARCHBAR_MOBILE_PATTERNS.some((pattern) => pattern.test(pathname)))
+    !isXl && (HIDE_SEARCHBAR_MOBILE_PATHS.includes(pathname) || HIDE_SEARCHBAR_MOBILE_PATTERNS.some((pattern) => pattern.test(pathname)))
   const hideSearchBarAlways =
     HIDE_SEARCHBAR_ALWAYS_PATHS.includes(pathname) || HIDE_SEARCHBAR_ALWAYS_PATTERNS.some((pattern) => pattern.test(pathname))
   const hideSearchBar = hideSearchBarMobile || hideSearchBarAlways
@@ -48,7 +47,10 @@ export default function MainLayout() {
     <div className="flex min-h-screen flex-col">
       {showHeader && <Header hideSearchBar={hideSearchBar} hideMenuButton={hideMenuButton} />}
       {/* <ChatFloatButton /> */}
-      <main className={cn('w-full flex-1', showHeader ? 'pt-16 md:pt-24' : 'pt-0')}>
+      <main
+        className="w-full flex-1 transition-[padding-top] duration-300"
+        style={{ paddingTop: showHeader ? 'var(--header-height, 72px)' : '0' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -229,7 +229,7 @@ function Home() {
 
   return (
     <>
-      <div className="bg-bg pb-4xl pt-8">
+      <div className="pb-4xl bg-white pt-6">
         <div className="px-lg mx-auto max-w-7xl">
           <div className="flex flex-col gap-12">
             <div className="flex flex-col gap-7">

--- a/src/pages/home/components/tab/ProductPetTypeTabs.tsx
+++ b/src/pages/home/components/tab/ProductPetTypeTabs.tsx
@@ -44,8 +44,8 @@ export function ProductPetTypeTabs({ activeTab, onTabChange }: ProductPetTypeTab
             type="button"
             onClick={() => onTabChange(tab.id)}
             className={cn(
-              'bg-primary-100 flex-1 cursor-pointer rounded-full text-base whitespace-nowrap md:rounded-2xl md:bg-white md:whitespace-normal',
-              activeTab === tab.id ? 'bg-primary-500 md:bg-primary-300 font-bold text-white' : 'hover:bg-primary-100 text-gray-900'
+              'bg-primary-100 flex-1 cursor-pointer rounded-full text-base whitespace-nowrap xl:rounded-2xl xl:bg-white xl:whitespace-normal',
+              activeTab === tab.id ? 'bg-primary-500 xl:bg-primary-300 font-bold text-white' : 'hover:bg-primary-100 text-gray-900'
             )}
             role="tab"
             aria-selected={activeTab === tab.id}

--- a/src/pages/product-detail/ProductDetail.tsx
+++ b/src/pages/product-detail/ProductDetail.tsx
@@ -48,7 +48,7 @@ function ProductDetail() {
 
   return (
     <>
-      <div className="px-lg bg-bg pb-4xl mx-auto max-w-7xl pt-8">
+      <div className="px-lg pb-4xl mx-auto max-w-7xl bg-white pt-8">
         <div className="flex flex-col gap-20">
           <div className="flex flex-col justify-center gap-8 md:flex-row">
             <div className="flex flex-1 flex-col gap-4">


### PR DESCRIPTION
## 📌 개요

- 헤더 반응형 breakpoint를 md(768px)에서 xl(1280px)로 변경하여 태블릿 환경 지원 개선
- iPad 6 landscape 모드(1024px)에서 헤더 레이아웃 깨짐 문제 해결

## 🔧 작업 내용

- [x] 헤더 컴포넌트 breakpoint md → xl 변경
- [x] 모바일/태블릿 SearchBar 아코디언 방식으로 변경
- [x] CSS 변수(--header-height)를 통한 동적 헤더 높이 관리
- [x] 검색바 열림/닫힘 시 main 콘텐츠 padding 자동 조정

## 📎 관련 이슈

Closes #568

## 💬 리뷰어 참고 사항

- 1280px 미만에서는 모바일/태블릿 UI 표시
- 검색바 아코디언 열림 시 main 요소의 padding-top이 동적으로 조정됨