### PR TITLE
refactor: Lighthouse 성능 최적화 - 폰트 메트릭 및 이미지 sizes 조정(#616)

### DIFF
--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -1,11 +1,12 @@
 @layer base {
-  /* @font-face {
-    font-family: 'Pretendard Variable';
-    font-weight: 45 920;
-    font-style: normal;
-    font-display: swap;
-    src: url('/assets/fonts/PretendardVariable.woff2') format('woff2');
-  } */
+  @font-face {
+    font-family: 'Pretendard Fallback';
+    src: local('Apple SD Gothic Neo'), local('Malgun Gothic'), local('Noto Sans KR');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 101%;
+  }
 
   @font-face {
     font-family: 'BMJUA';

--- a/src/styles/tokens.typography.css
+++ b/src/styles/tokens.typography.css
@@ -36,6 +36,6 @@
 @theme {
   /* 폰트 패밀리 */
   --font-pretendard: 'Pretendard Variable';
-  --font-family-sans: 'Pretendard Variable', ui-sans-serif, system-ui, sans-serif;
+  --font-family-sans: 'Pretendard Variable', 'Pretendard Fallback', ui-sans-serif, system-ui, sans-serif;
   --font-family-mono: ui-monospace, SFMono-Regular, 'SF Mono', Monaco, monospace;
 }

--- a/src/utils/imageUrl.ts
+++ b/src/utils/imageUrl.ts
@@ -42,11 +42,11 @@ export function getImageSrcSet(originalUrl: string | null | undefined): string {
  */
 export const IMAGE_SIZES = {
   // ProductThumbnail: 모바일 ~350px, 데스크탑 ~670px
-  productThumbnail: '(max-width: 768px) 350px, 670px',
+  productThumbnail: '(max-width: 1024px) 160px, 400px',
   // MainImage: 상세페이지 전체 너비
   mainImage: '100vw',
   // SubImages: 4열 그리드
-  subImages: '(max-width: 768px) 25vw, 200px',
+  subImages: '(max-width: 1024px) 25vw, 200px',
   // 작은 썸네일: 128px 고정
   smallThumbnail: '128px',
   // 아주 작은 썸네일: 64px 이하


### PR DESCRIPTION
## 📌 개요

- Lighthouse 성능 지표 개선을 위한 폰트 메트릭 및 이미지 sizes 최적화

## 🔧 작업 내용

- [x] Pretendard Fallback 폰트 메트릭 설정 추가 (ascent-override, descent-override, size-adjust)
- [x] font-family-sans에 Pretendard Fallback 추가
- [x] productThumbnail sizes 최적화 (160px/400px)
- [x] subImages sizes 브레이크포인트 조정 (1024px)

## 📎 관련 이슈

Closes #616

## 💬 리뷰어 참고 사항

- CLS 개선: 웹폰트 로딩 시 시스템 폰트와의 메트릭 차이로 인한 레이아웃 이동 감소
- LCP 개선: 실제 렌더링 크기에 맞는 이미지 로딩으로 불필요한 대역폭 사용 방지