### PR TITLE
refactor: 이미지 업로드 시 클라이언트 압축 적용(#588)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@tailwindcss/vite": "^4.1.11",
         "@tanstack/react-query": "^5.90.10",
         "axios": "^1.13.2",
+        "browser-image-compression": "^2.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -2640,6 +2641,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
       }
     },
     "node_modules/browserslist": {
@@ -8007,6 +8017,12 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
+      "license": "MIT"
     },
     "node_modules/vfile": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tailwindcss/vite": "^4.1.11",
     "@tanstack/react-query": "^5.90.10",
     "axios": "^1.13.2",
+    "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/src/pages/profile-update/components/ProfileUpdateBaseForm.tsx
+++ b/src/pages/profile-update/components/ProfileUpdateBaseForm.tsx
@@ -18,6 +18,7 @@ import { useMediaQuery } from '@src/hooks/useMediaQuery'
 import { Camera } from 'lucide-react'
 import { AnimatePresence } from 'framer-motion'
 import InlineNotification from '@src/components/commons/InlineNotification'
+import imageCompression from 'browser-image-compression'
 
 export interface ProfileUpdateBaseFormValues {
   nickname: string
@@ -78,6 +79,16 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
   const titleLength = watch('introduction')?.length ?? 0
   const nickname = watch('nickname')
 
+  const compressImage = async (file: File) => {
+    const options = {
+      maxSizeMB: 1, // 최대 1MB로 압축
+      maxWidthOrHeight: 1200, // 최대 1200px로 리사이징
+      useWebWorker: true, // 웹 워커 사용 (UI 블로킹 방지)
+      fileType: 'image/webp', // WebP 형식으로 변환
+    }
+    return await imageCompression(file, options)
+  }
+
   const handleNicknameCheck = async () => {
     try {
       const response = await checkNickname(nickname)
@@ -125,7 +136,8 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
     }
 
     try {
-      const uploadedUrl = await uploadImage([file])
+      const compressedFile = await compressImage(file)
+      const uploadedUrl = await uploadImage([compressedFile])
       setValue('profileImageUrl', uploadedUrl.mainImageUrl)
       setPreviewUrl(uploadedUrl.mainImageUrl)
     } catch {


### PR DESCRIPTION
## 📌 개요

- Lighthouse 성능 점수 개선을 위한 이미지 업로드 최적화
- 클라이언트에서 업로드 전 이미지를 압축/리사이징하여 전송 용량 대폭 감소

## 🔧 작업 내용

- [x] `browser-image-compression` 라이브러리 추가
- [x] 상품 등록 이미지 압축 적용 (DropzoneArea.tsx)
- [x] 프로필 이미지 압축 적용 (ProfileUpdateBaseForm.tsx)
- [x] 채팅 이미지 압축 적용 (ChattingPage.tsx)

### 압축 설정
- 최대 용량: 1MB
- 최대 크기: 1200px
- 출력 형식: WebP
- Web Worker 사용 (UI 블로킹 방지)

## 📎 관련 이슈

Closes #588

## 💬 리뷰어 참고 사항

- 기존 2267x3024px (~3.9MB) 이미지가 1200px, WebP로 압축되어 업로드됨
- 화면 표시 최대 크기가 ~1200px이므로 화질 저하 없음
- 예상 용량 절감: 약 90% 이상