### PR TITLE
refactor: 반응형 이미지(srcset/sizes) 적용으로 이미지 로딩 최적화(#608)

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,9 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
     <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <link rel="preconnect" href="https://df1xl13ui5mlo.cloudfront.net" crossorigin />
+    <link rel="preconnect" href="https://cmarket-api.duckdns.org" crossorigin />
     <link
       rel="stylesheet"
       as="style"
@@ -17,9 +20,6 @@
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css"
     />
     <link rel="preload" href="/assets/fonts/BMJUA.woff2" as="font" type="font/woff2" crossorigin />
-    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
-    <link rel="preconnect" href="https://df1xl13ui5mlo.cloudfront.net" crossorigin />
-    <link rel="preconnect" href="https://cmarket-api.duckdns.org" crossorigin />
 
     <script>
       window.global = window

--- a/src/components/commons/card/ChatProductCard.tsx
+++ b/src/components/commons/card/ChatProductCard.tsx
@@ -1,4 +1,5 @@
 import PlaceholderImage from '@assets/images/placeholder.webp'
+import { getImageSrcSet, IMAGE_SIZES, toResizedWebpUrl } from '@src/utils/imageUrl'
 import { formatPrice } from '@src/utils/formatPrice'
 
 interface ChatProductCardProps {
@@ -18,7 +19,9 @@ export function ChatProductCard({ productImageUrl, productTitle, productPrice, s
     <>
       <div className={`relative aspect-square shrink-0 overflow-hidden rounded-lg ${sizeClasses[size]}`}>
         <img
-          src={productImageUrl || PlaceholderImage}
+          src={productImageUrl ? toResizedWebpUrl(productImageUrl, 150) : PlaceholderImage}
+          srcSet={productImageUrl ? getImageSrcSet(productImageUrl) : undefined}
+          sizes={productImageUrl ? IMAGE_SIZES.tinyThumbnail : undefined}
           fetchPriority="high"
           loading="eager"
           alt={productTitle}

--- a/src/components/modal/DeleteConfirmModal.tsx
+++ b/src/components/modal/DeleteConfirmModal.tsx
@@ -1,4 +1,5 @@
 import PlaceholderImage from '@assets/images/placeholder.webp'
+import { getImageSrcSet, IMAGE_SIZES, toResizedWebpUrl } from '@src/utils/imageUrl'
 import { formatPrice } from '@src/utils/formatPrice'
 import { Button } from '../commons/button/Button'
 import AlertBox from './AlertBox'
@@ -42,7 +43,9 @@ function DeleteConfirmModal({ isOpen, product, onConfirm, onCancel, error, onCle
           <li className="flex gap-2.5 rounded-lg border border-gray-300 bg-gray-100/30 p-2.5">
             <div className="aspect-square w-16 shrink-0 overflow-hidden rounded-lg">
               <img
-                src={product.mainImageUrl || PlaceholderImage}
+                src={product.mainImageUrl ? toResizedWebpUrl(product.mainImageUrl, 150) : PlaceholderImage}
+                srcSet={product.mainImageUrl ? getImageSrcSet(product.mainImageUrl) : undefined}
+                sizes={product.mainImageUrl ? IMAGE_SIZES.tinyThumbnail : undefined}
                 alt={product.title}
                 fetchPriority="high"
                 loading="eager"

--- a/src/components/product/ProductListItem.tsx
+++ b/src/components/product/ProductListItem.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom'
 import PlaceholderImage from '@assets/images/placeholder.webp'
+import { getImageSrcSet, IMAGE_SIZES, toResizedWebpUrl } from '@src/utils/imageUrl'
 import { Badge } from '@src/components/commons/badge/Badge'
 import { ProductMetaItem } from './ProductMetaItem'
 import { ROUTES } from '@src/constants/routes'
@@ -26,7 +27,9 @@ export function ProductListItem({ product, children }: ProductListItemProps) {
       <Link to={ROUTES.DETAIL_ID(id)} className="flex w-full items-center justify-center gap-6 rounded-lg border border-gray-300 p-3.5">
         <div className="relative aspect-square w-32 shrink-0 overflow-hidden rounded-lg md:static md:w-[10%]">
           <img
-            src={mainImageUrl || PlaceholderImage}
+            src={mainImageUrl ? toResizedWebpUrl(mainImageUrl, 400) : PlaceholderImage}
+            srcSet={mainImageUrl ? getImageSrcSet(mainImageUrl) : undefined}
+            sizes={mainImageUrl ? IMAGE_SIZES.smallThumbnail : undefined}
             alt={title}
             fetchPriority="high"
             loading="eager"

--- a/src/components/product/components/ProductThumbnail.tsx
+++ b/src/components/product/components/ProductThumbnail.tsx
@@ -4,6 +4,7 @@ import { Heart } from 'lucide-react'
 import { Badge } from '@src/components/commons/badge/Badge'
 import PlaceholderImage from '@assets/images/placeholder.webp'
 import { cn } from '@src/utils/cn'
+import { getImageSrcSet, IMAGE_SIZES, toResizedWebpUrl } from '@src/utils/imageUrl'
 
 interface ProductThumbnailProps {
   imageUrl: string
@@ -58,8 +59,10 @@ export function ProductThumbnail({
       </div>
       <Badge className={cn('bottom-sm right-sm absolute z-1 text-white', productTradeColor)}>{displayTradeStatus}</Badge>
       <img
-        src={imageUrl || PlaceholderImage}
         alt={title}
+        src={imageUrl ? toResizedWebpUrl(imageUrl, 800) : PlaceholderImage}
+        srcSet={imageUrl ? getImageSrcSet(imageUrl) : undefined}
+        sizes={imageUrl ? IMAGE_SIZES.productThumbnail : undefined}
         fetchPriority={priority ? 'high' : 'auto'}
         loading={priority ? 'eager' : 'lazy'}
         className="t-0 l-0 absolute h-full w-full object-cover transition-all duration-300 ease-in-out group-hover:scale-105"

--- a/src/pages/chatting-page/ChattingPage.tsx
+++ b/src/pages/chatting-page/ChattingPage.tsx
@@ -112,7 +112,7 @@ export default function ChattingPage() {
   const compressImage = async (file: File) => {
     const options = {
       maxSizeMB: 1,
-      maxWidthOrHeight: 1200,
+      maxWidthOrHeight: 800, // 백엔드 최대 사이즈에 맞춤
       useWebWorker: true,
       fileType: 'image/webp' as const,
     }

--- a/src/pages/chatting-page/components/ChatLog.tsx
+++ b/src/pages/chatting-page/components/ChatLog.tsx
@@ -3,6 +3,7 @@ import { cn } from '@src/utils/cn'
 import { useUserStore } from '@src/store/userStore'
 import { useEffect, useRef } from 'react'
 import PlaceholderImage from '@assets/images/placeholder.webp'
+import { getImageSrcSet, IMAGE_SIZES, toResizedWebpUrl } from '@src/utils/imageUrl'
 import { AnimatePresence } from 'framer-motion'
 import InlineNotification from '@src/components/commons/InlineNotification'
 
@@ -164,7 +165,9 @@ export function ChatLog({
                   {message.messageType === 'IMAGE' ? (
                     <div className="relative aspect-square w-32 shrink-0 overflow-hidden rounded-lg md:static">
                       <img
-                        src={message.imageUrl || PlaceholderImage}
+                        src={message.imageUrl ? toResizedWebpUrl(message.imageUrl, 400) : PlaceholderImage}
+                        srcSet={message.imageUrl ? getImageSrcSet(message.imageUrl) : undefined}
+                        sizes={message.imageUrl ? IMAGE_SIZES.smallThumbnail : undefined}
                         alt={message.senderNickname}
                         fetchPriority="high"
                         loading="eager"

--- a/src/pages/my-page/components/MyList.tsx
+++ b/src/pages/my-page/components/MyList.tsx
@@ -1,4 +1,5 @@
 import PlaceholderImage from '@assets/images/placeholder.webp'
+import { getImageSrcSet, IMAGE_SIZES, toResizedWebpUrl } from '@src/utils/imageUrl'
 import { Badge } from '@src/components/commons/badge/Badge'
 import { SelectDropdown } from '@src/components/commons/select/SelectDropdown'
 import { STATUS_EN_TO_KO, type TransactionStatus, type MyPageTabId } from '@src/constants/constants'
@@ -95,7 +96,9 @@ export default function MyList({ id, title, price, mainImageUrl, tradeStatus, vi
       >
         <div className="relative aspect-square w-32 shrink-0 overflow-hidden rounded-lg md:static">
           <img
-            src={mainImageUrl || PlaceholderImage}
+            src={mainImageUrl ? toResizedWebpUrl(mainImageUrl, 400) : PlaceholderImage}
+            srcSet={mainImageUrl ? getImageSrcSet(mainImageUrl) : undefined}
+            sizes={mainImageUrl ? IMAGE_SIZES.smallThumbnail : undefined}
             alt={title}
             fetchPriority="high"
             loading="eager"

--- a/src/pages/product-detail/components/MainImage.tsx
+++ b/src/pages/product-detail/components/MainImage.tsx
@@ -1,4 +1,5 @@
 import PlaceholderImage from '@assets/images/placeholder.webp'
+import { getImageSrcSet, IMAGE_SIZES, toResizedWebpUrl } from '@src/utils/imageUrl'
 
 interface MainImageProps {
   mainImageUrl: string | null
@@ -9,7 +10,9 @@ export default function MainImage({ mainImageUrl, title }: MainImageProps) {
   return (
     <div className="relative overflow-hidden rounded-xl pb-[100%]">
       <img
-        src={mainImageUrl || PlaceholderImage}
+        src={mainImageUrl ? toResizedWebpUrl(mainImageUrl, 800) : PlaceholderImage}
+        srcSet={mainImageUrl ? getImageSrcSet(mainImageUrl) : undefined}
+        sizes={IMAGE_SIZES.mainImage}
         alt={title}
         fetchPriority="high"
         loading="eager"

--- a/src/pages/product-detail/components/SubImages.tsx
+++ b/src/pages/product-detail/components/SubImages.tsx
@@ -1,4 +1,5 @@
 import PlaceholderImage from '@assets/images/placeholder.webp'
+import { getImageSrcSet, IMAGE_SIZES, toResizedWebpUrl } from '@src/utils/imageUrl'
 
 interface SubImagesProps {
   mainImageUrl: string
@@ -14,7 +15,9 @@ export default function SubImages({ mainImageUrl, subImageUrls, title }: SubImag
         {subImageUrls.map((image, idx) => (
           <div key={idx} className="relative overflow-hidden rounded-lg bg-white pb-[100%]">
             <img
-              src={image || PlaceholderImage}
+              src={image ? toResizedWebpUrl(image, 400) : PlaceholderImage}
+              srcSet={image ? getImageSrcSet(image) : undefined}
+              sizes={IMAGE_SIZES.subImages}
               alt={`${title} - ${idx + 1}`}
               fetchPriority="high"
               loading="eager"

--- a/src/pages/product-post/components/imageUploadField/components/DropzoneArea.tsx
+++ b/src/pages/product-post/components/imageUploadField/components/DropzoneArea.tsx
@@ -41,7 +41,7 @@ export default function DropzoneArea<T extends FieldValues>({
   const compressImage = async (file: File) => {
     const options = {
       maxSizeMB: 1, // 최대 1MB로 압축
-      maxWidthOrHeight: 1200, // 최대 1200px로 리사이징
+      maxWidthOrHeight: 800, // 최대 800px로 리사이징 (백엔드 최대 사이즈에 맞춤)
       useWebWorker: true, // 웹 워커 사용 (UI 블로킹 방지)
       fileType: 'image/webp' as const, // WebP 형식으로 변환
     }

--- a/src/pages/profile-update/components/ProfileUpdateBaseForm.tsx
+++ b/src/pages/profile-update/components/ProfileUpdateBaseForm.tsx
@@ -82,7 +82,7 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
   const compressImage = async (file: File) => {
     const options = {
       maxSizeMB: 1, // 최대 1MB로 압축
-      maxWidthOrHeight: 1200, // 최대 1200px로 리사이징
+      maxWidthOrHeight: 800, // 최대 800px로 리사이징 (백엔드 최대 사이즈에 맞춤)
       useWebWorker: true, // 웹 워커 사용 (UI 블로킹 방지)
       fileType: 'image/webp', // WebP 형식으로 변환
     }

--- a/src/utils/imageUrl.ts
+++ b/src/utils/imageUrl.ts
@@ -1,0 +1,38 @@
+type ImageSize = 150 | 400 | 800
+
+/**
+ * 원본 이미지 URL을 리사이즈된 WebP URL로 변환
+ * @param originalUrl - API에서 받은 원본 이미지 URL (예: https://.../uuid.jpg)
+ * @param size - 원하는 크기 (150 | 400 | 800)
+ * @returns 리사이즈된 WebP URL (예: https://.../uuid_150.webp)
+ */
+export function toResizedWebpUrl(originalUrl: string | null | undefined, size: ImageSize): string {
+  if (!originalUrl) return ''
+  return originalUrl.replace(/\.[^.]+$/, `_${size}.webp`)
+}
+
+/**
+ * srcset용 이미지 URL 세트 생성
+ * @param originalUrl - API에서 받은 원본 이미지 URL
+ * @returns srcset 문자열 (예: "url_150.webp 150w, url_400.webp 400w, url_800.webp 800w")
+ */
+export function getImageSrcSet(originalUrl: string | null | undefined): string {
+  if (!originalUrl) return ''
+  return `${toResizedWebpUrl(originalUrl, 150)} 150w, ${toResizedWebpUrl(originalUrl, 400)} 400w, ${toResizedWebpUrl(originalUrl, 800)} 800w`
+}
+
+/**
+ * 사전 정의된 sizes 값
+ */
+export const IMAGE_SIZES = {
+  // ProductThumbnail: 모바일 ~350px, 데스크탑 ~670px
+  productThumbnail: '(max-width: 768px) 350px, 670px',
+  // MainImage: 상세페이지 전체 너비
+  mainImage: '100vw',
+  // SubImages: 4열 그리드
+  subImages: '(max-width: 768px) 25vw, 200px',
+  // 작은 썸네일: 128px 고정
+  smallThumbnail: '128px',
+  // 아주 작은 썸네일: 64px 이하
+  tinyThumbnail: '64px',
+} as const


### PR DESCRIPTION
## 📌 개요

- 백엔드에서 제공하는 반응형 이미지(150px, 400px, 800px)를 활용하여 이미지 로딩 성능 최적화
- Lighthouse 성능 점수 향상을 위한 srcset/sizes 속성 적용

## 🔧 작업 내용

- [x] 이미지 URL 변환 유틸리티 함수 생성 (`src/utils/imageUrl.ts`)
- [x] 모든 이미지 컴포넌트에 srcset/sizes 적용
  - ProductThumbnail, MainImage, SubImages
  - ProductListItem, MyList
  - ChatProductCard, ChatLog, DeleteConfirmModal
- [x] 이미지 업로드 시 압축 사이즈 최적화 (1200px → 800px)
  - DropzoneArea, ChattingPage, ProfileUpdateBaseForm

## 📎 관련 이슈

Closes #608

## 💬 리뷰어 참고 사항

- 브라우저 DevTools에서 srcset 동작 확인 가능 (DPR, 화면 크기에 따라 적절한 이미지 선택)
- IMAGE_SIZES 상수로 각 컴포넌트별 sizes 값 관리