### PR TITLE
refactor: 이미지 로드 실패 시 원본 URL fallback 추가(#612)

### DIFF
--- a/src/components/commons/card/ChatProductCard.tsx
+++ b/src/components/commons/card/ChatProductCard.tsx
@@ -25,6 +25,15 @@ export function ChatProductCard({ productImageUrl, productTitle, productPrice, s
           fetchPriority="high"
           loading="eager"
           alt={productTitle}
+          onError={(e) => {
+            const img = e.currentTarget
+            if (productImageUrl && img.src !== productImageUrl) {
+              img.srcset = ''
+              img.src = productImageUrl
+            } else {
+              img.src = PlaceholderImage
+            }
+          }}
           className="h-full w-full object-cover transition-all duration-300 ease-in-out group-hover:scale-105"
         />
       </div>

--- a/src/components/product/ProductListItem.tsx
+++ b/src/components/product/ProductListItem.tsx
@@ -33,6 +33,15 @@ export function ProductListItem({ product, children }: ProductListItemProps) {
             alt={title}
             fetchPriority="high"
             loading="eager"
+            onError={(e) => {
+              const img = e.currentTarget
+              if (mainImageUrl && img.src !== mainImageUrl) {
+                img.srcset = ''
+                img.src = mainImageUrl
+              } else {
+                img.src = PlaceholderImage
+              }
+            }}
             className="h-full w-full object-cover transition-all duration-300 ease-in-out group-hover:scale-105"
           />
           {!isMd &&

--- a/src/components/product/components/ProductThumbnail.tsx
+++ b/src/components/product/components/ProductThumbnail.tsx
@@ -65,6 +65,15 @@ export function ProductThumbnail({
         sizes={imageUrl ? IMAGE_SIZES.productThumbnail : undefined}
         fetchPriority={priority ? 'high' : 'auto'}
         loading={priority ? 'eager' : 'lazy'}
+        onError={(e) => {
+          const img = e.currentTarget
+          if (imageUrl && img.src !== imageUrl) {
+            img.srcset = ''
+            img.src = imageUrl
+          } else {
+            img.src = PlaceholderImage
+          }
+        }}
         className="t-0 l-0 absolute h-full w-full object-cover transition-all duration-300 ease-in-out group-hover:scale-105"
       />
     </div>

--- a/src/pages/my-page/components/MyList.tsx
+++ b/src/pages/my-page/components/MyList.tsx
@@ -102,6 +102,15 @@ export default function MyList({ id, title, price, mainImageUrl, tradeStatus, vi
             alt={title}
             fetchPriority="high"
             loading="eager"
+            onError={(e) => {
+              const img = e.currentTarget
+              if (mainImageUrl && img.src !== mainImageUrl) {
+                img.srcset = ''
+                img.src = mainImageUrl
+              } else {
+                img.src = PlaceholderImage
+              }
+            }}
             className="h-full w-full object-cover transition-all duration-300 ease-in-out group-hover:scale-105"
           />
           {!isMd && trade_status && <Badge className={cn('absolute top-2 left-2 bg-[#48BB78] text-white', productTradeColor)}>{trade_status}</Badge>}

--- a/src/pages/product-detail/components/MainImage.tsx
+++ b/src/pages/product-detail/components/MainImage.tsx
@@ -16,6 +16,16 @@ export default function MainImage({ mainImageUrl, title }: MainImageProps) {
         alt={title}
         fetchPriority="high"
         loading="eager"
+        onError={(e) => {
+          const img = e.currentTarget
+          // 리사이즈 이미지 실패 시 원본 URL로 fallback
+          if (mainImageUrl && img.src !== mainImageUrl) {
+            img.srcset = ''
+            img.src = mainImageUrl
+          } else {
+            img.src = PlaceholderImage
+          }
+        }}
         className="t-0 l-0 absolute h-full w-full object-cover"
       />
     </div>

--- a/src/pages/product-detail/components/SubImages.tsx
+++ b/src/pages/product-detail/components/SubImages.tsx
@@ -21,6 +21,16 @@ export default function SubImages({ mainImageUrl, subImageUrls, title }: SubImag
               alt={`${title} - ${idx + 1}`}
               fetchPriority="high"
               loading="eager"
+              onError={(e) => {
+                const img = e.currentTarget
+                // 리사이즈 이미지 실패 시 원본 URL로 fallback
+                if (image && img.src !== image) {
+                  img.srcset = ''
+                  img.src = image
+                } else {
+                  img.src = PlaceholderImage
+                }
+              }}
               className="t-0 l-0 absolute h-full w-full object-cover object-top"
             />
           </div>


### PR DESCRIPTION
## 📌 개요

- AWS Lambda 이미지 리사이징 처리 지연으로 인해 상품 등록/수정 직후 리사이즈된 이미지가 404 에러 발생하는 문제 해결

## 🔧 작업 내용

- [x] MainImage.tsx에 onError fallback 추가
- [x] SubImages.tsx에 onError fallback 추가
- [x] ProductThumbnail.tsx에 onError fallback 추가
- [x] MyList.tsx에 onError fallback 추가
- [x] ProductListItem.tsx에 onError fallback 추가
- [x] ChatProductCard.tsx에 onError fallback 추가

## 📎 관련 이슈

Closes #612

## 💬 리뷰어 참고 사항

- 리사이즈 이미지 로드 실패 시 원본 URL로 자동 fallback
- 원본도 실패 시 PlaceholderImage 표시
- Lambda 처리 완료 전에도 이미지가 정상 표시됨