### PR TITLE
fix: 신고 모달 이미지 업로드 후 버튼 비활성화 버그 수정(#576)

### DIFF
--- a/src/components/modal/ReportModalBase.tsx
+++ b/src/components/modal/ReportModalBase.tsx
@@ -56,6 +56,10 @@ export default function ReportModalBase({ isOpen, heading, description, reasons,
 
   const titleLength = watch('detailReason')?.length ?? 0
 
+  // 디버깅용
+  console.log('🔍 ReportModal - isValid:', isValid)
+  console.log('🔍 ReportModal - errors:', errors)
+
   const handleCancel = () => {
     reset()
     onCancel()
@@ -125,7 +129,7 @@ export default function ReportModalBase({ isOpen, heading, description, reasons,
                 setError={setError}
                 clearErrors={clearErrors}
                 mainImageField="imageFiles"
-                heading="신고 이미지 첨부 (선택항목)"
+                heading="신고 이미지 첨부 (선택항목/최대 3장)"
                 showSection={false}
                 maxFiles={3}
                 className="gap-1"

--- a/src/pages/product-post/components/imageUploadField/components/DropzoneArea.tsx
+++ b/src/pages/product-post/components/imageUploadField/components/DropzoneArea.tsx
@@ -39,13 +39,22 @@ export default function DropzoneArea<T extends FieldValues>({
 
   const { getRootProps, getInputProps } = useDropzone({
     accept: { 'image/*': ['.jpg', '.jpeg', '.png', '.webp'] },
-    maxFiles: maxFiles,
+    // maxFiles 옵션 제거 - 직접 검증으로 대체 (react-dropzone의 maxFiles는 누적 카운트 문제 발생)
     maxSize: 5 * 1024 * 1024,
     onDrop: async (acceptedFiles, rejectedFiles) => {
+      console.log('🔍 onDrop 시작')
+      console.log('🔍 acceptedFiles:', acceptedFiles.length, '개')
+      console.log('🔍 rejectedFiles:', rejectedFiles.length, '개')
+      console.log('🔍 현재 previewUrls:', previewUrls.length, '개')
+
       clearErrors(mainImageField)
+      console.log('🔍 clearErrors 호출됨')
 
       const totalCount = previewUrls.length + acceptedFiles.length
+      console.log('🔍 totalCount:', totalCount, 'maxFiles:', maxFiles)
+
       if (totalCount > maxFiles) {
+        console.log('🔍 maxFiles 초과 - 에러 설정')
         setError(mainImageField, { type: 'manual', message: getTooManyFilesError(maxFiles) })
         return
       }
@@ -70,12 +79,13 @@ export default function DropzoneArea<T extends FieldValues>({
         const allUrls = [...previewUrls, ...newUrls]
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        setValue(mainImageField, allUrls[0] as any)
+        setValue(mainImageField, allUrls as any, { shouldValidate: true })
         if (subImagesField) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           setValue(subImagesField, allUrls.slice(1) as any)
         }
         setPreviewUrls(allUrls)
+        console.log('🔍 업로드 성공 - setValue with shouldValidate 호출됨')
       } catch {
         setError(mainImageField, {
           type: 'manual',


### PR DESCRIPTION
## 📌 개요

- 신고 모달에서 이미지 업로드 후 제출 버튼이 비활성화 상태로 유지되는 버그 수정

## 🔧 작업 내용

- [x] `DropzoneArea.tsx`: `setValue` 호출 시 `{ shouldValidate: true }` 옵션 추가하여 폼 유효성 검사 트리거
- [x] `DropzoneArea.tsx`: `react-dropzone`의 `maxFiles` 옵션 제거 → 직접 검증으로 대체 (누적 카운트 문제 해결)
- [x] `ReportModalBase.tsx`: heading 텍스트 "(선택항목)" → "(선택항목/최대 3장)"으로 변경
- [x] 디버깅용 console.log 추가 (확인 후 제거 예정)

## 📎 관련 이슈

Closes #576

## 💬 리뷰어 참고 사항

- `react-hook-form`의 `isValid` 상태가 이미지 업로드 후에도 갱신되지 않던 문제는 `shouldValidate: true` 옵션으로 해결
- `react-dropzone`의 `maxFiles` 옵션은 세션 내 누적 카운트 문제가 있어 직접 검증으로 대체
- 디버깅 로그는 버그 확인 후 별도 커밋으로 제거 예정