### PR TITLE
refactor: Input 컴포넌트 패딩 및 검색바 스타일 조정(#634)

### DIFF
--- a/src/components/commons/Input.tsx
+++ b/src/components/commons/Input.tsx
@@ -57,7 +57,7 @@ export function Input({
         placeholder={placeholder}
         aria-label={placeholder}
         className={cn(
-          'w-full py-2 placeholder:text-gray-400 focus:border-transparent focus:outline-none md:py-0',
+          'w-full py-2 placeholder:text-gray-400 focus:border-transparent focus:outline-none md:py-3',
           backgroundColor,
           Icon ? 'pl-0' : 'px-3',
           size,

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -74,7 +74,7 @@ function Header({ hideSearchBar = false, hideMenuButton = false }: HeaderProps) 
               )}
             </div>
             <div className="flex items-center gap-1 xl:gap-8">
-              {!hideSearchBar && <SearchBar className="hidden xl:block" inputClass="text-sm" />}
+              {!hideSearchBar && <SearchBar className="hidden xl:block" inputClass="text-sm py-0" />}
               {/* 모바일 검색 아이콘 */}
               {!hideSearchBar && !isXl && (
                 <IconButton aria-label="검색" onClick={() => setIsSearchOpen(!isSearchOpen)}>


### PR DESCRIPTION
## 📌 개요

- Input 컴포넌트의 기본 패딩을 원복하고, 헤더 검색바에만 별도 패딩 적용

## 🔧 작업 내용

- [x] Input 컴포넌트 기본 패딩 원복 (`md:py-0` → `md:py-3`)
- [x] 헤더 검색바 inputClass에 `py-0` 추가

## 📎 관련 이슈

Closes #634

## 📸 스크린샷 (선택)

(해당 없음)

## 💬 리뷰어 참고 사항

- Input 컴포넌트의 범용성을 유지하면서 헤더 검색바에만 개별 스타일을 적용했습니다