### PR TITLE
refactor: Tabs 컴포넌트 패딩 스타일 조정(#638)

### DIFF
--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -19,7 +19,7 @@ export function Tabs({ tabs, activeTab, onTabChange, ariaLabel, excludeTabId }: 
   const filteredTabs = excludeTabId ? tabs.filter((tab) => tab.id !== excludeTabId) : tabs
   const isMd = useMediaQuery('(min-width: 768px)')
   return (
-    <div role="tablist" aria-label={ariaLabel} className={cn('border-b-primary-200 flex gap-1 px-3.5 md:gap-2.5 md:border-b-2 md:p-0 md:pb-1')}>
+    <div role="tablist" aria-label={ariaLabel} className={cn('border-b-primary-200 flex gap-1 md:gap-2.5 md:border-b-2 md:pb-1')}>
       {filteredTabs.map((tab) => (
         <Button
           key={tab.id}


### PR DESCRIPTION
## 📌 개요

- Tabs 컴포넌트의 불필요한 패딩 클래스를 제거하여 유연성 향상

## 🔧 작업 내용

- [x] Tabs 컴포넌트에서 `px-3.5 md:p-0` 패딩 클래스 제거

## 📎 관련 이슈

Closes #638

## 📸 스크린샷 (선택)

(해당 없음)

## 💬 리뷰어 참고 사항

- 부모 컴포넌트에서 패딩을 제어할 수 있도록 개선되었습니다