### PR TITLE
chore: 이미지 압축 디버그 로그에 해상도 확인 추가(#600)

### DIFF
--- a/src/pages/product-post/components/imageUploadField/components/DropzoneArea.tsx
+++ b/src/pages/product-post/components/imageUploadField/components/DropzoneArea.tsx
@@ -38,18 +38,31 @@ export default function DropzoneArea<T extends FieldValues>({
 }: DropzoneAreaProps<T>) {
   const [previewUrls, setPreviewUrls] = useState<string[]>([])
 
+  const getImageDimensions = (file: File): Promise<{ width: number; height: number }> => {
+    return new Promise((resolve) => {
+      const img = new Image()
+      img.onload = () => {
+        resolve({ width: img.width, height: img.height })
+        URL.revokeObjectURL(img.src)
+      }
+      img.src = URL.createObjectURL(file)
+    })
+  }
+
   const compressImage = async (file: File) => {
-    console.log('압축 전:', file.name, file.size, file.type)
+    const beforeDim = await getImageDimensions(file)
+    console.log('압축 전:', file.name, file.size, file.type, `${beforeDim.width}x${beforeDim.height}`)
+
     const options = {
       maxSizeMB: 1, // 최대 1MB로 압축
       maxWidthOrHeight: 1200, // 최대 1200px로 리사이징
       useWebWorker: true, // 웹 워커 사용 (UI 블로킹 방지)
       fileType: 'image/webp' as const, // WebP 형식으로 변환
     }
-    // return await imageCompression(file, options)
     const compressed = await imageCompression(file, options)
 
-    console.log('압축 후:', compressed.name, compressed.size, compressed.type)
+    const afterDim = await getImageDimensions(compressed)
+    console.log('압축 후:', compressed.name, compressed.size, compressed.type, `${afterDim.width}x${afterDim.height}`)
     return compressed
   }
 


### PR DESCRIPTION
## 📌 개요

- 이미지 압축 시 해상도(dimension) 디버그 로그 추가
- Lighthouse 경고 원인 파악을 위한 디버깅 목적

## 🔧 작업 내용

- [x] `getImageDimensions` 함수 추가
- [x] 압축 전/후 width x height 로그 출력

## 📎 관련 이슈

Closes #600

## 💬 리뷰어 참고 사항

- 문제 원인 파악 후 해당 로그 코드 제거 예정
- Lighthouse 경고: 이미지 크기가 표시 크기보다 큼 (1708x1280 → 671x447)