### PR TITLE
refactor: Home 페이지 스켈레톤 UI 적용으로 CLS 개선(#590)

### DIFF
--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -15,6 +15,7 @@ import { useUserStore } from '@src/store/userStore'
 import { useMediaQuery } from '@src/hooks/useMediaQuery'
 import { useFilterStore } from '@src/store/filterStore'
 import { Z_INDEX } from '@src/constants/ui'
+import HomeSkeleton from './components/product-section/HomeSkeleton'
 
 function Home() {
   const { isLogin } = useUserStore()
@@ -205,15 +206,6 @@ function Home() {
     }
   }, [searchParams])
 
-  if (isLoading && !data) {
-    return (
-      <div className="px-lg py-md tablet:py-xl mx-auto max-w-7xl">
-        <div className="flex items-center justify-center py-20">
-          <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600" role="status" aria-label="상품 로딩 중"></div>
-        </div>
-      </div>
-    )
-  }
   if (error || !data) {
     return (
       <div className="flex min-h-screen items-center justify-center">
@@ -258,14 +250,26 @@ function Home() {
                 onTabChange={(tabId) => setActiveProductTypeTab(tabId as ProductTypeTabId)}
                 ariaLabel="상품 타입 분류"
               />
-              <ProductsSection
+              {/* <ProductsSection
                 products={allProducts}
                 totalElements={totalElements}
                 activeTab={activeProductTypeTab}
                 selectedSort={selectedSort as SORT_LABELS}
                 setSelectedSort={setSelectedSort}
                 // onSortChange={handleSortChange}
-              />
+              /> */}
+              {isLoading ? (
+                <HomeSkeleton />
+              ) : (
+                <ProductsSection
+                  products={allProducts}
+                  totalElements={totalElements}
+                  activeTab={activeProductTypeTab}
+                  selectedSort={selectedSort as SORT_LABELS}
+                  setSelectedSort={setSelectedSort}
+                  // onSortChange={handleSortChange}
+                />
+              )}
             </div>
           </div>
           {/* 무한 스크롤 감지용 요소 */}
@@ -278,7 +282,6 @@ function Home() {
           )}
         </div>
       </div>
-      {/* <ChatButton /> */}
       {isLoggedIn && (
         <div className={`fixed right-10 bottom-5 ${Z_INDEX.FLOATING_BUTTON}`}>
           <Button size={isMd ? 'lg' : 'md'} className="bg-primary-300 cursor-pointer text-white" icon={Plus} onClick={toGoProductPostPage}>

--- a/src/pages/home/components/product-section/HomeSkeleton.tsx
+++ b/src/pages/home/components/product-section/HomeSkeleton.tsx
@@ -1,0 +1,14 @@
+export default function HomeSkeleton() {
+  return (
+    // 상품 그리드 스켈레톤
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-3 lg:grid-cols-4">
+      {[...Array(8)].map((_, i) => (
+        <div key={i} className="animate-pulse">
+          <div className="aspect-square rounded-xl bg-gray-200" />
+          <div className="mt-2 h-4 w-3/4 rounded bg-gray-200" />
+          <div className="mt-1 h-4 w-1/2 rounded bg-gray-200" />
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## 📌 개요

- Lighthouse CLS(Cumulative Layout Shift) 개선
- 로딩 시 레이아웃 변경 방지를 위한 스켈레톤 UI 적용

## 🔧 작업 내용

- [x] HomeSkeleton 컴포넌트 생성
- [x] Home.tsx에서 로딩 시 전체 레이아웃 유지하도록 변경
- [x] 상품 목록 영역만 스켈레톤으로 대체 (필터는 즉시 렌더링)

## 📎 관련 이슈

- Close #590

## 💬 리뷰어 참고 사항

- 기존: 로딩 시 스피너만 표시 → 로딩 완료 후 전체 레이아웃 변경 (CLS 발생)
- 변경: 로딩 중에도 동일한 레이아웃 유지 → CLS 감소