### PR TITLE
refactor: ProductList 반응형 그리드 및 IconButton 스타일 개선(#570)

### DIFF
--- a/src/components/commons/button/IconButton.tsx
+++ b/src/components/commons/button/IconButton.tsx
@@ -15,12 +15,7 @@ const sizeStyles = {
 
 export function IconButton({ children, onClick, size = 'md', className, type = 'button', ...rest }: IconButtonProps) {
   return (
-    <button
-      type={type}
-      onClick={onClick}
-      className={cn('cursor-pointer rounded hover:bg-gray-100', sizeStyles[size], className)}
-      {...rest}
-    >
+    <button type={type} onClick={onClick} className={cn('cursor-pointer rounded', sizeStyles[size], className)} {...rest}>
       {children}
     </button>
   )

--- a/src/components/product/ProductList.tsx
+++ b/src/components/product/ProductList.tsx
@@ -24,7 +24,7 @@ export default function ProductList({ products, showMoreButton = false, sellerId
     navigate(`/user-profile/${sellerId}`)
   }
   return (
-    <ul className={cn('grid grid-cols-1 gap-4 md:grid-cols-4', showMoreButton && sellerId && 'items-center')}>
+    <ul className={cn('grid grid-cols-1 gap-4 md:grid-cols-3 lg:grid-cols-4', showMoreButton && sellerId && 'items-center')}>
       {products.map((product, index) => (
         <li key={product.id}>
           <ProductCard data-index={index} data={product} />
@@ -34,7 +34,7 @@ export default function ProductList({ products, showMoreButton = false, sellerId
         <button
           type="button"
           onClick={() => goToUserPage(sellerId)}
-          className="bg-primary-300 h-fit w-fit cursor-pointer rounded-full px-4 py-5 font-bold text-white"
+          className="bg-primary-300 h-fit w-full cursor-pointer rounded-lg px-4 py-2.5 font-bold text-white md:w-fit md:rounded-full md:py-5"
         >
           더보기
         </button>


### PR DESCRIPTION
## 📌 개요

- ProductList 반응형 그리드 개선 및 IconButton hover 스타일 제거

## 🔧 작업 내용

- [x] ProductList 그리드 md:3열, lg:4열로 변경
- [x] 더보기 버튼 모바일 스타일 개선 (전체 너비, 둥근 모서리)
- [x] IconButton hover:bg-gray-100 제거

## 📎 관련 이슈

Closes #570

## 💬 리뷰어 참고 사항

- 태블릿(768px~1023px)에서 3열, 데스크톱(1024px~)에서 4열 표시