### PR TITLE
refactor: 홈 페이지 UI 스타일 개선(#630)

### DIFF
--- a/src/components/commons/Input.tsx
+++ b/src/components/commons/Input.tsx
@@ -57,7 +57,7 @@ export function Input({
         placeholder={placeholder}
         aria-label={placeholder}
         className={cn(
-          'w-full py-2 placeholder:text-gray-400 focus:border-transparent focus:outline-none md:py-3',
+          'w-full py-2 placeholder:text-gray-400 focus:border-transparent focus:outline-none md:py-0',
           backgroundColor,
           Icon ? 'pl-0' : 'px-3',
           size,

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -63,13 +63,13 @@ function Header({ hideSearchBar = false, hideMenuButton = false }: HeaderProps) 
                 <>
                   <NavLink
                     to={ROUTES.HOME}
-                    className={cn('text-lg', isMarketActive ? 'border-b-2 border-white font-extrabold text-white' : 'text-gray-700')}
+                    className={cn('text-md font-extrabold', isMarketActive ? 'border-b-2 border-white text-white' : 'text-gray-700')}
                   >
                     마켓
                   </NavLink>
                   <NavLink
                     to={ROUTES.COMMUNITY}
-                    className={cn('text-lg', isCommunityActive ? 'border-b-2 border-white font-extrabold text-white' : 'text-gray-700')}
+                    className={cn('text-md font-extrabold', isCommunityActive ? 'border-b-2 border-white text-white' : 'text-gray-700')}
                   >
                     커뮤니티
                   </NavLink>
@@ -77,7 +77,7 @@ function Header({ hideSearchBar = false, hideMenuButton = false }: HeaderProps) 
               )}
             </div>
             <div className="flex items-center gap-1 xl:gap-8">
-              {!hideSearchBar && <SearchBar className="hidden xl:block" />}
+              {!hideSearchBar && <SearchBar className="hidden xl:block" inputClass="text-sm" />}
               {/* 모바일 검색 아이콘 */}
               {!hideSearchBar && !isXl && (
                 <IconButton aria-label="검색" onClick={() => setIsSearchOpen(!isSearchOpen)}>

--- a/src/components/header/components/SearchBar.tsx
+++ b/src/components/header/components/SearchBar.tsx
@@ -70,7 +70,7 @@ export function SearchBar({
   }, [currentKeyword])
 
   return (
-    <div className={cn('h-5 flex-1 md:h-10 md:min-w-[480px]', className)}>
+    <div className={cn('h-5 flex-1 md:h-9 md:min-w-[480px]', className)}>
       <Input
         type="text"
         value={keyword}

--- a/src/components/header/components/user-section/AuthMenu.tsx
+++ b/src/components/header/components/user-section/AuthMenu.tsx
@@ -14,7 +14,7 @@ export default function AuthMenu({ isSideOpen, setIsSideOpen, hideMenuButton = f
   const isXl = useMediaQuery('(min-width: 1280px)')
   return isXl ? (
     <div className="flex items-center gap-5">
-      <Link to={ROUTES.LOGIN} className="rounded-lg bg-white px-2 py-1 text-center xl:min-w-20 xl:px-4 xl:py-2">
+      <Link to={ROUTES.LOGIN} className="rounded-lg bg-white px-2 py-1 text-center text-sm xl:min-w-20 xl:px-3 xl:py-2">
         로그인 / 회원가입
       </Link>
     </div>

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -230,8 +230,9 @@ function Home() {
                 onTabChange={setActivePetTypeTab}
                 selectedDetailPet={selectedDetailPet}
                 onPetDetailTypeChange={setSelectedDetailPet}
+                headingClassName="heading-h5"
               />
-              <CategoryFilter selectedCategory={selectedCategory} onCategoryChange={setSelectedCategory} />
+              <CategoryFilter selectedCategory={selectedCategory} onCategoryChange={setSelectedCategory} headingClassName="heading-h5" />
               <DetailFilter
                 isOpen={isDetailFilterOpen}
                 onToggle={handleDetailFilterToggle}
@@ -241,9 +242,10 @@ function Home() {
                 onMinPriceChange={setSelectedProductPrice}
                 onLocationChange={setSelectedLocation}
                 filterReset={filterReset}
+                headingClassName="lg:text-base!"
               />
             </div>
-            <div className="flex flex-col gap-5">
+            <div className="flex flex-col gap-3">
               <Tabs
                 tabs={PRODUCT_TYPE_TABS}
                 activeTab={activeProductTypeTab}

--- a/src/pages/home/components/filter/DetailFilter.tsx
+++ b/src/pages/home/components/filter/DetailFilter.tsx
@@ -14,6 +14,7 @@ interface DetailFilterProps {
   onMinPriceChange?: (priceRange: PriceRange | null) => void
   onLocationChange?: (location: LocationFilterType | null) => void
   filterReset: (e: React.MouseEvent) => void
+  headingClassName?: string
 }
 
 export const DetailFilter = memo(function DetailFilterSection({
@@ -25,6 +26,7 @@ export const DetailFilter = memo(function DetailFilterSection({
   onMinPriceChange,
   onLocationChange,
   filterReset,
+  headingClassName,
 }: DetailFilterProps) {
   return (
     <div className="flex flex-col gap-2.5">
@@ -36,9 +38,14 @@ export const DetailFilter = memo(function DetailFilterSection({
           id="detail-filter-content"
           aria-label="세부 필터 옵션"
         >
-          <ProductStateFilter selectedProductStatus={selectedProductStatus} onProductStatusChange={onProductStatusChange} useUrlSync />
-          <PriceFilter selectedPriceRange={selectedPriceRange} onMinPriceChange={onMinPriceChange} />
-          <LocationFilter onLocationChange={onLocationChange} />
+          <ProductStateFilter
+            selectedProductStatus={selectedProductStatus}
+            onProductStatusChange={onProductStatusChange}
+            useUrlSync
+            headingClassName={headingClassName}
+          />
+          <PriceFilter selectedPriceRange={selectedPriceRange} onMinPriceChange={onMinPriceChange} headingClassName={headingClassName} />
+          <LocationFilter onLocationChange={onLocationChange} headingClassName={headingClassName} />
         </div>
       )}
     </div>

--- a/src/pages/home/components/filter/DetailFilterButton.tsx
+++ b/src/pages/home/components/filter/DetailFilterButton.tsx
@@ -25,7 +25,7 @@ export function DetailFilterButton({ isOpen, onClick, ariaControls, filterReset 
     >
       <div className={cn('flex items-center gap-2')}>
         <FilterIcon className={cn('h-4 w-4')} aria-hidden="true" />
-        <span className={cn('heading-h4')}>세부 필터</span>
+        <span className={cn('font-sm font-bold')}>세부 필터</span>
         {isMd && (
           <p className={cn('bg-primary-50 items-center justify-center overflow-hidden rounded-md px-3 py-1 text-sm')} aria-hidden="true">
             상품상태 · 가격대 · 지역

--- a/src/pages/home/components/product-section/ProductsSection.tsx
+++ b/src/pages/home/components/product-section/ProductsSection.tsx
@@ -10,14 +10,9 @@ interface ProductListHeaderProps {
 
 function ProductListHeader({ totalElements }: ProductListHeaderProps) {
   return (
-    <div>
-      <h2 id="product-list-title" className="heading4 text-text-primary">
-        전체 상품
-      </h2>
-      <p className="mt-xs bodySmall text-text-secondary" aria-live="polite">
-        {`총 ${totalElements}개의 상품`}
-      </p>
-    </div>
+    <p className="text-text-secondary" aria-live="polite">
+      {`총 ${totalElements}개의 상품`}
+    </p>
   )
 }
 

--- a/src/pages/home/components/tab/ProductPetTypeTabs.tsx
+++ b/src/pages/home/components/tab/ProductPetTypeTabs.tsx
@@ -44,7 +44,7 @@ export function ProductPetTypeTabs({ activeTab, onTabChange }: ProductPetTypeTab
             type="button"
             onClick={() => onTabChange(tab.id)}
             className={cn(
-              'bg-primary-100 flex-1 cursor-pointer rounded-full text-base whitespace-nowrap xl:rounded-2xl xl:bg-white xl:whitespace-normal',
+              'bg-primary-100 text-md flex-1 cursor-pointer rounded-full py-1.5 whitespace-nowrap xl:rounded-2xl xl:bg-white xl:whitespace-normal',
               activeTab === tab.id ? 'bg-primary-500 xl:bg-primary-300 font-bold text-white' : 'hover:bg-primary-100 text-gray-900'
             )}
             role="tab"


### PR DESCRIPTION
## 📌 개요

- 홈 페이지 및 헤더 컴포넌트의 UI 스타일을 개선하여 더 컴팩트하고 일관된 디자인 적용

## 🔧 작업 내용

- [x] Input 컴포넌트 패딩 조정
- [x] 헤더 네비게이션 텍스트 크기 및 스타일 변경
- [x] 검색바 높이 조정
- [x] 로그인/회원가입 버튼 스타일 조정
- [x] 필터 컴포넌트에 headingClassName props 추가
- [x] 세부 필터 버튼 스타일 변경
- [x] 상품 섹션 헤더 간소화 ("전체 상품" 제목 제거)
- [x] 펫 타입 탭 스타일 조정

## 📎 관련 이슈

Closes #630

## 📸 스크린샷 (선택)

(해당 없음)

## 💬 리뷰어 참고 사항

- headingClassName props를 통해 필터 컴포넌트 스타일링의 유연성이 향상되었습니다
- 전체적으로 텍스트 크기와 간격이 조정되어 더 컴팩트한 UI를 제공합니다