### PR TITLE
fix: 상품 등록 시 mainImageUrl 배열 전송 버그 수정(#594)

### DIFF
--- a/src/pages/product-post/components/imageUploadField/components/DropzoneArea.tsx
+++ b/src/pages/product-post/components/imageUploadField/components/DropzoneArea.tsx
@@ -82,7 +82,7 @@ export default function DropzoneArea<T extends FieldValues>({
         const allUrls = [...previewUrls, ...newUrls]
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        setValue(mainImageField, allUrls as any, { shouldValidate: true })
+        setValue(mainImageField, allUrls[0] as any, { shouldValidate: true })
         if (subImagesField) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           setValue(subImagesField, allUrls.slice(1) as any)


### PR DESCRIPTION
## 📌 개요

- 상품 등록 시 `mainImageUrl`이 배열로 전송되는 버그 수정
- API 스펙에 맞게 단일 URL 문자열로 전송되도록 수정

## 🔧 작업 내용

- [x] `DropzoneArea.tsx`에서 `setValue(mainImageField, allUrls)` → `setValue(mainImageField, allUrls[0])`으로 수정

## 📎 관련 이슈

Closes #594

## 💬 리뷰어 참고 사항

- #576 커밋에서 `allUrls[0]` → `allUrls`로 변경되면서 발생한 버그
- 기존 코드로 복원하는 수정