### PR TITLE
refactor: 상품 등록/수정 후 이미지 처리 대기 로딩 추가(#610)

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -188,6 +188,9 @@ export const COMMUNITY_SEARCH_TYPE = [
 
 export const MAX_FILES = 5
 
+// ========== 이미지 처리 관련 상수 ==========
+export const IMAGE_PROCESSING_DELAY = 2000 // Lambda 이미지 리사이징 처리 대기 시간 (ms)
+
 // ========== 회원탈퇴 이유 관련 상수 ==========
 export const WiTH_DRAW_REASON = [
   { id: 'SERVICE_DISSATISFACTION', label: '서비스 불만족' },

--- a/src/pages/product-post/components/ProductPostForm.tsx
+++ b/src/pages/product-post/components/ProductPostForm.tsx
@@ -8,8 +8,9 @@ import PriceAndStatusSection from './priceAndStatusSection/PriceAndStatusSection
 import type { ProductDetailItem, ProductPostRequestData } from '@src/types'
 import { patchProduct, postProduct } from '@src/api/products'
 import { cn } from '@src/utils/cn'
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import TradeInfoSection from './tradeInfoSection/TradeInfoSection'
+import { IMAGE_PROCESSING_DELAY } from '@src/constants/constants'
 
 export interface ProductPostFormValues {
   petType: string
@@ -59,6 +60,7 @@ export function ProductPostForm({ isEditMode, productId: id, initialData }: Prod
     },
   }) // 폼에서 관리할 필드들의 타입(이름) 정의.
   const navigate = useNavigate()
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
   const initialImages = useMemo(() => {
     if (initialData) {
@@ -82,17 +84,23 @@ export function ProductPostForm({ isEditMode, productId: id, initialData }: Prod
       addressGugun: data.addressGugun,
     }
 
+    setIsSubmitting(true)
     try {
       if (isEditMode && id) {
         // 편집 모드: 기존 상품 ID로 이동
         await patchProduct(requestData, Number(id))
+        // Lambda 이미지 리사이징 처리 대기
+        await new Promise((resolve) => setTimeout(resolve, IMAGE_PROCESSING_DELAY))
         navigate(`/products/${id}`)
       } else {
         // 새 등록: 서버에서 생성된 ID로 이동
         const createdProduct = await postProduct(requestData)
+        // Lambda 이미지 리사이징 처리 대기
+        await new Promise((resolve) => setTimeout(resolve, IMAGE_PROCESSING_DELAY))
         navigate(`/products/${createdProduct.id}`)
       }
     } catch {
+      setIsSubmitting(false)
       alert(isEditMode ? '상품 수정에 실패했습니다.' : '상품 등록에 실패했습니다.')
     }
   }
@@ -113,6 +121,17 @@ export function ProductPostForm({ isEditMode, productId: id, initialData }: Prod
       })
     }
   }, [isEditMode, initialData, reset])
+
+  if (isSubmitting) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="flex flex-col items-center gap-4">
+          <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600"></div>
+          <p className="text-gray-600">상품을 {isEditMode ? '수정' : '등록'}하고 있습니다...</p>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div role="tabpanel" id="panel-SELL" aria-labelledby="tab-sales">


### PR DESCRIPTION
## 📌 개요

- AWS Lambda 이미지 리사이징 처리 지연으로 인해 상품 등록/수정 후 상세페이지에서 이미지가 로드되지 않는 문제 해결

## 🔧 작업 내용

- [x] `ProductPostForm.tsx` - 상품 등록/수정 후 로딩 스피너 및 2초 대기 추가
- [x] `ProductRequestForm.tsx` - 판매요청 등록/수정 후 로딩 스피너 및 2초 대기 추가
- [x] `constants.ts` - `IMAGE_PROCESSING_DELAY` 상수 중앙화

## 📎 관련 이슈

Closes #610

## 💬 리뷰어 참고 사항

- Lambda 이미지 리사이징 처리 완료까지 대기 시간(2초)은 `IMAGE_PROCESSING_DELAY` 상수로 관리되며, 필요시 조정 가능