### PR TITLE
feat: 프로필 수정 페이지 회원탈퇴 기능 및 birthDate 전송 추가(#580)

### DIFF
--- a/src/components/profile/ProfileData.tsx
+++ b/src/components/profile/ProfileData.tsx
@@ -1,11 +1,12 @@
 import { Link, useLocation } from 'react-router-dom'
-import { MapPin, Calendar, Settings, Flag, Ban, LockOpen, ShieldAlert } from 'lucide-react'
+import { MapPin, Calendar, Settings, Flag, Ban, LockOpen, ShieldAlert, Route } from 'lucide-react'
 import { ProductMetaItem } from '@src/components/product/ProductMetaItem'
 import { type Dispatch, type SetStateAction } from 'react'
 import { formatJoinDate } from '@src/utils/formatJoinDate'
 import { Button } from '@src/components/commons/button/Button'
 import { ROUTES } from '@src/constants/routes'
 import { useMediaQuery } from '@src/hooks/useMediaQuery'
+import { useUserStore } from '@src/store/userStore'
 
 export interface MyPageData {
   id: number
@@ -40,11 +41,19 @@ export default function ProfileData({
   isMyProfile,
   unblockUser,
 }: ProfileDataProps) {
+  const user = useUserStore((state) => state.user)
   const isMd = useMediaQuery('(min-width: 768px)')
   const { pathname } = useLocation()
   const isProfileEditPage = /^\/profile-update$/.test(pathname)
-
   const formattedJoinDate = data?.createdAt ? formatJoinDate(data.createdAt) : ''
+
+  const getProvider = (email: string | undefined) => {
+    if (email?.includes('gmail')) return 'google'
+    if (email?.includes('kakao')) return 'kakao'
+    return '이메일' // 일반 회원
+  }
+
+  const provider = getProvider(user?.email)
 
   return (
     <section className="flex h-fit flex-col rounded-none border-b border-gray-200 px-5 py-0 pt-5 md:max-w-72 md:min-w-72 md:rounded-xl md:border md:py-5">
@@ -82,6 +91,7 @@ export default function ProfileData({
                   <div className="flex flex-col gap-2.5">
                     <ProductMetaItem icon={MapPin} iconSize={17} label={`${data?.addressSido} ${data?.addressGugun}`} className="gap-2" />
                     <ProductMetaItem icon={Calendar} iconSize={17} label={`가입일: ${formattedJoinDate}`} className="gap-2" />
+                    <ProductMetaItem icon={Route} iconSize={17} label={`가입 경로: ${provider}`} className="gap-2" />
                   </div>
                 )}
                 {!isProfileEditPage && (
@@ -94,15 +104,13 @@ export default function ProfileData({
                   </Link>
                 )}
               </div>
-              {!isProfileEditPage && (
-                <button
-                  type="button"
-                  className="w-full cursor-pointer rounded-lg border-gray-300 pb-5 text-right text-sm text-gray-500 hover:underline md:border-t md:pt-6 md:pb-0 md:text-left"
-                  onClick={() => setIsWithdrawModalOpen?.(true)}
-                >
-                  회원탈퇴
-                </button>
-              )}
+              <button
+                type="button"
+                className="w-full cursor-pointer border-gray-300 pb-5 text-right text-sm text-gray-500 hover:underline md:border-t md:pt-6 md:pb-0 md:text-left"
+                onClick={() => setIsWithdrawModalOpen?.(true)}
+              >
+                회원탈퇴
+              </button>
             </>
           )}
 

--- a/src/pages/profile-update/components/ProfileUpdateBaseForm.tsx
+++ b/src/pages/profile-update/components/ProfileUpdateBaseForm.tsx
@@ -21,6 +21,7 @@ import InlineNotification from '@src/components/commons/InlineNotification'
 
 export interface ProfileUpdateBaseFormValues {
   nickname: string
+  birthDate: string
   profileImageUrl: string
   introduction: string
   addressSido: Province | ''
@@ -50,6 +51,7 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
     mode: 'onChange',
     defaultValues: {
       nickname: '',
+      birthDate: '',
       profileImageUrl: '',
       introduction: '',
       addressSido: '',
@@ -140,6 +142,7 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
   const onSubmit = async (data: ProfileUpdateBaseFormValues) => {
     const isUnchanged =
       data.nickname === myData?.nickname &&
+      data.birthDate === myData?.birthDate &&
       data.profileImageUrl === myData?.profileImageUrl &&
       data.introduction === myData?.introduction &&
       data.addressSido === myData?.addressSido &&
@@ -184,6 +187,7 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
       setPreviewUrl(myData.profileImageUrl || '')
       reset({
         nickname: myData.nickname || '',
+        birthDate: myData.birthDate || '',
         profileImageUrl: myData.profileImageUrl || '',
         introduction: myData.introduction || '',
         addressSido: (myData.addressSido as Province) || '',

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -61,6 +61,7 @@ export interface MyBlockedUsersResponse {
 // ========== 프로필 수정 요청 타입 ==========
 export interface ProfileUpdateRequestData {
   nickname?: string
+  birthDate?: string
   addressSido?: string
   addressGugun?: string
   profileImageUrl?: string


### PR DESCRIPTION
## 📌 개요

- 프로필 수정 페이지에서 회원탈퇴 기능 사용 가능하도록 수정
- 프로필 수정 시 birthDate가 API에 전송되도록 수정

## 🔧 작업 내용

- [x] ProfileData.tsx: 프로필 수정 페이지에서도 회원탈퇴 버튼 표시 (isProfileEditPage 조건 제거)
- [x] ProfileUpdate.tsx: 회원탈퇴 모달 및 핸들러 추가
- [x] ProfileUpdateBaseForm.tsx: birthDate 필드 추가 (폼 데이터에 포함)
- [x] types/user.ts: ProfileUpdateRequestData에 birthDate 타입 추가

## 📎 관련 이슈

Closes #580

## 💬 리뷰어 참고 사항

- 기존 마이페이지의 회원탈퇴 로직을 프로필 수정 페이지에서도 재사용
- birthDate는 변경 불가 필드지만, API 요청 시 함께 전송되어야 함