### PR TITLE
refactor: 상품 상세 페이지 및 타이포그래피 스타일 개선(#636)

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -74,7 +74,7 @@ function Header({ hideSearchBar = false, hideMenuButton = false }: HeaderProps) 
               )}
             </div>
             <div className="flex items-center gap-1 xl:gap-8">
-              {!hideSearchBar && <SearchBar className="hidden xl:block" inputClass="text-sm py-0" />}
+              {!hideSearchBar && <SearchBar className="hidden md:h-9 xl:block" inputClass="text-sm py-0" />}
               {/* 모바일 검색 아이콘 */}
               {!hideSearchBar && !isXl && (
                 <IconButton aria-label="검색" onClick={() => setIsSearchOpen(!isSearchOpen)}>

--- a/src/components/header/components/SearchBar.tsx
+++ b/src/components/header/components/SearchBar.tsx
@@ -70,7 +70,7 @@ export function SearchBar({
   }, [currentKeyword])
 
   return (
-    <div className={cn('h-5 flex-1 md:h-9 md:min-w-[480px]', className)}>
+    <div className={cn('h-5 flex-1 md:h-10 md:min-w-[480px]', className)}>
       <Input
         type="text"
         value={keyword}

--- a/src/components/product/ProductMetaItem.tsx
+++ b/src/components/product/ProductMetaItem.tsx
@@ -11,7 +11,7 @@ export function ProductMetaItem({ icon: Icon, label, iconSize = 16, className = 
   return (
     <div className={`flex items-center gap-1 ${className}`}>
       <Icon size={iconSize} aria-hidden="true" />
-      <span className="font-medium whitespace-nowrap">{label}</span>
+      <span className="font-medium whitespace-nowrap lg:text-sm">{label}</span>
     </div>
   )
 }

--- a/src/components/profile/ProfileData.tsx
+++ b/src/components/profile/ProfileData.tsx
@@ -115,7 +115,7 @@ export default function ProfileData({
                     className="bg-primary-200 flex items-center justify-center gap-2.5 rounded-lg px-3 py-2 text-white transition-all"
                   >
                     <Settings size={19} />
-                    <span>내 정보 수정</span>
+                    <span className="lg:text-sm lg:font-bold">내 정보 수정</span>
                   </Link>
                 )}
               </div>

--- a/src/pages/community/CommunityPage.tsx
+++ b/src/pages/community/CommunityPage.tsx
@@ -21,7 +21,7 @@ import { EmptyState } from '@src/components/EmptyState'
 export default function CommunityPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const tabParam = searchParams.get('tab') as CommunityTabId | null
-  const initialTab = tabParam === 'tab-question' ? 'tab-question' : 'tab-info'
+  const initialTab = tabParam === 'tab-info' ? 'tab-info' : 'tab-question'
   const isMd = useMediaQuery('(min-width: 768px)')
   const { isCollapsed: isFilterCollapsed } = useScrollDirection()
 

--- a/src/pages/product-detail/ProductDetail.tsx
+++ b/src/pages/product-detail/ProductDetail.tsx
@@ -59,7 +59,7 @@ function ProductDetail() {
             </div>
 
             <div className="flex flex-1 flex-col gap-3.5">
-              <div className="flex flex-col gap-9">
+              <div className="flex flex-col gap-6">
                 <div className="flex flex-col gap-3.5">
                   <ProductBadges {...data} />
                   <ProductSummary data={data} />

--- a/src/pages/product-detail/components/ProductBadges.tsx
+++ b/src/pages/product-detail/components/ProductBadges.tsx
@@ -22,10 +22,10 @@ export default function ProductBadges({ tradeStatus, petDetailType, category, pr
 
   return (
     <div className="flex items-center gap-2 md:gap-1">
-      {tradeStatus && <Badge className={cn('px-2.5 py-1.5 text-base font-semibold text-white', productTradeColor)}>{productTradeName}</Badge>}
-      <Badge className={cn('bg-primary-700 px-2.5 py-1.5 text-base font-semibold text-white')}>{petTypeName}</Badge>
-      <Badge className={cn('border bg-white px-2.5 py-1.5 text-base font-semibold text-gray-900')}>{categoryName}</Badge>
-      <Badge className={cn('bg-primary-200 px-2.5 py-1.5 text-base font-semibold')}>{productStatusName}</Badge>
+      {tradeStatus && <Badge className={cn('px-2.5 py-1.5 text-sm font-semibold text-white', productTradeColor)}>{productTradeName}</Badge>}
+      <Badge className={cn('bg-primary-700 px-2.5 py-1.5 text-sm font-semibold text-white')}>{petTypeName}</Badge>
+      <Badge className={cn('border bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900')}>{categoryName}</Badge>
+      <Badge className={cn('bg-primary-200 px-2.5 py-1.5 text-sm font-semibold')}>{productStatusName}</Badge>
     </div>
   )
 }

--- a/src/pages/product-detail/components/ProductDescription.tsx
+++ b/src/pages/product-detail/components/ProductDescription.tsx
@@ -3,11 +3,8 @@ interface ProductDescriptionProps {
 }
 export default function ProductDescription({ description }: ProductDescriptionProps) {
   return (
-    <div className="flex flex-col gap-4">
-      <p className="heading-h4 text-gray-600">상품 설명</p>
-      <div className="h-64 overflow-y-auto rounded-lg border border-gray-300 p-3.5 whitespace-pre-line text-gray-900 md:min-h-[22vh]">
-        {description}
-      </div>
+    <div className="h-64 overflow-y-auto rounded-lg border border-gray-300 p-3.5 whitespace-pre-line text-gray-900 md:min-h-[22vh]">
+      {description}
     </div>
   )
 }

--- a/src/pages/product-detail/components/ProductTitle.tsx
+++ b/src/pages/product-detail/components/ProductTitle.tsx
@@ -11,10 +11,10 @@ export default function ProductTitle({ title, productType, price }: ProductTitle
   const productTypeName = getProductType(productType)
   return (
     <div className="flex flex-col gap-3.5">
-      <h2 className="heading-h2 text-gray-900">{title}</h2>
+      <h2 className="heading-h2_5 text-gray-900">{title}</h2>
       <div className="flex flex-col">
         <span className="text-lg font-semibold text-gray-500">{productTypeName}</span>
-        <span className="text-primary-300 heading-h2 max-w-[90%] overflow-hidden">
+        <span className="text-primary-300 heading-h3 max-w-[90%] overflow-hidden">
           <span>{formatPrice(price)}</span>원
         </span>
       </div>

--- a/src/styles/tokens.typography.css
+++ b/src/styles/tokens.typography.css
@@ -13,6 +13,12 @@
   --text-h2--weight: 700;
   --text-h2--tracking: 0;
 
+  /* H2.5 */
+  --text-h2_5: 28px;
+  --text-h2_5--line-height: 38px;
+  --text-h2_5--weight: 700;
+  --text-h2_5--tracking: 0;
+
   /* H3 */
   --text-h3: 24px;
   --text-h3--line-height: 32px;

--- a/src/styles/utilities/typography.css
+++ b/src/styles/utilities/typography.css
@@ -14,6 +14,13 @@
     letter-spacing: var(--text-h2--tracking);
   }
 
+  .heading-h2_5 {
+    font-size: var(--text-h2_5);
+    line-height: var(--text-h2_5--line-height);
+    font-weight: var(--text-h2_5--weight);
+    letter-spacing: var(--text-h2_5--tracking);
+  }
+
   .heading-h3 {
     font-size: var(--text-h3);
     line-height: var(--text-h3--line-height);


### PR DESCRIPTION
## 📌 개요

- 상품 상세 페이지 UI 스타일 개선 및 타이포그래피 시스템 확장

## 🔧 작업 내용

- [x] 검색바 높이 조정
- [x] ProductMetaItem 텍스트 크기 추가 (`lg:text-sm`)
- [x] 프로필 "내 정보 수정" 버튼 스타일 추가
- [x] 커뮤니티 페이지 기본 탭 변경 (`tab-info` → `tab-question`)
- [x] 상품 상세 페이지 gap 조정
- [x] ProductBadges 텍스트 크기 변경 (`text-base` → `text-sm`)
- [x] ProductDescription "상품 설명" 제목 제거 및 구조 간소화
- [x] ProductTitle 제목/가격 크기 변경
- [x] `heading-h2_5` 타이포그래피 토큰 및 유틸리티 추가

## 📎 관련 이슈

Closes #636

## 📸 스크린샷 (선택)

(해당 없음)

## 💬 리뷰어 참고 사항

- `heading-h2_5` (28px)는 h2(32px)와 h3(24px) 사이의 중간 크기로 추가되었습니다
- 상품 상세 페이지의 전체적인 시각적 계층 구조가 개선되었습니다